### PR TITLE
Link with pthread on UNIX systems

### DIFF
--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -960,6 +960,10 @@ set(ChronoEngine_FILES
 # Add the ChronoEngine library to the project
 add_library(ChronoEngine SHARED ${ChronoEngine_FILES})
 
+if (UNIX)
+  target_link_libraries(ChronoEngine pthread)
+endif()
+
 # Set some custom properties of this target
 set_target_properties(ChronoEngine PROPERTIES
     COMPILE_FLAGS "${CH_CXX_FLAGS}"
@@ -967,7 +971,7 @@ set_target_properties(ChronoEngine PROPERTIES
     COMPILE_DEFINITIONS "CH_API_COMPILE")
 
 if(XCODE_VERSION)
-    set_target_properties(ChronoEngine PROPERTIES XCODE_ATTRIBUTE_ENABLE_OPENMP_SUPPORT YES)
+    set_target_properties(ChronoEngine PROPERTIES XCODE_ATTRIBUTE_ENABLE_OPENMP_SUPPORT ${ENABLE_OPENMP})
 endif()
 
 # Install the main ChronoEngine library


### PR DESCRIPTION
This fixes a build failure with `ENABLE_OPENMP=False` caused by pthread linking errors.

The following should reproduce the failure on the develop branch:

~~~
mkdir build
cd build
cmake .. -DENABLE_OPENMP=False
make
~~~

I was seeing the following errors:

~~~
Linking CXX executable ../../../bin/demo_buildsystem
../../../lib/libChronoEngine.so: undefined reference to `pthread_spin_init'
../../../lib/libChronoEngine.so: undefined reference to `pthread_mutexattr_destroy'
../../../lib/libChronoEngine.so: undefined reference to `pthread_create'
../../../lib/libChronoEngine.so: undefined reference to `sem_wait'
../../../lib/libChronoEngine.so: undefined reference to `sem_init'
../../../lib/libChronoEngine.so: undefined reference to `sem_destroy'
../../../lib/libChronoEngine.so: undefined reference to `pthread_spin_destroy'
../../../lib/libChronoEngine.so: undefined reference to `sem_post'
../../../lib/libChronoEngine.so: undefined reference to `pthread_mutexattr_settype'
../../../lib/libChronoEngine.so: undefined reference to `pthread_cancel'
../../../lib/libChronoEngine.so: undefined reference to `pthread_mutexattr_init'
collect2: error: ld returned 1 exit status
~~~

Linking to pthread fixes it for me.