### PR TITLE
Update assets inserted in ChLinkMarker (and derived class) objects

### DIFF
--- a/src/chrono/physics/ChLinkMarkers.cpp
+++ b/src/chrono/physics/ChLinkMarkers.cpp
@@ -341,6 +341,9 @@ void ChLinkMarkers::Update(double time, bool update_assets) {
 
     // 3 -
     UpdateForces(time);
+
+    // Inherit time changes of parent class (ChLink)
+    ChLink::Update(time, update_assets);
 }
 
 //// STATE BOOKKEEPING FUNCTIONS

--- a/src/chrono/physics/ChLinkMasked.cpp
+++ b/src/chrono/physics/ChLinkMasked.cpp
@@ -549,6 +549,9 @@ void ChLinkMasked::Update(double time, bool update_assets) {
 
     // 4 -
     UpdateForces(time);
+    
+    // Inherit time changes of parent class (ChLinkMarkers)
+    ChLinkMarkers::Update(time, update_assets);
 }
 
 // Define some  link-specific flags for backward compatibility


### PR DESCRIPTION
Previously, the `Update()` function of `ChAsset` inserted in `ChLink` was not called since the `ChLink` class did not overload the `Update()` of `ChPhysicsItem`.
This issue was fixed in terms of `ChLink` and most of derived classes, but still remains as for `ChLinkMarkers` and its derivatives.