### PR TITLE
ChLog: add shims compatible with google-glog

### DIFF
--- a/src/core/ChLog.h
+++ b/src/core/ChLog.h
@@ -30,6 +30,33 @@
 #include "ChStream.h"
 #include "ChApiCE.h"
 
+// Shim providing interface similar to google-glog
+//
+// Usage:
+//
+//   LOG(level) << "log message";
+//   LOG_IF(level, condition) << "log message";
+//
+//   where `level` is one of:
+//     INFO, WARNING, ERROR, FATAL,
+//     CHERROR, CHWARNING, CHMESSAGE, CHSTATUS, CHQUIET
+//   and `condition` is a conditional that is passed to an if statement
+#define LOG(level) chrono::GetLog() - chrono::ChLog::level
+#define LOG_IF(level, condition) !(condition) ? LOG(CHQUIET) : LOG(level)
+
+// Same as above, but only logs if in debug mode
+#ifndef NDEBUG
+
+#define DLOG(level) LOG(level)
+#define DLOG_IF(level, condition) LOG_IF(level, condition)
+
+#else  // NDEBUG
+
+#define DLOG(level) LOG(CHQUIET)
+#define DLOG_IF(level, condition) LOG_IF(CHQUIET, condition)
+
+#endif  // NDEBUG
+
 namespace chrono {
 
 //////////////////////////////////////////////////////////////////
@@ -47,7 +74,7 @@ class ChApi ChLog : public ChStreamOutAscii {
     /// specializations of the ChLog class may handle message output
     /// in different ways (for example a ChLogForGUIapplication may
     /// print logs in STATUS level only to the bottom of the window, etc.)
-    enum eChLogLevel { CHERROR = 0, CHWARNING, CHMESSAGE, CHSTATUS, CHQUIET };
+    enum eChLogLevel { INFO, WARNING, ERROR, FATAL, CHERROR = 0, CHWARNING, CHMESSAGE, CHSTATUS, CHQUIET };
 
   protected:
     eChLogLevel current_level;


### PR DESCRIPTION
Add logging macros similar to [google-glog](https://google-glog.googlecode.com/svn/trunk/doc/glog.html). This provides a shorter way to specify the log level/severity, but preserves backwards compatibility with existing code.

Previous:
```
chrono::GetLog() - chrono::ChLog::FATAL << "cannot initialize ...";
```
New:
```
LOG(FATAL) << "cannot initialize ...";
```

New macros:
- `LOG(level)` logs a message with severity level 'level'
- `LOG_IF(level, condition)` logs a message if `condition` evaluates to `true`
- `DLOG(level)` logs a message with severity level 'level', but only if compiled in debug mode
- `DLOG_IF(level, condition)` logs a message if `condition` evaluates to `true`, but only if compiled in debug mode