### PR TITLE
Add base infrastructure for performance metrics monitoring

### DIFF
--- a/src/unit_tests/BaseTest.h
+++ b/src/unit_tests/BaseTest.h
@@ -1,0 +1,166 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2016 projectchrono.org
+// All right reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Felipe Gutierrez, Conlain Kelly, Radu Serban
+// =============================================================================
+
+#ifndef BASE_TEST_H
+#define BASE_TEST_H
+
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+class Object {
+  public:
+    Object() { m_content << "{"; }
+    ~Object() {}
+
+    void AddMember(const std::string& key, double value, bool verbose) {
+        if (verbose)
+            std::cout << "Adding entry " << key << " (type double)" << std::endl;
+        m_content << "\n    \"" << key << "\": " << value << ",";
+    }
+
+    void AddMember(const std::string& key, Object& value, bool verbose) {
+        if (verbose)
+            std::cout << "Adding entry " << key << " (type Object)" << std::endl;
+        m_content << "\n    \"" << key << "\": " << value.GetContent() << ",";
+    }
+
+    void AddMember(const std::string& key, uint64_t value, bool verbose) {
+        if (verbose)
+            std::cout << "Adding entry " << key << " (type uint64)" << std::endl;
+        m_content << "\n    \"" << key << "\": " << value << ",";
+    }
+
+    void AddMember(const std::string& key, int value, bool verbose) {
+        if (verbose)
+            std::cout << "Adding entry " << key << " (type int)" << std::endl;
+        m_content << "\n    \"" << key << "\": " << value << ",";
+    }
+
+    void AddMember(const std::string& key, const std::string& value, bool verbose) {
+        if (verbose)
+            std::cout << "Adding entry " << key << " (type string)" << std::endl;
+        m_content << "\n    \"" << key << "\": \"" << value << "\",";
+    }
+
+    std::string GetContent() const {
+        // Remove last comma and close the JSON object.
+        return m_content.str().substr(0, m_content.str().length() - 1) + "\n}\n";
+    }
+
+  private:
+    std::stringstream m_content;  // object content (JSON format)
+};
+
+class BaseTest {
+  public:
+    /// Constructor: Every test has to have a name and an associated project to it.
+    BaseTest(const std::string& testName, const std::string& testProjectName)
+        : m_name(testName), m_projectName(testProjectName), m_outDir("."), m_verbose(false) {}
+
+    virtual ~BaseTest() {}
+
+    /// Get the test name.
+    const std::string& getTestName() const { return m_name; }
+
+    /// Get the project name.
+    const std::string& getProjectName() const { return m_projectName; }
+
+    /// Get the output directory.
+    const std::string& getOutDir() const { return m_outDir; }
+
+    /// Enable/disable verbose output.
+    void setVerbose(bool val) { m_verbose = val; }
+
+    /// Set output directory (default: current directory).
+    void setOutDir(const std::string& outDir) { m_outDir = outDir; }
+
+    /// Main function for running the test.
+    bool run() {
+        // Execute the actual test and collect metrics
+        bool passed = execute();
+
+        // Populate output JSON string
+        m_jsonTest.AddMember("name", m_name, false);
+        m_jsonTest.AddMember("project_name", m_projectName, false);
+        m_jsonTest.AddMember("passed", passed, false);
+        m_jsonTest.AddMember("execution_time", getExecutionTime(), false);
+        m_jsonTest.AddMember("metrics", m_jsonMetrics, false);
+
+        // Write output file
+        std::string fname = m_outDir + "/" + m_name + ".json";
+        if (m_verbose)
+            std::cout << "Write output file: " << fname << std::endl;
+        m_jsonfile.open(fname);
+        if (m_jsonfile.is_open()) {
+            m_jsonfile << m_jsonTest.GetContent();
+            m_jsonfile.close();
+        } else {
+            std::cerr << "UNABLE to open file." << std::endl;
+        }
+
+        return passed;
+    }
+
+    /// Add a test-specific metric (a key-value pair)
+    void addMetric(const std::string& metricName, double metricValue) {
+        m_jsonMetrics.AddMember(metricName, metricValue, m_verbose);
+    }
+
+    void addMetric(const std::string& metricName, int metricValue) {
+        m_jsonMetrics.AddMember(metricName, metricValue, m_verbose);
+    }
+
+    void addMetric(const std::string& metricName, uint64_t metricValue) {
+        m_jsonMetrics.AddMember(metricName, metricValue, m_verbose);
+    }
+
+    void addMetric(const std::string& metricName, const std::string& metricValue) {
+        m_jsonMetrics.AddMember(metricName, metricValue, m_verbose);
+    }
+
+    // void addMetric(const std::string&   metricName,
+    //                std::vector<double>& metricValue) {
+    //   m_jsonMetrics.AddMember(metricName, metricValue, m_verbose);
+    // }
+
+    /// Execute the actual test.
+    /// A derived class must implement this function to return true if the test passes
+    /// and false otherwise. During execution of the test, various performance metrics
+    /// can be cached by calling the addMetric() methods.
+    virtual bool execute() = 0;
+
+    /// Return total execution time for this test.
+    virtual double getExecutionTime() const = 0;
+
+    /// Print the content of the JSON string.
+    void print() {
+        std::cout << "Test Information: " << std::endl;
+        std::cout << m_jsonTest.GetContent();
+    }
+
+  private:
+    std::ofstream m_jsonfile;   ///< Output JSON file
+    std::string m_name;         ///< Name of test
+    std::string m_projectName;  ///< Name of the project
+    std::string m_outDir;       ///< Name of output directory
+    bool m_verbose;             ///< Verbose output
+    Object m_jsonMetrics;       ///< collected metrics
+    Object m_jsonTest;          ///< JSON output of the test
+};
+
+#endif

