### PR TITLE
Update usage of Submatrix and Subvector

### DIFF
--- a/src/chrono_parallel/ChDataManager.h
+++ b/src/chrono_parallel/ChDataManager.h
@@ -40,11 +40,11 @@
 // Blaze Includes
 #include <blaze/math/CompressedMatrix.h>
 #include <blaze/math/DynamicVector.h>
-#include <blaze/math/DenseSubvector.h>
+#include <blaze/math/Subvector.h>
 
 using blaze::CompressedMatrix;
 using blaze::DynamicVector;
-using blaze::SparseSubmatrix;
+using blaze::Submatrix;
 using blaze::submatrix;
 using blaze::subvector;
 using thrust::host_vector;
@@ -54,11 +54,11 @@ namespace chrono {
 /// @addtogroup parallel_module
 /// @{
 
-typedef blaze::SparseSubmatrix<CompressedMatrix<real> > SubMatrixType;
-typedef blaze::DenseSubvector<DynamicVector<real> > SubVectorType;
+typedef blaze::Submatrix<CompressedMatrix<real> > SubMatrixType;
+typedef blaze::Subvector<DynamicVector<real> > SubVectorType;
 
-typedef blaze::SparseSubmatrix<const CompressedMatrix<real> > ConstSubMatrixType;
-typedef blaze::DenseSubvector<const DynamicVector<real> > ConstSubVectorType;
+typedef blaze::Submatrix<const CompressedMatrix<real> > ConstSubMatrixType;
+typedef blaze::Subvector<const DynamicVector<real> > ConstSubVectorType;
 
 // The maximum number of shear history contacts per smaller body (DEM)
 #define max_shear 20

--- a/src/chrono_parallel/constraints/ChConstraintBilateral.cpp
+++ b/src/chrono_parallel/constraints/ChConstraintBilateral.cpp
@@ -13,9 +13,6 @@
 
 using namespace chrono;
 
-using blaze::DenseSubvector;
-using blaze::subvector;
-
 void ChConstraintBilateral::Build_b() {
     std::vector<ChConstraint*>& mconstraints = data_manager->system_descriptor->GetConstraintsList();
 

--- a/src/chrono_parallel/solver/ChSolverParallelJacobi.cpp
+++ b/src/chrono_parallel/solver/ChSolverParallelJacobi.cpp
@@ -1,6 +1,5 @@
 #include "chrono_parallel/solver/ChSolverParallelJacobi.h"
-#include <blaze/math/SparseRow.h>
-#include <blaze/math/CompressedVector.h>
+#include <blaze/math/CompressedMatrix.h>
 using namespace chrono;
 
 uint ChSolverParallelJacobi::SolveJacobi(const uint max_iter,

--- a/src/chrono_parallel/solver/ChSolverParallelPGS.cpp
+++ b/src/chrono_parallel/solver/ChSolverParallelPGS.cpp
@@ -1,6 +1,4 @@
 #include "chrono_parallel/solver/ChSolverParallelPGS.h"
-#include <blaze/math/SparseRow.h>
-#include <blaze/math/CompressedVector.h>
 using namespace chrono;
 
 uint ChSolverParallelPGS::SolvePGS(const uint max_iter,


### PR DESCRIPTION
Blaze has merged the {Sparse,Dense}Sub{matrix,vector} classes, so the build
is broken with new versions of Blaze. This fixes that by updating the usage
and also removes some files that referenced the Submatrix/vector classes but
weren't actually using them.