### PR TITLE
Bugfixes for building Chrono Parallel and Chrono FSI on Linux

### DIFF
--- a/src/chrono_fsi/CMakeLists.txt
+++ b/src/chrono_fsi/CMakeLists.txt
@@ -29,6 +29,13 @@ find_package(CUDA)
 
 #SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")
 #SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --device-c")
+
+# Chrono FSI on GCC requires explicit C++11 support. '-std=c++11' must also be
+# passed to the host compiler to override -std=c++14 if it is enabled.
+IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std c++11")
+  SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -std=c++11")
+ENDIF()
 SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_30,code=sm_30")
 #SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ---gpu-code=sm_30")
 
@@ -109,9 +116,9 @@ SOURCE_GROUP("" FILES
     ${ChronoEngine_FSI_SOURCES} 
     ${ChronoEngine_FSI_HEADERS})
 
-#-----------------------------------------------------------------------------	
+#-----------------------------------------------------------------------------  
 # Create the ChronoEngine_fsi library
-#-----------------------------------------------------------------------------	
+#-----------------------------------------------------------------------------  
 
 set(CXX_FLAGS ${CH_CXX_FLAGS})
 set(LIBRARIES "ChronoEngine")
@@ -122,14 +129,14 @@ if(ENABLE_MODULE_OPENGL)
 ENDIF()
 
 if(ENABLE_MODULE_PARALLEL)
-	set(CXX_FLAGS ${CH_PARALLEL_CXX_FLAGS})
-	include_directories(${CH_PARALLEL_INCLUDES})
-	list(APPEND LIBRARIES ChronoEngine_parallel)
+  set(CXX_FLAGS ${CH_PARALLEL_CXX_FLAGS})
+  include_directories(${CH_PARALLEL_INCLUDES})
+  list(APPEND LIBRARIES ChronoEngine_parallel)
 endif()
 
 if(ENABLE_MODULE_VEHICLE)
-	include_directories(${CH_VEHICLE_INCLUDES})
-	list(APPEND LIBRARIES ChronoEngine_vehicle)
+  include_directories(${CH_VEHICLE_INCLUDES})
+  list(APPEND LIBRARIES ChronoEngine_vehicle)
 endif()
 
 CUDA_ADD_LIBRARY(ChronoEngine_fsi SHARED 

--- a/src/chrono_parallel/CMakeLists.txt
+++ b/src/chrono_parallel/CMakeLists.txt
@@ -15,7 +15,18 @@ if(NOT ENABLE_MODULE_PARALLEL)
   mark_as_advanced(FORCE BLAZE_DIR)
   mark_as_advanced(FORCE USE_PARALLEL_DOUBLE)
   mark_as_advanced(FORCE USE_PARALLEL_SIMD)
-  mark_as_advanced(FORCE USE_PARALLEL_CUDA)
+  
+  # GCC > 4.9 does not support CUDA (<= 8.0) by default. 
+  # Users may explicitly select CUDA support if they are sure that their compiler
+  # does make use of any conflicting features, such as C++14.
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+      message(STATUS "GCC version:  ${CMAKE_CXX_COMPILER_VERSION} does not support USE_PARALLEL_CUDA by default")
+      set(USE_PARALLEL_CUDA OFF CACHE OFF "")
+      mark_as_advanced(FORCE USE_PARALLEL_CUDA)
+    endif()
+  endif()
+
   return()
 endif()
 
@@ -43,22 +54,20 @@ find_package(CUDA)
 
 cmake_dependent_option(USE_PARALLEL_CUDA "Enable CUDA support in Chrono::Parallel" ON "CUDA_FOUND" OFF)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
-    message(STATUS "GCC version:  ${CMAKE_CXX_COMPILER_VERSION} does not support USE_PARALLEL_CUDA")
-    set(USE_PARALLEL_CUDA OFF CACHE OFF "" FORCE)
-  endif()
-
-endif()
-
-
 
 IF(USE_PARALLEL_CUDA)
 	SET(CUDA_SEPARABLE_COMPILATION ON)
 
 	IF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-	  SET(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; --compiler-options -fPIC)
+        IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+            IF(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+                SET(CUDA_SEPARABLE_COMPILATION OFF)
+                SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std c++11")
+                SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -std=c++11")
+            ENDIF()
+        ENDIF()
+        SET(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; --compiler-options -fPIC)
 	ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	  SET(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; --compiler-options -fPIC)
 	ENDIF()

--- a/src/chrono_parallel/CMakeLists.txt
+++ b/src/chrono_parallel/CMakeLists.txt
@@ -42,6 +42,17 @@ set(CH_PARALLEL_C_FLAGS "")
 find_package(CUDA)
 
 cmake_dependent_option(USE_PARALLEL_CUDA "Enable CUDA support in Chrono::Parallel" ON "CUDA_FOUND" OFF)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+    message(STATUS "GCC version:  ${CMAKE_CXX_COMPILER_VERSION} does not support USE_PARALLEL_CUDA")
+    set(USE_PARALLEL_CUDA OFF CACHE OFF "" FORCE)
+  endif()
+
+endif()
+
+
+
 IF(USE_PARALLEL_CUDA)
 	SET(CUDA_SEPARABLE_COMPILATION ON)
 


### PR DESCRIPTION
A few changes to the CMake configurations of Chrono::Parallel and Chrono::FSI for GCC versions after 4.9 fix most of the compatibility issues on Linux. 

- Enables support for GCC 5 and newer.
- Enables building against Blaze versions up to the newest (3.1) on Linux.
- GCC 6 now works with Chrono::FSI builds if CUDA_HOST_COMPILER is set to GCC 5.4 or earlier.