### PR TITLE
Brushing up ANCF Shell and Brick elements

### DIFF
--- a/src/chrono/timestepper/ChTimestepper.cpp
+++ b/src/chrono/timestepper/ChTimestepper.cpp
@@ -888,7 +888,7 @@ void ChTimestepperHHT::Advance(const double dt  ///< timestep to advance
                     false  // do not StateScatter update to Xnew Vnew T+dt before computing correction
                     );
 
-                L += Dl;  // Note it is not -= Dl because we assume StateSolveCorrection flips sign of Dl
+				L += Dl*(1.0 / scaling_factor);  // Note it is not -= Dl because we assume StateSolveCorrection flips sign of Dl
 
                 Xnew = Xnew + Da;  // X + V * dt + A * (dt * dt * (0.5 - beta)) + Anew * (dt * dt * beta);
                 Vnew = V * (-(gamma / beta - 1.0)) - A * dt * (gamma / (2.0 * beta) - 1.0);

--- a/src/chrono_fea/ChElementBrick.cpp
+++ b/src/chrono_fea/ChElementBrick.cpp
@@ -1775,33 +1775,6 @@ void ChElementBrick::ComputeStiffnessMatrix() {
 
 void ChElementBrick::ComputeMassMatrix() {
     double rho = m_Material->Get_density();
-    ChMatrixNM<double, 24, 1> InitialCoord;
-    ChMatrixNM<double, 8, 3> d0;
-    d0 = GetInitialPos();
-    d0(0, 0) = InitialCoord(0, 0);
-    d0(0, 1) = InitialCoord(1, 0);
-    d0(0, 2) = InitialCoord(2, 0);
-    d0(1, 0) = InitialCoord(3, 0);
-    d0(1, 1) = InitialCoord(4, 0);
-    d0(1, 2) = InitialCoord(5, 0);
-    d0(2, 0) = InitialCoord(6, 0);
-    d0(2, 1) = InitialCoord(7, 0);
-    d0(2, 2) = InitialCoord(8, 0);
-    d0(3, 0) = InitialCoord(9, 0);
-    d0(3, 1) = InitialCoord(10, 0);
-    d0(3, 2) = InitialCoord(11, 0);
-    d0(4, 0) = InitialCoord(12, 0);
-    d0(4, 1) = InitialCoord(13, 0);
-    d0(4, 2) = InitialCoord(14, 0);
-    d0(5, 0) = InitialCoord(15, 0);
-    d0(5, 1) = InitialCoord(16, 0);
-    d0(5, 2) = InitialCoord(17, 0);
-    d0(6, 0) = InitialCoord(18, 0);
-    d0(6, 1) = InitialCoord(19, 0);
-    d0(6, 2) = InitialCoord(20, 0);
-    d0(7, 0) = InitialCoord(21, 0);
-    d0(7, 1) = InitialCoord(22, 0);
-    d0(7, 2) = InitialCoord(23, 0);
 
     class MyMass : public ChIntegrable3D<ChMatrixNM<double, 24, 24> > {
       public:
@@ -1872,7 +1845,7 @@ void ChElementBrick::ComputeMassMatrix() {
     };
 
     MyMass myformula;
-    myformula.d0 = &d0;
+    myformula.d0 = &m_d0;
     myformula.element = this;
 
     ChQuadrature::Integrate3D<ChMatrixNM<double, 24, 24> >(m_MassMatrix,  // result of integration will go there

--- a/src/chrono_fea/ChElementShellANCF.cpp
+++ b/src/chrono_fea/ChElementShellANCF.cpp
@@ -210,9 +210,6 @@ void ChElementShellANCF::ComputeMassMatrix() {
             ChElementShellANCF* element;
             ChMatrixNM<double, 8, 3>* d0;  //// pointer to initial coordinates
             ChMatrixNM<double, 3, 24> S;
-            ChMatrixNM<double, 3, 24> Sx;
-            ChMatrixNM<double, 3, 24> Sy;
-            ChMatrixNM<double, 3, 24> Sz;
             ChMatrixNM<double, 1, 8> N;
             ChMatrixNM<double, 1, 8> Nx;
             ChMatrixNM<double, 1, 8> Ny;
@@ -269,7 +266,7 @@ void ChElementShellANCF::ComputeMassMatrix() {
                 // perform  r = S'*S
                 result.MatrTMultiply(S, S);
 
-                // multiply integration weighs
+                // multiply integration weights
                 result *=
                     detJ0 * (element->GetLengthX() / 2) * (element->GetLengthY() / 2) * (element->m_thickness / 2);
             }
@@ -309,7 +306,6 @@ void ChElementShellANCF::ComputeGravityForce() {
           public:
             ChElementShellANCF* element;
             ChMatrixNM<double, 8, 3>* d0;
-            ChMatrixNM<double, 3, 24> S;
             ChMatrixNM<double, 1, 8> N;
             ChMatrixNM<double, 1, 8> Nx;
             ChMatrixNM<double, 1, 8> Ny;
@@ -338,25 +334,6 @@ void ChElementShellANCF::ComputeGravityForce() {
                     LocalGravityForce(2, 0) = 0.0;
                 }
 
-                // S=[N1*eye(3) N2*eye(3) N3*eye(3) N4*eye(3)]
-                ChMatrix33<> Si;
-                Si.FillDiag(N(0));
-                S.PasteMatrix(&Si, 0, 0);
-                Si.FillDiag(N(1));
-                S.PasteMatrix(&Si, 0, 3);
-                Si.FillDiag(N(2));
-                S.PasteMatrix(&Si, 0, 6);
-                Si.FillDiag(N(3));
-                S.PasteMatrix(&Si, 0, 9);
-                Si.FillDiag(N(4));
-                S.PasteMatrix(&Si, 0, 12);
-                Si.FillDiag(N(5));
-                S.PasteMatrix(&Si, 0, 15);
-                Si.FillDiag(N(6));
-                S.PasteMatrix(&Si, 0, 18);
-                Si.FillDiag(N(7));
-                S.PasteMatrix(&Si, 0, 21);
-
                 ChMatrixNM<double, 1, 3> Nx_d0;
                 Nx_d0.MatrMultiply(Nx, *d0);
 
@@ -379,7 +356,13 @@ void ChElementShellANCF::ComputeGravityForce() {
 
                 double detJ0 = rd0.Det();
 
-                result.MatrTMultiply(S, LocalGravityForce);
+				for (int i = 0; i < 8; i++)
+				{
+					for (int j = 0; j < 3; j++)
+					{
+						result(i * 3 + j, 0) = N(0, i)*LocalGravityForce(j, 0);
+					}
+				}
 
                 result *= detJ0 * wx2 * wy2 * wz2;
             }
@@ -629,9 +612,6 @@ void ChElementShellANCF::ComputeInternalForces(ChMatrixDynamic<>& Fi) {
                 ChMatrixNM<double, 9, 9> Sigm;
                 ChMatrixNM<double, 24, 6> temp246;
                 ChMatrixNM<double, 24, 9> temp249;
-                ChMatrixNM<double, 3, 24> Sx;
-                ChMatrixNM<double, 3, 24> Sy;
-                ChMatrixNM<double, 3, 24> Sz;
                 ChMatrixNM<double, 1, 8> Nx;
                 ChMatrixNM<double, 1, 8> Ny;
                 ChMatrixNM<double, 1, 8> Nz;
@@ -683,61 +663,7 @@ void ChElementShellANCF::ComputeInternalForces(ChMatrixDynamic<>& Fi) {
                     betaHHT = 0.25 * (1.0 - alphaHHT) * (1.0 - alphaHHT);
                     gammaHHT = 0.5 - alphaHHT;
 
-                    // Expand shape function derivatives in 3x24 matrices
-                    ChMatrix33<> Sxi;
-                    Sxi.FillDiag(Nx(0));
-                    Sx.PasteMatrix(&Sxi, 0, 0);
-                    Sxi.FillDiag(Nx(1));
-                    Sx.PasteMatrix(&Sxi, 0, 3);
-                    Sxi.FillDiag(Nx(2));
-                    Sx.PasteMatrix(&Sxi, 0, 6);
-                    Sxi.FillDiag(Nx(3));
-                    Sx.PasteMatrix(&Sxi, 0, 9);
-                    Sxi.FillDiag(Nx(4));
-                    Sx.PasteMatrix(&Sxi, 0, 12);
-                    Sxi.FillDiag(Nx(5));
-                    Sx.PasteMatrix(&Sxi, 0, 15);
-                    Sxi.FillDiag(Nx(6));
-                    Sx.PasteMatrix(&Sxi, 0, 18);
-                    Sxi.FillDiag(Nx(7));
-                    Sx.PasteMatrix(&Sxi, 0, 21);
-
-                    ChMatrix33<> Syi;
-                    Syi.FillDiag(Ny(0));
-                    Sy.PasteMatrix(&Syi, 0, 0);
-                    Syi.FillDiag(Ny(1));
-                    Sy.PasteMatrix(&Syi, 0, 3);
-                    Syi.FillDiag(Ny(2));
-                    Sy.PasteMatrix(&Syi, 0, 6);
-                    Syi.FillDiag(Ny(3));
-                    Sy.PasteMatrix(&Syi, 0, 9);
-                    Syi.FillDiag(Ny(4));
-                    Sy.PasteMatrix(&Syi, 0, 12);
-                    Syi.FillDiag(Ny(5));
-                    Sy.PasteMatrix(&Syi, 0, 15);
-                    Syi.FillDiag(Ny(6));
-                    Sy.PasteMatrix(&Syi, 0, 18);
-                    Syi.FillDiag(Ny(7));
-                    Sy.PasteMatrix(&Syi, 0, 21);
-
-                    ChMatrix33<> Szi;
-                    Szi.FillDiag(Nz(0));
-                    Sz.PasteMatrix(&Szi, 0, 0);
-                    Szi.FillDiag(Nz(1));
-                    Sz.PasteMatrix(&Szi, 0, 3);
-                    Szi.FillDiag(Nz(2));
-                    Sz.PasteMatrix(&Szi, 0, 6);
-                    Szi.FillDiag(Nz(3));
-                    Sz.PasteMatrix(&Szi, 0, 9);
-                    Szi.FillDiag(Nz(4));
-                    Sz.PasteMatrix(&Szi, 0, 12);
-                    Szi.FillDiag(Nz(5));
-                    Sz.PasteMatrix(&Szi, 0, 15);
-                    Szi.FillDiag(Nz(6));
-                    Sz.PasteMatrix(&Szi, 0, 18);
-                    Szi.FillDiag(Nz(7));
-                    Sz.PasteMatrix(&Szi, 0, 21);
-
+                    
                     //==EAS and Initial Shape==//
                     ChMatrixNM<double, 3, 3> rd0;
                     ChMatrixNM<double, 1, 3> temp33;
@@ -905,12 +831,35 @@ void ChElementShellANCF::ComputeInternalForces(ChMatrixDynamic<>& Fi) {
                     /// Straint derivative component ///
                     ////////////////////////////////////
                     ChMatrixNM<double, 6, 24> strainD_til;
+					ChMatrixNM<double, 1, 3> tempB3;
+					ChMatrixNM<double, 1, 3> tempB31;
                     strainD_til.Reset();
-                    tempB = Nx * (*d) * Sx;
+					tempB3.MatrMultiply(Nx, (*d));
+					for (int i = 0; i < 8; i++)
+					{
+						for (int j = 0; j < 3; j++)
+						{
+							tempB(0, i * 3 + j) = tempB3(0, j)*Nx(0, i);
+						}
+					}
                     strainD_til.PasteClippedMatrix(&tempB, 0, 0, 1, 24, 0, 0);
-                    tempB = Ny * (*d) * Sy;
+					tempB3.MatrMultiply(Ny, (*d));
+					for (int i = 0; i < 8; i++)
+					{
+						for (int j = 0; j < 3; j++)
+						{
+							tempB(0, i * 3 + j) = tempB3(0, j)*Ny(0, i);
+						}
+					}
                     strainD_til.PasteClippedMatrix(&tempB, 0, 0, 1, 24, 1, 0);
-                    tempB = Nx * (*d) * Sy + Ny * (*d) * Sx;
+					tempB31.MatrMultiply(Nx, (*d));
+					for (int i = 0; i < 8; i++)
+					{
+						for (int j = 0; j < 3; j++)
+						{
+							tempB(0, i * 3 + j) = tempB3(0, j)*Nx(0, i) + tempB31(0, j)*Ny(0, i);
+						}
+					}
                     strainD_til.PasteClippedMatrix(&tempB, 0, 0, 1, 24, 2, 0);
                     //== Compatible strain (No ANS)==//
                     // tempB = Nz*(*d)*Sz;
@@ -1318,7 +1267,6 @@ void ChElementShellANCF::ComputeInternalForces(ChMatrixDynamic<>& Fi) {
                 ChElementShellANCF* element;
                 ChMatrixNM<double, 8, 3>* d0;
                 ChMatrixNM<double, 8, 3>* d;
-                ChMatrixNM<double, 3, 24> S;
                 ChMatrixNM<double, 1, 4> S_ANS;
                 ChMatrixNM<double, 1, 8> N;
                 ChMatrixNM<double, 1, 8> Nx;
@@ -1341,25 +1289,6 @@ void ChElementShellANCF::ComputeInternalForces(ChMatrixDynamic<>& Fi) {
                     double Pressure0 = 0;
                     if (element->m_air_pressure_on)
                         Pressure0 = 220.0 * 1000.0;  // 220 KPa
-
-                    // S=[N1*eye(3) N2*eye(3) N3*eye(3) N4*eye(3)]
-                    ChMatrix33<> Si;
-                    Si.FillDiag(N(0));
-                    S.PasteMatrix(&Si, 0, 0);
-                    Si.FillDiag(N(1));
-                    S.PasteMatrix(&Si, 0, 3);
-                    Si.FillDiag(N(2));
-                    S.PasteMatrix(&Si, 0, 6);
-                    Si.FillDiag(N(3));
-                    S.PasteMatrix(&Si, 0, 9);
-                    Si.FillDiag(N(4));
-                    S.PasteMatrix(&Si, 0, 12);
-                    Si.FillDiag(N(5));
-                    S.PasteMatrix(&Si, 0, 15);
-                    Si.FillDiag(N(6));
-                    S.PasteMatrix(&Si, 0, 18);
-                    Si.FillDiag(N(7));
-                    S.PasteMatrix(&Si, 0, 21);
 
                     ChMatrixNM<double, 1, 3> Nx_d;
                     Nx_d.MatrMultiply(Nx, *d);
@@ -1410,7 +1339,13 @@ void ChElementShellANCF::ComputeInternalForces(ChMatrixDynamic<>& Fi) {
                     double G1xG2norm = sqrt(G1xG2(0) * G1xG2(0) + G1xG2(1) * G1xG2(1) + G1xG2(2) * G1xG2(2));
 
                     LocalAirPressure = -G1xG2 * (Pressure0 / G1xG2norm);
-                    result.MatrTMultiply(S, LocalAirPressure);
+					for (int i = 0; i < 8; i++)
+					{
+						for (int j = 0; j < 3; j++)
+						{
+							result(i * 3 + j, 0) = N(0, i)*LocalAirPressure(j, 0);
+						}
+					}
 
                     result *= detJ0 * wx2 * wy2;  // 6/12/2015
                 }
@@ -1472,9 +1407,6 @@ void ChElementShellANCF::AssumedNaturalStrain_BilinearShell(ChMatrixNM<double, 8
     temp_knot(7, 0) = 0.0;   // D
     temp_knot(7, 1) = 1.0;   // D
 
-    ChMatrixNM<double, 3, 24> Sx;
-    ChMatrixNM<double, 3, 24> Sy;
-    ChMatrixNM<double, 3, 24> Sz;
     ChMatrixNM<double, 1, 8> Nx;
     ChMatrixNM<double, 1, 8> Ny;
     ChMatrixNM<double, 1, 8> Nz;
@@ -1492,66 +1424,13 @@ void ChElementShellANCF::AssumedNaturalStrain_BilinearShell(ChMatrixNM<double, 8
     ChMatrixNM<double, 1, 1> tempA;
     ChMatrixNM<double, 1, 1> tempA1;
     ChMatrixNM<double, 1, 24> tempB;
+	ChMatrixNM<double, 1, 3> tempB3;
+	ChMatrixNM<double, 1, 3> tempB31;
 
     for (int kk = 0; kk < 8; kk++) {
         ShapeFunctionsDerivativeX(Nx, temp_knot(kk, 0), temp_knot(kk, 1), temp_knot(kk, 2));
         ShapeFunctionsDerivativeY(Ny, temp_knot(kk, 0), temp_knot(kk, 1), temp_knot(kk, 2));
         ShapeFunctionsDerivativeZ(Nz, temp_knot(kk, 0), temp_knot(kk, 1), temp_knot(kk, 2));
-
-        // Sd=[Nd1*eye(3) Nd2*eye(3) Nd3*eye(3) Nd4*eye(3)]
-        ChMatrix33<> Sxi;
-        Sxi.FillDiag(Nx(0));
-        Sx.PasteMatrix(&Sxi, 0, 0);
-        Sxi.FillDiag(Nx(1));
-        Sx.PasteMatrix(&Sxi, 0, 3);
-        Sxi.FillDiag(Nx(2));
-        Sx.PasteMatrix(&Sxi, 0, 6);
-        Sxi.FillDiag(Nx(3));
-        Sx.PasteMatrix(&Sxi, 0, 9);
-        Sxi.FillDiag(Nx(4));
-        Sx.PasteMatrix(&Sxi, 0, 12);
-        Sxi.FillDiag(Nx(5));
-        Sx.PasteMatrix(&Sxi, 0, 15);
-        Sxi.FillDiag(Nx(6));
-        Sx.PasteMatrix(&Sxi, 0, 18);
-        Sxi.FillDiag(Nx(7));
-        Sx.PasteMatrix(&Sxi, 0, 21);
-
-        ChMatrix33<> Syi;
-        Syi.FillDiag(Ny(0));
-        Sy.PasteMatrix(&Syi, 0, 0);
-        Syi.FillDiag(Ny(1));
-        Sy.PasteMatrix(&Syi, 0, 3);
-        Syi.FillDiag(Ny(2));
-        Sy.PasteMatrix(&Syi, 0, 6);
-        Syi.FillDiag(Ny(3));
-        Sy.PasteMatrix(&Syi, 0, 9);
-        Syi.FillDiag(Ny(4));
-        Sy.PasteMatrix(&Syi, 0, 12);
-        Syi.FillDiag(Ny(5));
-        Sy.PasteMatrix(&Syi, 0, 15);
-        Syi.FillDiag(Ny(6));
-        Sy.PasteMatrix(&Syi, 0, 18);
-        Syi.FillDiag(Ny(7));
-        Sy.PasteMatrix(&Syi, 0, 21);
-
-        ChMatrix33<> Szi;
-        Szi.FillDiag(Nz(0));
-        Sz.PasteMatrix(&Szi, 0, 0);
-        Szi.FillDiag(Nz(1));
-        Sz.PasteMatrix(&Szi, 0, 3);
-        Szi.FillDiag(Nz(2));
-        Sz.PasteMatrix(&Szi, 0, 6);
-        Szi.FillDiag(Nz(3));
-        Sz.PasteMatrix(&Szi, 0, 9);
-        Szi.FillDiag(Nz(4));
-        Sz.PasteMatrix(&Szi, 0, 12);
-        Szi.FillDiag(Nz(5));
-        Sz.PasteMatrix(&Szi, 0, 15);
-        Szi.FillDiag(Nz(6));
-        Sz.PasteMatrix(&Szi, 0, 18);
-        Szi.FillDiag(Nz(7));
-        Sz.PasteMatrix(&Szi, 0, 21);
 
         d_d.MatrMultiplyT(d, d);
         ddNx.MatrMultiplyT(d_d, Nx);
@@ -1567,21 +1446,44 @@ void ChElementShellANCF::AssumedNaturalStrain_BilinearShell(ChMatrixNM<double, 8
             tempA = Nz * ddNz;
             tempA1 = Nz * d0d0Nz;
             strain_ans(kk, 0) = 0.5 * (tempA(0, 0) - tempA1(0, 0));
-            tempB = Nz * (d)*Sz;
+			tempB3.MatrMultiply(Nz, d);
+			for (int i = 0; i < 8; i++)
+			{
+				for (int j = 0; j < 3; j++)
+				{
+					tempB(0, i * 3 + j) = tempB3(0, j)*Nz(0, i);
+				}
+			}
             strainD_ans.PasteClippedMatrix(&tempB, 0, 0, 1, 24, kk, 0);
         }
         if (kk == 4 || kk == 5) {  // kk=4,5 =>yz
             tempA = Ny * ddNz;
             tempA1 = Ny * d0d0Nz;
             strain_ans(kk, 0) = tempA(0, 0) - tempA1(0, 0);
-            tempB = Ny * (d)*Sz + Nz * (d)*Sy;
+			tempB3.MatrMultiply(Ny, d);
+			tempB31.MatrMultiply(Nz, d);
+			for (int i = 0; i < 8; i++)
+			{
+				for (int j = 0; j < 3; j++)
+				{
+					tempB(0, i * 3 + j) = tempB3(0, j)*Nz(0, i) + tempB31(0, j)*Ny(0, i);
+				}
+			}
             strainD_ans.PasteClippedMatrix(&tempB, 0, 0, 1, 24, kk, 0);
         }
         if (kk == 6 || kk == 7) {  // kk=6,7 =>xz
             tempA = Nx * ddNz;
             tempA1 = Nx * d0d0Nz;
             strain_ans(kk, 0) = tempA(0, 0) - tempA1(0, 0);
-            tempB = Nx * (d)*Sz + Nz * (d)*Sx;
+			tempB3.MatrMultiply(Nx, d);
+			tempB31.MatrMultiply(Nz, d);
+			for (int i = 0; i < 8; i++)
+			{
+				for (int j = 0; j < 3; j++)
+				{
+					tempB(0, i * 3 + j) = tempB3(0, j)*Nz(0, i) + tempB31(0, j)*Nx(0, i);
+				}
+			}
             strainD_ans.PasteClippedMatrix(&tempB, 0, 0, 1, 24, kk, 0);
         }
     }

--- a/src/chrono_fea/ChElementShellANCF.h
+++ b/src/chrono_fea/ChElementShellANCF.h
@@ -386,9 +386,10 @@ class ChApiFea ChElementShellANCF : public ChElementShell,
             for (int kl = 0; kl < m_numLayers; kl++) {
                 int ij = 14 * kl;
                 double rho = m_InertFlexVec(ij);
-                tot_density += rho;
+				double layerthick = m_InertFlexVec(ij + 3);
+				tot_density += rho*layerthick;
             }
-            return tot_density * this->m_thickness;
+            return tot_density;
      } 
 
             /// Gets the normal to the surface at the parametric coordinate U,V. 


### PR DESCRIPTION
-Fixed scaling factor for HHT integrator.
-Made correction to density calculation for multilayered ANCF Shell elements.
-Removed unnecessarily large shape matrices from ChElementShellANCF.cpp
-Fixed error in Mass Matrix calculation for ChElementBrick.cpp