### PR TITLE
cmake: enable ccache if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ set(MEMORYCHECK_COMMAND "/usr/bin/valgrind")
 set(CTEST_MEMORYCHECK_COMMAND "/usr/bin/valgrind")
 set(CTEST_MEMORYCHECK_COMMAND_OPTIONS "-v --tool=memcheck --leak-check=full --track-fds=yes --num-callers=50 --show-reachable=yes --track-origins=yes --malloc-fill=0xff --free-fill=0xfe")
 
+find_program(CCACHE_EXE ccache)
+if(CCACHE_EXE)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_EXE}")
+endif()
+
 #-----------------------------------------------------------------------------
 # Disable the warning when adding a subdir that has not CMakeLists.txt
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
No special configuration necessary, simply install `ccache`. CMake will
automatically enable if found and if using a supported generator
(Makefiles and Ninja).

Cache may be cleared via `ccache -C`

On my laptop, complete build with a clean build dir:

- empty cache: 74.6s
- warm cache: 5.3s

Obviously will not see that dramatic of speed up during everyday
development, but most rebuilds should be noticeably faster.

(For comparison, running `cmake` with no options takes 5.4s.)