### PR TITLE
New feature: assets to visualize some line shape between two moving points

### DIFF
--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -374,6 +374,7 @@ set(ChronoEngine_assets_SOURCES
     assets/ChPathShape.cpp
     assets/ChLineShape.cpp
     assets/ChEmitterAsset.cpp
+    assets/ChPointPointDrawing.cpp
     )
 
 set(ChronoEngine_assets_HEADERS
@@ -401,6 +402,7 @@ set(ChronoEngine_assets_HEADERS
     assets/ChPathShape.h
     assets/ChLineShape.h
     assets/ChEmitterAsset.h
+    assets/ChPointPointDrawing.h
     )
 
 source_group(assets FILES

--- a/src/chrono/assets/ChPointPointDrawing.cpp
+++ b/src/chrono/assets/ChPointPointDrawing.cpp
@@ -1,0 +1,76 @@
+//
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2016 Project Chrono
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file at the top level of the distribution
+// and at http://projectchrono.org/license-chrono.txt.
+//
+
+#include "assets/ChPointPointDrawing.h"
+#include "chrono/physics/ChLinkMarkers.h"
+#include "chrono/physics/ChLinkDistance.h"
+
+namespace chrono {
+
+void ChPointPointDrawing::Update(ChPhysicsItem* updater, const ChCoordsys<>& coords) {
+	// Extract two positions from updater if it has any, and then update line geometry from these positions.
+	if (auto link_markers = dynamic_cast<ChLinkMarkers*>(updater)) {
+		UpdateLineGeometry(
+			coords.TransformPointParentToLocal(link_markers->GetMarker1()->GetAbsCoord().pos)
+			, coords.TransformPointParentToLocal(link_markers->GetMarker2()->GetAbsCoord().pos));
+	}
+	else if (auto link = dynamic_cast<ChLink*>(updater)) {
+		UpdateLineGeometry(
+			coords.TransformPointParentToLocal(link->GetBody1()->GetPos())
+			, coords.TransformPointParentToLocal(link->GetBody2()->GetPos()));
+	}
+
+	// Inherit patent class (ChLineShape)
+	ChLineShape::Update(updater, coords);
+}
+
+// Set line geometry as a segment between two end point
+void ChPointPointSegment::UpdateLineGeometry(const ChVector<>& endpoint1, const ChVector<>& endpoint2) {
+	this->SetLineGeometry(std::static_pointer_cast<geometry::ChLine>(std::make_shared<geometry::ChLineSegment>(endpoint1, endpoint2)));
+};
+
+// Set line geometry as a coil between two end point
+void ChPointPointSpring::UpdateLineGeometry(const ChVector<>& endpoint1, const ChVector<>& endpoint2) {
+	auto linepath = std::make_shared<geometry::ChLinePath>();
+
+	// Following part was copied from irrlicht::ChIrrTools::drawSpring()
+	ChVector<> dist = endpoint2 - endpoint1;
+	ChVector<> Vx, Vy, Vz;
+	double length = dist.Length();
+	ChVector<> dir = dist.GetNormalized();
+	ChVector<> singul = VECT_Y;
+	XdirToDxDyDz(&dir, &singul, &Vx, &Vy, &Vz);
+
+	ChMatrix33<> rel_matrix;
+	rel_matrix.Set_A_axis(Vx, Vy, Vz);
+	ChCoordsys<> mpos(endpoint1, rel_matrix.Get_A_quaternion());
+
+	double phaseA = 0;
+	double phaseB = 0;
+	double heightA = 0;
+	double heightB = 0;
+
+	for (int iu = 1; iu <= resolution; iu++) {
+		phaseB = turns * CH_C_2PI * (double)iu / (double)resolution;
+		heightB = length * ((double)iu / (double)resolution);
+		ChVector<> V1(heightA, radius * cos(phaseA), radius * sin(phaseA));
+		ChVector<> V2(heightB, radius * cos(phaseB), radius * sin(phaseB));
+
+		auto segment = geometry::ChLineSegment(mpos.TransformLocalToParent(V1), mpos.TransformLocalToParent(V2));
+		linepath->AddSubLine(segment);
+		phaseA = phaseB;
+		heightA = heightB;
+	}
+
+	this->SetLineGeometry(std::static_pointer_cast<geometry::ChLine>(linepath));
+}
+
+}  // END_OF_NAMESPACE____

--- a/src/chrono/assets/ChPointPointDrawing.h
+++ b/src/chrono/assets/ChPointPointDrawing.h
@@ -1,0 +1,89 @@
+//
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2016 Project Chrono
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file at the top level of the distribution
+// and at http://projectchrono.org/license-chrono.txt.
+//
+
+#ifndef CHLINESHAPEPP_H
+#define CHLINESHAPEPP_H
+
+#include "chrono/assets/ChLineShape.h"
+
+namespace chrono {
+
+/// Base class for visualization of some deformable line shape
+/// between two moving points related to the parent ChPhysicsItem.
+/// (at this point, only ChLink and its derivatives are supported.)
+/// NOTE: An instance of this class should not be shared among multiple ChPhysicsItem instances.
+/// Otherwise drawing may broken since each physics item will try to update
+/// geometry of the line and causes race conditions.
+
+class ChApi ChPointPointDrawing : public ChLineShape {
+	// Chrono RTTI, needed for serialization
+	CH_RTTI(ChPointPointDrawing, ChLineShape);
+
+public:
+	ChPointPointDrawing() = default;
+	
+	// Call UpdateLineGeometry() if updater has any pair of points.
+	// (at this point, only ChLink and its derivatives are supported.)
+	virtual void Update(ChPhysicsItem* updater, const ChCoordsys<>& coords) override;
+
+private:
+	// Update underlying line geomerty from given two endpoints.
+	// This method will be called on Update() call and should be implemented by derived classes.
+	virtual void UpdateLineGeometry(
+		const ChVector<>& endpoint1, const ChVector<>& endpoint2) = 0;
+};
+
+
+/// Class to visualize a line segment between two moving points related to the parent ChPhysicsItem.
+/// (at this point, only ChLink and its derivatives are supported.)
+/// NOTE: An instance of this class should not be shared among multiple ChPhysicsItem instances.
+/// Otherwise drawing may broken since each physics item will try to update
+/// geometry of the line and causes race conditions.
+class ChApi ChPointPointSegment : public ChPointPointDrawing {
+	// Chrono RTTI, needed for serialization
+	CH_RTTI(ChPointPointSegment, ChPointPointDrawing);
+
+private:
+	// Set line geometry as segment between two end point
+	virtual void UpdateLineGeometry(const ChVector<>& endpoint1, const ChVector<>& endpoint2) override;
+};
+
+
+/// Class to visualize a coil spring between two moving points related to the parent ChPhysicsItem.
+/// (at this point, only ChLink and its derivatives are supported.)
+/// NOTE: An instance of this class should not be shared among multiple ChPhysicsItem instances.
+/// Otherwise drawing may broken since each physics item will try to update
+/// geometry of the line and causes race conditions.
+
+class ChApi ChPointPointSpring : public ChPointPointDrawing {
+	// Chrono RTTI, needed for serialization
+	CH_RTTI(ChPointPointSpring, ChPointPointDrawing);
+
+public:
+	ChPointPointSpring(double mradius = 0.05, int mresolution = 65, double mturns = 5.)
+		: radius(mradius)
+		, turns(mturns)
+		, resolution(mresolution)
+	{ }
+
+private:
+	// Set line geometry as coil between two end point
+	virtual void UpdateLineGeometry(const ChVector<>& endpoint1, const ChVector<>& endpoint2) override;
+	
+private:
+	double radius;
+	double turns;
+	size_t resolution;
+};
+
+}  // END_OF_NAMESPACE____
+
+#endif

--- a/src/demos/irrlicht/demo_spring.cpp
+++ b/src/demos/irrlicht/demo_spring.cpp
@@ -24,6 +24,8 @@
 
 #include <stdio.h>
 
+#include "chrono/assets/ChPointPointDrawing.h"
+
 #include "chrono/physics/ChSystem.h"
 #include "chrono/physics/ChBody.h"
 
@@ -109,6 +111,10 @@ int main(int argc, char* argv[]) {
     spring_1->Set_SpringR(damping_coef);
     system.AddLink(spring_1);
 
+	// Attach a visualization asset.
+	spring_1->AddAsset(col_1);
+	spring_1->AddAsset(std::make_shared<ChPointPointSpring>(0.05, 80, 15));
+
     // Create a body suspended through a ChLinkSpringCB
     // ------------------------------------------------
 
@@ -138,6 +144,10 @@ int main(int argc, char* argv[]) {
     spring_2->Set_SpringCallback(&force);
     system.AddLink(spring_2);
 
+	// Attach a visualization asset.
+	spring_2->AddAsset(col_2);
+	spring_2->AddAsset(std::make_shared<ChPointPointSpring>(0.05, 80, 15));
+
     // Create the Irrlicht application
     // -------------------------------
 
@@ -161,12 +171,6 @@ int main(int argc, char* argv[]) {
         application.BeginScene();
 
         application.DrawAll();
-
-        ChIrrTools::drawSpring(application.GetVideoDriver(), 0.05, spring_1->GetEndPoint1Abs(),
-                               spring_1->GetEndPoint2Abs(), video::SColor(255, 150, 20, 20), 80, 15, true);
-
-        ChIrrTools::drawSpring(application.GetVideoDriver(), 0.05, spring_2->GetEndPoint1Abs(),
-                               spring_2->GetEndPoint2Abs(), video::SColor(255, 20, 20, 150), 80, 15, true);
 
         application.DoStep();
 


### PR DESCRIPTION
We discussed about "spring asset" which can be used to visualize `ChLinkSpring` etc. [on forum](https://groups.google.com/forum/embed/?place=forum/projectchrono&showsearch=true&showpopout=true&parenturl=http%3A%2F%2Fprojectchrono.org%2Fforum%2F#!topic/projectchrono/Bbn2-hNoYwY).
Here is my implementation based on `ChLineShape`. The asset updates its underlying line geometry when `Update()` is called.

Usage:
```
std::shared_ptr<ChLinkSpring> spring;
// *** Initialize, add to the system, etc. ***
// Add visualizations
spring->AddAsset(color_asset);
spring->AddAsset(std::make_shared<ChPointPointSpring>(radius, resolution, turns));
```

Drawbacks:
These assets cannot be shared among physics items - otherwise drawing may broken since each physics item will try to update geometry of the line.
If someone wants to share same configurations of assets, to use lambda function may help:

```
auto make_spring_asset = [](){
	return std::make_shared<ChPointPointSpring>(0.1, 10, 60);
};
spring_1->AddAsset(make_spring_asset());
spring_2->AddAsset(make_spring_asset());
spring_3->AddAsset(make_spring_asset());
```