### PR TITLE
streamOUT needs to be overloaded for ChSpmatrix type when writing to ChS...

### DIFF
--- a/src/core/ChSpmatrix.cpp
+++ b/src/core/ChSpmatrix.cpp
@@ -1590,6 +1590,22 @@ void ChSparseMatrix::StreamOUTsparseMatlabFormat(ChStreamOutAscii& mstream) {
     }
 }
 
+void ChSparseMatrix::StreamOUT(ChStreamOutAscii& mstream) {
+  mstream << "\n"
+    << "Matrix " << GetRows() << " rows, " << GetColumns() << " columns."
+    << "\n";
+  for (int i = 0; i < ChMin(GetRows(), 8); i++) {
+    for (int j = 0; j < ChMin(GetColumns(), 8); j++)
+      mstream << GetElement(i, j) << "  ";
+    if (GetColumns() > 8)
+      mstream << "...";
+    mstream << "\n";
+  }
+  if (GetRows() > 8)
+    mstream << "... \n\n";
+}
+
+
 }  // END_OF_NAMESPACE____
 
 // END

--- a/src/core/ChSpmatrix.h
+++ b/src/core/ChSpmatrix.h
@@ -273,6 +273,10 @@ class ChApi ChSparseMatrix : public ChMatrix<double> {
     ///     row,    column,    value
     /// Note: the row and column indexes start from 1, not 0 as in C language.
     void StreamOUTsparseMatlabFormat(ChStreamOutAscii& mstream);
+
+    /// Write first few rows an columns to the console
+    /// Method to allow serializing transient data into in ascii
+    void StreamOUT(ChStreamOutAscii& mstream);
 };
 
 // used internally:

--- a/src/demos/lcp_solver/demo_LCPsolver.cpp
+++ b/src/demos/lcp_solver/demo_LCPsolver.cpp
@@ -177,6 +177,8 @@ void test_1() {
         GetLog() << "FILE ERROR: " << myex.what();
     }
 
+    matrM.StreamOUT(GetLog());
+    matrCq.StreamOUT(GetLog());
     // Other checks
 
     GetLog() << "**** Using ChLcpIterativeSOR  ********** \n\n";


### PR DESCRIPTION
...treamOutAscii, added this function to header and source

Add example of use to demo_LCPsolver.cpp
Max number of rows/cols printed hardcoded to 8