### PR TITLE
Contents of ChAssembly are not updated in certain situations such as ChSystem::DoStepDynamics()

### DIFF
--- a/src/chrono/physics/ChAssembly.cpp
+++ b/src/chrono/physics/ChAssembly.cpp
@@ -616,6 +616,13 @@ void ChAssembly::Setup() {
         ncoords_w - ndoc_w;  // number of degrees of freedom (approximate - does not consider constr. redundancy, etc)
 }
 
+// Update assemblies own properties first (ChTime and assets, if any).
+// Then update all contents of this assembly.
+void ChAssembly::Update(double mytime, bool update_assets) {
+	ChPhysicsItem::Update(mytime, update_assets);
+	Update(update_assets);
+}
+
 // - ALL PHYSICAL ITEMS (BODIES, LINKS,ETC.) ARE UPDATED,
 //   ALSO UPDATING THEIR AUXILIARY VARIABLES (ROT.MATRICES, ETC.).
 // - UPDATES ALL FORCES  (AUTOMATIC, AS CHILDREN OF BODIES)

--- a/src/chrono/physics/ChAssembly.h
+++ b/src/chrono/physics/ChAssembly.h
@@ -269,6 +269,10 @@ class ChApi ChAssembly : public ChPhysicsItem {
 
     /// Updates all the auxiliary data and children of
     /// bodies, forces, links, given their current state.
+    virtual void Update(double mytime, bool update_assets = true) override;
+
+    /// Updates all the auxiliary data and children of
+    /// bodies, forces, links, given their current state.
     virtual void Update(bool update_assets = true) override;
 
     /// Set zero speed (and zero accelerations) in state, without changing the position.


### PR DESCRIPTION
`ChPhysicsItem` has two overloaded update method: `Update(double mytime, bool update_assets)` and `Update(bool update_assets)`.
`ChAssembly` has an overriding of the second `Update()` to propagate method call to its contents, but not of first one.
Since some callers such as `ChSystem::DoStepDynamics()` take the first version of `Update()`, there are many chances to ignore updating assembly contents.
This causes some problems; for example, `ChLink` which contained in assemblies will not work.

This patch lets `ChAssembly` having an overriding of the first overloaded `Update()`, i.e. `Update(double mytime, bool update_assets)`, to fix above mentioned issues.