--- a/src/unit_tests/CMakeLists.txt
+++ b/src/unit_tests/CMakeLists.txt
@@ -24,6 +24,17 @@ IF("${isSystemDir}" STREQUAL "-1")
 ENDIF("${isSystemDir}" STREQUAL "-1")
 
 #--------------------------------------------------------------
+# Option to enable metrics tracking
+OPTION(TEST_METRICS "Enable tracking of performance metrics from instrumented tests" OFF)
+
+if (TEST_METRICS)
+  set(TEST_METRICS_PATH "" CACHE PATH "Output directory for JSON performance metrics files")
+  mark_as_advanced(CLEAR TEST_METRICS_PATH)
+else()
+  mark_as_advanced(FORCE TEST_METRICS_PATH)
+endif()
+
+#--------------------------------------------------------------
 # Propagate to subdirectories
 
 option(BUILD_TESTS_BASE "Build unit tests for base Chrono module" TRUE)

--- a/src/unit_tests/fea/CMakeLists.txt
+++ b/src/unit_tests/fea/CMakeLists.txt
@@ -18,6 +18,7 @@ SET(TESTS
 )
 
 MESSAGE(STATUS "Unit test programs for FEA module...")
+
 # A hack to set the working directory in which to execute the CTest
 # runs.  This is needed for tests that need to access the Chrono data
 # directory (since we use a relative path to it)
@@ -25,6 +26,13 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(MY_WORKING_DIR "${EXECUTABLE_OUTPUT_PATH}/$<CONFIGURATION>")
 else()
   set(MY_WORKING_DIR ${EXECUTABLE_OUTPUT_PATH})
+endif()
+
+# Optional command line argument (output path for performance metrics)
+if (TEST_METRICS)
+  set(ARGS ${TEST_METRICS_PATH})
+else()
+  set(ARGS "")
 endif()
 
 FOREACH(PROGRAM ${TESTS})
@@ -48,7 +56,7 @@ FOREACH(PROGRAM ${TESTS})
     #         COMMAND ${PROJECT_BINARY_DIR}/bin/${PROGRAM}
     #         WORKING_DIRECTORY ${MY_WORKING_DIR})
 
