### PR TITLE
Do not add default value of texture coordinates when not specified.

### DIFF
--- a/src/geometry/ChCTriangleMeshConnected.cpp
+++ b/src/geometry/ChCTriangleMeshConnected.cpp
@@ -729,7 +729,18 @@ int OBJ::ParseLine(int /*lineno*/,int argc,const char **argv)  // return TRUE to
 			{
 				// the index of i-th texel
 				int tindex = atoi( texel+1) - 1;
-				this->mIndexesTexels.push_back(tindex);
+				
+				// Justin: if input file only specifies a face w/ verts, normals, this is -1.
+				// Crashes your Chrono application if someone (e.g., Irrlicht) tries to iterate thru vector later. 
+				// Don't push it to the array if that happens, and warn the user w/ a console message.
+				// (tindex > -1) ? mIndexesTexels.push_back(tindex) : GetLog() << " no texture coordinate for face #: " << mIndexesVerts.size() << "\n";
+				
+				// Also, can just not warn and not do anything when not adding to the vector.
+				if(tindex > -1)
+				{
+					mIndexesTexels.push_back(tindex);
+				}
+				// this->mIndexesTexels.push_back(tindex);
 
 				const char *normal = strstr(texel+1,"/");
 				if ( normal )


### PR DESCRIPTION
Happens when you specify an OBJ file with only vertex/normal for each face, and do not specify a texture coordinate.
When parsing input data, do not push texture coordinates to the index vector when they are not specified (and default value is -1).