### PR TITLE
Add ChFunction support for generic lambdas

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,8 @@ set(CH_CXX_FLAGS "")
 #-----------------------------------------------------------------------------
 
 find_package(ModernCXX)
-set(CH_CXX_FLAGS "${CH_CXX_FLAGS} ${CMAKE_CXX11_STANDARD_COMPILE_OPTION}")
+#set(CH_CXX_FLAGS "${CH_CXX_FLAGS} ${CMAKE_CXX11_STANDARD_COMPILE_OPTION}")
+set(CH_CXX_FLAGS "${CH_CXX_FLAGS} ${CMAKE_CXX14_STANDARD_COMPILE_OPTION}")
 
 #-----------------------------------------------------------------------------
 # Threads and OpenMP support

--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -602,7 +602,7 @@ set(ChronoEngine_motion_functions_HEADERS
     motion_functions/ChFunction_Sequence.h
     motion_functions/ChFunction_Sigma.h
     motion_functions/ChFunction_Sine.h
-    )
+        motion_functions/ChFunction_Lambda.h)
 
 source_group(motion_functions FILES
     ${ChronoEngine_motion_functions_SOURCES}

--- a/src/chrono/motion_functions/ChFunction_Base.h
+++ b/src/chrono/motion_functions/ChFunction_Base.h
@@ -69,7 +69,8 @@ class ChApi ChFunction {
         FUNCT_REPEAT,
         FUNCT_SEQUENCE,
         FUNCT_SIGMA,
-        FUNCT_SINE
+        FUNCT_SINE,
+        FUNCT_LAMBDA
     };
 
   public:

--- a/src/chrono/motion_functions/ChFunction_Lambda.h
+++ b/src/chrono/motion_functions/ChFunction_Lambda.h
@@ -1,0 +1,101 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All right reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Tyler Olsen
+// =============================================================================
+
+#ifndef CHFUNCT_LAMBDA_H
+#define CHFUNCT_LAMBDA_H
+
+#include "chrono/motion_functions/ChFunction_Base.h"
+#include "chrono_thirdparty/yafel/DualNumber.hpp"
+
+namespace chrono {
+
+
+/**
+ * \class ChFunction_Lambda
+ *
+ * Child of ChFunction designed to take a C++14 generic lambda as an argument.
+ * It provides analytical first and second derivatives via Dual Number forward-mode
+ * automatic differentiation, provided by the third party "yafel" finite element library.
+ * (https://github.com/tjolsen/YAFEL)
+ *
+ * Due to the template on the generic lambda type, it is difficult to construct this class in
+ * the usual manner. For this reason, a function called "make_ChFunction_Lambda" has
+ * been provided to leverage modern C++ automatic return type deduction.
+ *
+ * For similar reasons, a utility function called "make_shared_ChFunction_Lambda"
+ * is provided that returns a shared pointer to a heap-allocated ChFunction_Lambda.
+ *
+ * Example usage:
+ *
+ * auto F = make_ChFunction_Lambda( [](auto x) { return x*x; } );
+ *
+ * auto Fp = make_shared_ChFunction_Lambda( [](auto x) { return x*x; } );
+ *
+ * @tparam LAMBDA Type of generic lambda passed to constructor.
+ */
+template<typename LAMBDA>
+class ChFunction_Lambda : public ChFunction
+{
+
+    CH_FACTORY_TAG(ChFunction_Lambda)
+
+
+private:
+    LAMBDA function;
+
+
+public:
+
+    ChFunction_Lambda(LAMBDA && _f) : function(_f) {}
+
+    virtual ChFunction_Lambda* Clone() const override { return new  ChFunction_Lambda<LAMBDA>(*this); }
+
+    virtual double Get_y(double x) const override { return function(x); }
+
+    virtual double Get_y_dx(double x) const override { return function(yafel::DualNumber<double>(double(x),1.0)).second; }
+
+    virtual double Get_y_dxdx(double x) const override {
+        auto X = yafel::make_dual(yafel::make_dual(x));
+        X.first.second = 1.0;
+        X.second.first = 1.0;
+        return function(X).second.second;
+    }
+
+    virtual FunctionType Get_Type() const override { return FUNCT_LAMBDA; }
+};
+
+
+/** \brief Create a stack-allocated ChFunction_Lambda
+ *
+ * @tparam T Type of generic lambda argument. Not necessary to type manually.
+ * @param func Generic lambda
+ */
+template<typename T>
+ChFunction_Lambda<T> make_ChFunction_Lambda(T && func) {
+    return { std::forward<T>(func) };
+}
+
+/** \brief Create a shared pointer to a heap-allocated ChFunction_Lambda
+ *
+ * @tparam T Type of generic lambda argument. Not necessary to type manually.
+ * @param func Generic lambda
+ */
+template<typename T>
+std::shared_ptr<ChFunction_Lambda<T>> make_shared_ChFunction_Lambda(T && func) {
+    return std::make_shared<ChFunction_Lambda<T>>(std::forward<T>(func));
+}
+
+} // end namespace chrono
+
+#endif //CHRONO_CHFUNCTION_LAMBDA_H

--- a/src/chrono_thirdparty/yafel/DualNumber.hpp
+++ b/src/chrono_thirdparty/yafel/DualNumber.hpp
@@ -1,0 +1,150 @@
+#ifndef YAFEL_DUALNUMBER_HPP
+#define YAFEL_DUALNUMBER_HPP
+
+#include <cmath>
+
+namespace yafel {
+
+template<typename T>
+class DualNumber
+{
+public:
+    T first;
+    T second;
+
+    DualNumber() : DualNumber(0, 0)
+    {}
+
+    DualNumber(T v1) : DualNumber(v1, 0)
+    {}
+
+    DualNumber(T v1, T v2) : first(v1), second(v2)
+    {}
+
+    // arithmetic operator overloading (+, -, *, /)
+    DualNumber<T> &operator+=(const DualNumber<T> &rhs)
+    {
+        second += rhs.second;
+        first += rhs.first;
+        return *this;
+    }
+
+    DualNumber<T> &operator-=(const DualNumber<T> &rhs)
+    {
+        second -= rhs.second;
+        first -= rhs.first;
+        return *this;
+    }
+
+    DualNumber<T> &operator*=(const DualNumber<T> &rhs)
+    {
+        second = second * rhs.first + first * rhs.second;
+        first = first * rhs.first;
+        return *this;
+    }
+
+    DualNumber<T> &operator/=(const DualNumber<T> &rhs)
+    {
+        second = (second * rhs.first - first * rhs.second) / (rhs.first * rhs.first);
+        first = first / rhs.first;
+        return *this;
+    }
+
+    DualNumber<T> operator+(DualNumber<T> rhs) const
+    {
+        return (rhs += *this);
+    }
+
+    DualNumber<T> operator-(const DualNumber<T> &rhs) const
+    {
+        DualNumber<T> copy(*this);
+        return (copy -= rhs);
+    }
+
+    DualNumber<T> operator*(DualNumber<T> rhs) const
+    {
+        return (rhs *= *this);
+    }
+
+    DualNumber<T> operator/(const DualNumber<T> &rhs) const
+    {
+        DualNumber<T> copy(*this);
+        return (copy /= rhs);
+    }
+
+    // comparison operators
+    bool operator>(const DualNumber<T> &rhs) const
+    {
+        return (first > rhs.first);
+    }
+
+    bool operator<(const DualNumber<T> &rhs) const
+    {
+        return (rhs > *this);
+    }
+
+    // unary operator-()
+    DualNumber<T> operator-() const
+    {
+        return DualNumber<T>(-first, -second);
+    }
+};
+
+template<typename T>
+DualNumber<T> make_dual(T lhs)
+{
+    return DualNumber<T>(lhs);
+}
+
+template<typename T, typename L>
+DualNumber<T> operator+(L lhs, DualNumber<T> rhs)
+{
+    return (make_dual(static_cast<T>(lhs)) + rhs);
+}
+
+template<typename T, typename L>
+DualNumber<T> operator-(L lhs, DualNumber<T> rhs)
+{
+    return (make_dual(static_cast<T>(lhs)) - rhs);
+}
+
+template<typename T, typename L>
+DualNumber<T> operator*(L lhs, DualNumber<T> rhs)
+{
+    return (make_dual(static_cast<T>(lhs)) * rhs);
+}
+
+template<typename T, typename L>
+DualNumber<T> operator/(L lhs, DualNumber<T> rhs)
+{
+    return (make_dual(static_cast<T>(lhs)) / rhs);
+}
+
+// More Useful Functions
+template<typename T>
+DualNumber<T> sin(DualNumber<T> x)
+{
+    using std::sin;
+    using std::cos;
+    return DualNumber<T>(sin(x.first), x.second * cos(x.first));
+}
+
+template<typename T>
+DualNumber<T> cos(DualNumber<T> x)
+{
+    using std::sin;
+    using std::cos;
+    return DualNumber<T>(cos(x.first), -x.second * sin(x.first));
+}
+
+template<typename T>
+DualNumber<T> exp(DualNumber<T> x)
+{
+    using std::exp;
+    return DualNumber<T>(exp(x.first), x.second * exp(x.first));
+}
+
+
+} //end namespace yafel
+
+#endif

--- a/src/unit_tests/core/CMakeLists.txt
+++ b/src/unit_tests/core/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(TESTS
     utest_CH_math
     utest_CH_sparse_matrix
 	utest_CH_ChCSR3Matrix
+    utest_CH_ChFunction_Lambda
     #utest_CH_stream
 )
 

--- a/src/unit_tests/core/utest_CH_ChFunction_Lambda.cpp
+++ b/src/unit_tests/core/utest_CH_ChFunction_Lambda.cpp
@@ -51,5 +51,5 @@ int main() {
     if(!passed)
         std::cerr << "ChFunction_Lambda Error: All tests not passed\n";
 
-    return passed;
+    return !passed;
 }

--- a/src/unit_tests/core/utest_CH_ChFunction_Lambda.cpp
+++ b/src/unit_tests/core/utest_CH_ChFunction_Lambda.cpp
@@ -1,0 +1,55 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All right reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Tyler Olsen
+// =============================================================================
+//
+// Unit test for MatrMultiplyAVX and MatrMultiplyTAVX.
+//
+// =============================================================================
+
+#include <iostream>
+#include "motion_functions/ChFunction_Lambda.h"
+
+using namespace chrono;
+
+int main() {
+
+    bool passed = true;
+
+    // y = x*x @ x=3.0. --> y=9, dy/dx=6, d^2y/dx^2 = 2
+    auto F1 = make_ChFunction_Lambda([](auto x) { return x*x; });
+    passed = passed
+             && F1.Get_y(3.0) == 9.0
+             && F1.Get_y_dx(3.0) == 6.0
+             && F1.Get_y_dxdx(3.0) == 2.0;
+
+
+    // y = exp(2*x)
+    auto F2 = make_ChFunction_Lambda([](auto x){ return exp(2*x); });
+    passed = passed
+            && F2.Get_y(2.0) == exp(4.0)
+            && F2.Get_y_dx(2.0) == 2.0*exp(4.0)
+            && F2.Get_y_dxdx(2.0) == 4.0*exp(4.0);
+
+
+    // y = cos(x), via shared pointer
+    auto Fp3 = make_shared_ChFunction_Lambda([](auto x){ return cos(x); });
+    passed = passed
+             && Fp3->Get_y(5.0) == cos(5.0)
+             && Fp3->Get_y_dx(5.0) == -sin(5.0)
+             && Fp3->Get_y_dxdx(5.0) == -cos(5.0);
+
+    if(!passed)
+        std::cerr << "ChFunction_Lambda Error: All tests not passed\n";
+
+    return passed;
+}

--- a/src/unit_tests/core/utest_CH_ChFunction_Lambda.cpp
+++ b/src/unit_tests/core/utest_CH_ChFunction_Lambda.cpp
@@ -12,7 +12,7 @@
 // Authors: Tyler Olsen
 // =============================================================================
 //
-// Unit test for MatrMultiplyAVX and MatrMultiplyTAVX.
+// Unit test for ChFunction_Lambda
 //
 // =============================================================================
 


### PR DESCRIPTION
Note: the new ChFunction_Lambda class requires -std=c++14 in order to be used properly since generic lambdas are not supported in C++11. This update was made explicitly in src/CMakeLists.txt in this commit, but should be achieved with conditional compilation. 