-    ADD_TEST(${PROGRAM} ${PROJECT_BINARY_DIR}/bin/${PROGRAM})
+    ADD_TEST(${PROGRAM} ${PROJECT_BINARY_DIR}/bin/${PROGRAM} ${ARGS})
 
     SET_TESTS_PROPERTIES (${PROGRAM} PROPERTIES 
                           WORKING_DIRECTORY ${MY_WORKING_DIR})

--- a/src/unit_tests/fea/utest_FEA_compute_contact_mesh.cpp
+++ b/src/unit_tests/fea/utest_FEA_compute_contact_mesh.cpp
@@ -9,15 +9,15 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 // =============================================================================
-// Author: Antonio Recuero
+// Author: Antonio Recuero, Radu Serban, Conlain Kelly
 // =============================================================================
 //
 // Unit test for ComputeContactForces utility: NodeCloud, Mesh Vs Body Contact.
 // Method system->GetContactContainer()->ComputeContactForces() iterates over
 // all bodies/meshes into contact and stores resultant contact force in an unordered map.
 // Upon invocation of myBody->GetContactForce(), the user can retrieve the resultant
-// of all (!) contact forces acting on the body from the NodeCloud DEM-P contact. 
-// In this unit test, the overall contact force applied to a box (from mesh) is compared 
+// of all (!) contact forces acting on the body from the NodeCloud DEM-P contact.
+// In this unit test, the overall contact force applied to a box (from mesh) is compared
 // to the total weight of the ANCF shell mesh.
 //
 // =============================================================================
@@ -35,15 +35,18 @@
 #include "chrono_fea/ChElementShellANCF.h"
 #include "chrono_fea/ChMesh.h"
 
+#include "../BaseTest.h"
+
 using namespace chrono;
 using namespace chrono::fea;
+
 // ====================================================================================
 
 // ---------------------
 // Simulation parameters
 // ---------------------
 
-double end_time = 0.05;     // total simulation time
+double end_time = 0.05;    // total simulation time
 double start_time = 0.04;  // start check after this period
 double time_step = 2e-4;   // integration step size
 double gravity = -9.81;    // gravitational acceleration
@@ -90,15 +93,51 @@ double bin_width = 10;
 double bin_length = 10;
 double bin_thickness = 0.1;
 
