### PR TITLE
Fix irrlicht demos on osx by using absolute path to data folder

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -199,6 +199,8 @@ ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	endif()
     SET (CPACK_SYSTEM_NAME "OSX-x64")
 ENDIF()
+SET (CHRONO_DATA_PATH ${CMAKE_INSTALL_PREFIX}/data/)
+SET (CH_BUILDFLAGS "${CH_BUILDFLAGS} -DCHRONO_DATA_PATH=\"${CHRONO_DATA_PATH}\"")
 
 #-----------------------------------------------------------------------------
 # Some global  C++ definitions and includes that are used 

--- a/src/physics/ChGlobal.cpp
+++ b/src/physics/ChGlobal.cpp
@@ -84,7 +84,9 @@ int GetUniqueIntID()
 // Functions for manipulating the Chrono data directory
 // -----------------------------------------------------------------------------
 
-static std::string chrono_data_path("../data/");
+#define STRINGIFY(s) XSTR(s)
+#define XSTR(s) #s
+static std::string chrono_data_path(STRINGIFY(CHRONO_DATA_PATH));
 
 // Set the path to the Chrono data directory (ATTENTION: not thread safe)
 void SetChronoDataPath(const std::string& path)


### PR DESCRIPTION
Many of the irrlicht demos don't work correctly on osx, specifically the ones that try to load resources from the `data` folder:

```
Could not open file of texture: ../data/logo_chronoengine_alpha.png
Could not open file of texture: ../data/skybox/sky_lf.jpg
Could not open file of texture: ../data/skybox/sky_dn.jpg
```

@hmazhar suggested that this is a problem with irrlicht using the wrong relative path. This fixes the problem by computing the absolute path of the installed data folder. It works for me on osx, though it requires `make install` before the demos can be run. I haven't tested on Ubuntu or Windows.
