### PR TITLE
Revert "ChLog: add shims compatible with google-glog"

### DIFF
--- a/src/core/ChLog.h
+++ b/src/core/ChLog.h
@@ -30,33 +30,6 @@
 #include "ChStream.h"
 #include "ChApiCE.h"
 
-// Shim providing interface similar to google-glog
-//
-// Usage:
-//
-//   LOG(level) << "log message";
-//   LOG_IF(level, condition) << "log message";
-//
-//   where `level` is one of:
-//     INFO, WARNING, ERROR, FATAL,
-//     CHERROR, CHWARNING, CHMESSAGE, CHSTATUS, CHQUIET
-//   and `condition` is a conditional that is passed to an if statement
-#define LOG(level) chrono::GetLog() - chrono::ChLog::level
-#define LOG_IF(level, condition) !(condition) ? LOG(CHQUIET) : LOG(level)
-
-// Same as above, but only logs if in debug mode
-#ifndef NDEBUG
-
-#define DLOG(level) LOG(level)
-#define DLOG_IF(level, condition) LOG_IF(level, condition)
-
-#else  // NDEBUG
-
-#define DLOG(level) LOG(CHQUIET)
-#define DLOG_IF(level, condition) LOG_IF(CHQUIET, condition)
-
-#endif  // NDEBUG
-
 namespace chrono {
 
 //////////////////////////////////////////////////////////////////
@@ -74,7 +47,7 @@ class ChApi ChLog : public ChStreamOutAscii {
     /// specializations of the ChLog class may handle message output
     /// in different ways (for example a ChLogForGUIapplication may
     /// print logs in STATUS level only to the bottom of the window, etc.)
-    enum eChLogLevel { INFO, WARNING, ERROR, FATAL, CHERROR = 0, CHWARNING, CHMESSAGE, CHSTATUS, CHQUIET };
+    enum eChLogLevel { CHERROR = 0, CHWARNING, CHMESSAGE, CHSTATUS, CHQUIET };
 
   protected:
     eChLogLevel current_level;


### PR DESCRIPTION
Reverts projectchrono/chrono#34

This macro causes interference with Easylogging, which is used in projectchrono/chrono-parallel