-// Forward declaration
-bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method);
+// ====================================================================================
+
+// Test class
+class MeshContactTest : public BaseTest {
+  public:
+    MeshContactTest(const std::string& testName,
+                    const std::string& testProjectName,
+                    ChMaterialSurfaceBase::ContactMethod method)
+        : BaseTest(testName, testProjectName), m_method(method), m_execTime(0) {}
+
+    ~MeshContactTest() {}
+
+    // Override corresponding functions in BaseTest
+    virtual bool execute() override;
+    virtual double getExecutionTime() const override { return m_execTime; }
+
+  private:
+    ChMaterialSurfaceBase::ContactMethod m_method;
+    double m_execTime;
+};
 
 // ====================================================================================
 
 int main(int argc, char* argv[]) {
     bool passed = true;
-    passed &= test_computecontact(ChMaterialSurfaceBase::DEM);
-    // passed &= test_computecontact(ChMaterialSurfaceBase::DVI);
+
+    MeshContactTest testDEM("utest_FEA_compute_contact_mesh_DEM", "Chrono::FEA", ChMaterialSurfaceBase::DEM);
+    MeshContactTest testDVI("utest_FEA_compute_contact_mesh_DVI", "Chrono::FEA", ChMaterialSurfaceBase::DVI);
+
+    if (argc > 1) {
+        // Generate metrics JSON output files
+        testDEM.setOutDir(argv[1]);
+        testDEM.setVerbose(true);
+        passed &= testDEM.run();
+        testDEM.print();
+
+        // testDVI.setOutDir(argv[1]);
+        // testDVI.setVerbose(true);
+        // passed &= testDVI.run();
+        // testDVI.print();
+    } else {
+        // Run in unit test mode
+        passed &= testDEM.execute();
+        // passed &= testDVI.execute();
+    }
 
     // Return 0 if all tests passed.
     return !passed;
@@ -106,12 +145,12 @@ int main(int argc, char* argv[]) {
 
 // ====================================================================================
 
-bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
+bool MeshContactTest::execute() {
     // Create system and contact material.
     ChSystem* system;
     std::shared_ptr<ChMaterialSurfaceBase> material;
 
-    switch (method) {
+    switch (m_method) {
         case ChMaterialSurfaceBase::DEM: {
             GetLog() << "Using PENALTY method.\n";
 
@@ -155,9 +194,9 @@ bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
 
     auto my_mesh = std::make_shared<ChMesh>();
     // Geometry of the plate
-    double plate_lenght_x = 0.5;
-    double plate_lenght_y = 0.05;
-    double plate_lenght_z = 0.5;  // small thickness
+    double plate_length_x = 0.5;
+    double plate_length_y = 0.05;
+    double plate_length_z = 0.5;  // small thickness
     // Specification of the mesh
     int N_x = numDiv_x + 1;
     int N_y = numDiv_y + 1;
@@ -167,9 +206,9 @@ bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
     //(1+1) is the number of nodes in the z direction
     int TotalNumNodes = (numDiv_x + 1) * (numDiv_z + 1);  // Or *(numDiv_y+1) for multilayer
     // Element dimensions (uniform grid)
-    double dx = plate_lenght_x / numDiv_x;
-    double dy = plate_lenght_y / numDiv_y;
-    double dz = plate_lenght_z / numDiv_z;
+    double dx = plate_length_x / numDiv_x;
+    double dy = plate_length_y / numDiv_y;
+    double dz = plate_length_z / numDiv_z;
 
     // Create and add the nodes
 
@@ -205,11 +244,11 @@ bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
         int node2 = (i / (numDiv_x)) * (N_x) + i % numDiv_x + 1 + N_x;
         int node3 = (i / (numDiv_x)) * (N_x) + i % numDiv_x + 1;
 
-        /*GetLog() << std::dynamic_pointer_cast<ChNodeFEAxyzD>(my_mesh->GetNode(node0))->GetPos() << "\t" << 
-            std::dynamic_pointer_cast<ChNodeFEAxyzD>(my_mesh->GetNode(node1))->GetPos() << "\t" <<
-            std::dynamic_pointer_cast<ChNodeFEAxyzD>(my_mesh->GetNode(node2))->GetPos() << "\t" <<
-            std::dynamic_pointer_cast<ChNodeFEAxyzD>(my_mesh->GetNode(node3))->GetPos() << "\t";
-        getchar();*/
+        /*GetLog() << std::dynamic_pointer_cast<ChNodeFEAxyzD>(my_mesh->GetNode(node0))->GetPos() << "\t" <<
+         std::dynamic_pointer_cast<ChNodeFEAxyzD>(my_mesh->GetNode(node1))->GetPos() << "\t" <<
+         std::dynamic_pointer_cast<ChNodeFEAxyzD>(my_mesh->GetNode(node2))->GetPos() << "\t" <<
+         std::dynamic_pointer_cast<ChNodeFEAxyzD>(my_mesh->GetNode(node3))->GetPos() << "\t";
+         getchar();*/
 
         // Create the element and set its nodes.
         auto element = std::make_shared<ChElementShellANCF>();
@@ -223,7 +262,7 @@ bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
         // Single layer
         element->AddLayer(dy, 0.0, mat);  // Thickness: dy;  Ply angle: 0.
         // Set other element properties
-        element->SetAlphaDamp(0.05);   // Structural damping for this
+        element->SetAlphaDamp(0.05);  // Structural damping for this
         element->SetGravityOn(true);  // element calculates its own gravitational load
         // Add element to mesh
         my_mesh->AddElement(element);
@@ -254,9 +293,9 @@ bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
     system->SetupInitial();
 
     // Create container box
-    auto ground =
-        utils::CreateBoxContainer(system, binId, material, ChVector<>(bin_width, bin_length, 200 * dy), bin_thickness,
-        ChVector<>(0, -1.5*m_contact_node_radius, 0), ChQuaternion<>(1, 0, 0, 0), true, true, false, false);
+    auto ground = utils::CreateBoxContainer(system, binId, material, ChVector<>(bin_width, bin_length, 200 * dy),
+                                            bin_thickness, ChVector<>(0, -1.5 * m_contact_node_radius, 0),
+                                            ChQuaternion<>(1, 0, 0, 0), true, true, false, false);
 
     // -------------------
     // Setup linear solver
@@ -284,7 +323,7 @@ bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
     // Setup integrator
     // ----------------
 
-    if (method == ChMaterialSurfaceBase::DEM) {
+    if (m_method == ChMaterialSurfaceBase::DEM) {
         GetLog() << "Using HHT integrator.\n";
         system->SetIntegrationType(ChSystem::INT_HHT);
         auto integrator = std::static_pointer_cast<ChTimestepperHHT>(system->GetTimestepper());
@@ -296,22 +335,26 @@ bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
         GetLog() << "Using default integrator.\n";
     }
 
+    double total_weight = rho * plate_length_x * plate_length_y * plate_length_z * std::abs(gravity);
+    GetLog() << "Total Weight of Shell: " << total_weight << "\n";
+
     // ---------------
     // Simulation loop
     // ---------------
-
+    ChTimer<> timer;
+    int num_steps = 0;
     bool passed = true;
-    double total_weight = rho*plate_lenght_x*plate_lenght_y*plate_lenght_z*std::abs(gravity);
     while (system->GetChTime() < end_time) {
+        timer.start();
         system->DoStepDynamics(time_step);
-
         system->GetContactContainer()->ComputeContactForces();
+        timer.stop();
+
+        num_steps++;
         ChVector<> contact_force = ground->GetContactForce();
-        GetLog() << "t = " << system->GetChTime() << " num contacts = " <<
-        system->GetContactContainer()->GetNcontacts()
-                 << "  force =  " << contact_force.y << "\n";
-        GetLog() << "Vertical Displacement of a Node: " << nodeRef->GetPos().y << "\n";
-        GetLog() << "Total Weight of Shell: " << total_weight << "\n";
+        GetLog() << "t = " << system->GetChTime()
+                 << "  num contacts = " << system->GetContactContainer()->GetNcontacts()
+                 << "  force =  " << contact_force.y << "  node y displacement = " << nodeRef->GetPos().y << "\n";
 
         if (system->GetChTime() > start_time) {
             if (std::abs(1 - std::abs(contact_force.y) / total_weight) > rtol) {
@@ -321,6 +364,10 @@ bool test_computecontact(ChMaterialSurfaceBase::ContactMethod method) {
             }
         }
     }
+
+    m_execTime = timer.GetTimeSeconds();
+    addMetric("num_steps", num_steps);
+    addMetric("avg_time_per_step", m_execTime / num_steps);
 
     GetLog() << "Test " << (passed ? "PASSED" : "FAILED") << "\n\n\n";
 


### PR DESCRIPTION
This branch enables the testing infrastructure to operate by adding CMake flags TEST_METRICS and TEST_METRICS_PATH. 
If TEST_METRICS is set to true then utest_FEA_compute_contact_mesh will output a JSON file containing metrics information to the path described by TEST_METRICS_PATH. This will be read by a buildbot-triggered python script on each build machine used for build- and performance-testing.
If the TEST_METRICS flag is not set to true, then utest_FEA_compute_contact_mesh will have exactly the same behavior as before. This configuration is already supported by buildbot and and be easily implemented for all unit tests in the future.