### PR TITLE
OpenGL support for Chrono::FSI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -351,6 +351,12 @@ else()
   set(CHRONO_PARALLEL "#undef CHRONO_PARALLEL")
 endif()
 
+if(ENABLE_MODULE_FSI)
+  set(CHRONO_FSI "#define CHRONO_FSI")
+else()
+  set(CHRONO_FSI "#undef CHRONO_FSI")
+endif()
+
 # Note: OPENGL must be configured *after* PARALLEL
 if(ENABLE_MODULE_OPENGL)
   set(CHRONO_OPENGL "#define CHRONO_OPENGL")
@@ -382,11 +388,6 @@ else()
   set(CHRONO_VEHICLE "#undef CHRONO_VEHICLE")
 endif()
 
-if(ENABLE_MODULE_FSI)
-  set(CHRONO_FSI "#define CHRONO_FSI")
-else()
-  set(CHRONO_FSI "#undef CHRONO_FSI")
-endif()
 
 if(ENABLE_OPENMP)
   set(CHRONO_OPENMP_ENABLED "#define CHRONO_OPENMP_ENABLED")

--- a/src/chrono_fsi/CMakeLists.txt
+++ b/src/chrono_fsi/CMakeLists.txt
@@ -134,10 +134,10 @@ source_group(utils FILES
 set(CXX_FLAGS ${CH_CXX_FLAGS})
 set(LIBRARIES "ChronoEngine")
 
-if(ENABLE_MODULE_OPENGL)
-    include_directories(${CH_OPENGL_INCLUDES})
-    list(APPEND LIBRARIES ChronoEngine_opengl)
-ENDIF()
+#if(ENABLE_MODULE_OPENGL)
+#    include_directories(${CH_OPENGL_INCLUDES})
+#    list(APPEND LIBRARIES ChronoEngine_opengl)
+#ENDIF()
 
 if(ENABLE_MODULE_PARALLEL)
   set(CXX_FLAGS ${CH_PARALLEL_CXX_FLAGS})

--- a/src/chrono_fsi/ChSystemFsi.h
+++ b/src/chrono_fsi/ChSystemFsi.h
@@ -9,7 +9,7 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 // =============================================================================
-// Author: Arman Pazouki
+// Author: Arman Pazouki,Milad Rakhsha
 // =============================================================================
 //
 // Implementation of FSI system that includes all subclasses for proximity and
@@ -27,9 +27,9 @@
 #include "chrono_fsi/ChFsiDataManager.cuh"
 #include "chrono_fsi/ChFsiInterface.h"
 
-#ifdef CHRONO_OPENGL
-#include "chrono_opengl/ChOpenGLWindow.h"
-#endif
+//#ifdef CHRONO_OPENGL
+//#include "chrono_opengl/ChOpenGLWindow.h"
+//#endif
 
 namespace chrono {
 namespace fsi {
@@ -84,10 +84,6 @@ class CH_FSI_API ChSystemFsi : public ChFsiGeneral {
     /// These ChBodies are stored in a std::vector using their shared pointers.
     std::vector<std::shared_ptr<ChBody>>* GetFsiBodiesPtr() { return &fsiBodeisPtr; }
 
-    /// Initialize the graphics openGL interface for visualization.
-    void InitializeChronoGraphics(chrono::ChVector<> CameraLocation = chrono::ChVector<>(1, 0, 0),
-                                  chrono::ChVector<> CameraLookAt = chrono::ChVector<>(0, 0, 0));
-
     /// Finalize the construction of the fsi system.
     /// This function must be called when the fsi system is constructed,
     /// before the simulation starts. This function calls FinalizeData function
@@ -95,8 +91,6 @@ class CH_FSI_API ChSystemFsi : public ChFsiGeneral {
     virtual void Finalize();
 
   private:
-    /// Integrate the chrono system based on an explicit Euler scheme.
-    int DoStepChronoSystem(Real dT, double mTime);
 
     ChFsiDataManager* fsiData;                          ///< pointer to data manager which holds all the data
     std::vector<std::shared_ptr<ChBody>> fsiBodeisPtr;  ///< vector of a pointers to FSI bodies
@@ -112,9 +106,9 @@ class CH_FSI_API ChSystemFsi : public ChFsiGeneral {
     double mTime;    ///< current real time of the simulation
     bool haveFluid;  ///< boolean to check if the system have fluid or not
 
-#ifdef CHRONO_OPENGL
-    chrono::opengl::ChOpenGLWindow* gl_window;  ///< opengl graphics window if opengl exist
-#endif
+//#ifdef CHRONO_OPENGL
+//    chrono::opengl::ChOpenGLWindow* gl_window;  ///< opengl graphics window if opengl exist
+//#endif
 };
 
 /// @} fsi_physics

--- a/src/chrono_opengl/CMakeLists.txt
+++ b/src/chrono_opengl/CMakeLists.txt
@@ -78,7 +78,9 @@ INCLUDE_DIRECTORIES(${CH_OPENGL_INCLUDES})
 IF(ENABLE_MODULE_PARALLEL)
     INCLUDE_DIRECTORIES(${CH_PARALLEL_INCLUDES})
 ENDIF()
-
+IF(ENABLE_MODULE_FSI)
+    INCLUDE_DIRECTORIES(${CH_FSI_INCLUDES})
+ENDIF()
 # ------------------------------------------------------------------------------
 # Make some variables visible from parent directory
 # ------------------------------------------------------------------------------
@@ -281,6 +283,10 @@ if(ENABLE_MODULE_PARALLEL)
 	SET(CE_OpenGL_FLAGS "${CE_OpenGL_FLAGS} ${CH_PARALLEL_CXX_FLAGS}")
 endif()
 
+if(ENABLE_MODULE_FSI)
+        SET(CE_OpenGL_LIBRARIES ${CE_OpenGL_LIBRARIES} ChronoEngine_fsi)
+	SET(CE_OpenGL_FLAGS "${CE_OpenGL_FLAGS} ${CH_FSI_CXX_FLAGS}")
+endif()
 
 SET_TARGET_PROPERTIES(ChronoEngine_opengl PROPERTIES 
   COMPILE_FLAGS "${CE_OpenGL_FLAGS}"

--- a/src/chrono_opengl/ChOpenGLViewer.h
+++ b/src/chrono_opengl/ChOpenGLViewer.h
@@ -9,7 +9,7 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 // =============================================================================
-// Authors: Hammad Mazhar
+// Authors: Hammad Mazhar, Milad Rakhsha
 // =============================================================================
 // OpenGL viewer, this class draws the system to the screen and handles input
 // =============================================================================
@@ -31,6 +31,10 @@
 #include "chrono/physics/ChSystem.h"
 #include "chrono/core/ChTimer.h"
 
+#ifdef CHRONO_FSI
+#include "chrono_fsi/ChSystemFsi.h"
+#endif
+
 //#include "chrono_parallel/physics/ChSystemParallel.h"
 #include <glfw3.h>
 
@@ -46,6 +50,13 @@ enum RenderMode { POINTS, WIREFRAME, SOLID };
 class CH_OPENGL_API ChOpenGLViewer : public ChOpenGLBase {
   public:
     ChOpenGLViewer(ChSystem* system);
+
+#ifdef CHRONO_FSI
+    ChOpenGLViewer(ChSystem* system, chrono::fsi::ChSystemFsi* m_fsisystem) : ChOpenGLViewer(system) {
+        fsi_system = m_fsisystem;
+    }
+#endif
+
     ~ChOpenGLViewer();
     void TakeDown();
     bool Initialize();
@@ -69,7 +80,11 @@ class CH_OPENGL_API ChOpenGLViewer : public ChOpenGLBase {
     int interval;
 
     ChOpenGLCamera render_camera, ortho_camera;
-    ChSystem* physics_system;
+    ChSystem* physics_system;///<Pointer to the chrono system that is rendered.
+
+#ifdef CHRONO_FSI
+    chrono::fsi::ChSystemFsi* fsi_system; ///<Pointer to the (possible) FSI system that is rendered.
+#endif
 
     ChOpenGLShader main_shader;
     ChOpenGLShader cloud_shader;
@@ -134,6 +149,5 @@ class CH_OPENGL_API ChOpenGLViewer : public ChOpenGLBase {
 };
 
 /// @} opengl_module
-
 }
 }

--- a/src/chrono_opengl/ChOpenGLWindow.cpp
+++ b/src/chrono_opengl/ChOpenGLWindow.cpp
@@ -9,7 +9,7 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 // =============================================================================
-// Authors: Hammad Mazhar
+// Authors: Hammad Mazhar, Milad Rakhsha
 // =============================================================================
 // OpenGL window singleton, this class manages the opengl context and window
 // =============================================================================
@@ -85,6 +85,16 @@ void ChOpenGLWindow::Initialize(int size_x, int size_y, const char* title, ChSys
     GLReturnedError("Initialize Viewer ");
     poll_frame = 0;
 }
+#ifdef CHRONO_FSI
+void ChOpenGLWindow::Initialize(int size_x,
+                                int size_y,
+                                const char* title,
+                                ChSystem* msystem,
+                                chrono::fsi::ChSystemFsi* fsi_sys) {
+    ChOpenGLWindow::Initialize(size_x, size_y, title, msystem);
+    viewer->fsi_system=fsi_sys;
+}
+#endif
 
 void ChOpenGLWindow::StartDrawLoop(double time_step) {
     GLReturnedError("Start Draw Loop");

--- a/src/chrono_opengl/ChOpenGLWindow.h
+++ b/src/chrono_opengl/ChOpenGLWindow.h
@@ -9,7 +9,7 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 // =============================================================================
-// Authors: Hammad Mazhar
+// Authors: Hammad Mazhar, Milad Rakhsha
 // =============================================================================
 // OpenGL window singleton, this class manages the opengl context and window
 // =============================================================================
@@ -31,39 +31,50 @@ namespace opengl {
 /// Manager for the OpenGL context and window.
 class CH_OPENGL_API ChOpenGLWindow {
   public:
-    // Get the unique instance for the OpenGL window
-    // Call this function to get a pointer to the window
+    /// @brief Get the unique instance for the OpenGL window
+    /// Call this function to get a pointer to the window
     static ChOpenGLWindow& getInstance() {
         static ChOpenGLWindow instance;
         return instance;
     }
 
-    // Initialize the window and set up the opengl viewer class
-    void Initialize(int size_x,         // Width of window in pixels
-                    int size_y,         // Height of window in pixels
-                    const char* title,  // Window title string
-                    ChSystem* msystem   // The ChSystem that is attached to this window
+    /// Initialize the window and set up the opengl viewer class
+    void Initialize(int size_x,         ///< Width of window in pixels
+                    int size_y,         ///< Height of window in pixels
+                    const char* title,  ///< Window title string
+                    ChSystem* msystem   ///< The ChSystem that is attached to this window
                     );
-    // This starts the drawing loop and takes control away from the main program
-    // This function is the easiest way to start rendering
+
+#ifdef CHRONO_FSI
+    /// Initialize the window and set up the opengl viewer class if the FSI module is available
+    void Initialize(int size_x,         ///< Width of window in pixels
+                    int size_y,         ///< Height of window in pixels
+                    const char* title,  ///< Window title string
+                    ChSystem* msystem,  ///< The ChSystem that is attached to this window
+                    chrono::fsi::ChSystemFsi* fsi_sys ///< The ChSystemFsi that is attached to this window
+                    );
+#endif
+
+    /// This starts the drawing loop and takes control away from the main program
+    /// This function is the easiest way to start rendering
     void StartDrawLoop(double time_step  // integration step size
                        );
 
-    // Perform a dynamics step, the user needs to use this so that pausing the
-    // simulation works correctly
+    /// Perform a dynamics step, the user needs to use this so that pausing the
+    /// simulation works correctly
     bool DoStepDynamics(double time_step  // integration step size
                         );
 
-    // Render the ChSystem and the HUD
+    /// Render the ChSystem and the HUD
     void Render();
 
-    // Check if the glfw context is still valid and the window has not been closed
+    /// Check if the glfw context is still valid and the window has not been closed
     bool Active();
 
-    // Check if the simulation is running or paused
+    /// Check if the simulation is running or paused
     bool Running();
 
-    // Pause simulation
+    /// Pause simulation
     void Pause();
 
     // Set the camera position, look at and up vectors
@@ -82,12 +93,11 @@ class CH_OPENGL_API ChOpenGLWindow {
 
     void SetRenderMode(RenderMode mode) { viewer->render_mode = mode; }
 
-    // Provides the version of the opengl context along with driver information
-    static void GLFWGetVersion(GLFWwindow* main_window  // A pointer to the window/context
+    /// Provides the version of the opengl context along with driver information
+    static void GLFWGetVersion(GLFWwindow* main_window  ///< A pointer to the window/context
                                );
 
-    // Pointer to the opengl viewer that handles rendering, text and user
-    // interaction
+    /// Pointer to the opengl viewer that handles rendering, text and user interaction
     ChOpenGLViewer* viewer;
 
   private:
@@ -124,7 +134,6 @@ class CH_OPENGL_API ChOpenGLWindow {
 };
 
 /// @} opengl_module
-
 }
 }
 

--- a/src/demos/fsi/demo_FSI_DamBreak.cpp
+++ b/src/demos/fsi/demo_FSI_DamBreak.cpp
@@ -61,22 +61,23 @@ std::ofstream simParams;
 //----------------------------
 const std::string out_dir = "FSI_OUTPUT";
 const std::string demo_dir = out_dir + "/DamBreak";
-// Save data as csv files
+// Save data as csv files, turn it on to be able to see the results off-line using paraview
 bool save_output = true;
-int out_fps = 50;
+// Frequency of the save output
+int out_fps = 20;
 typedef fsi::Real Real;
 
 Real contact_recovery_speed = 1;  ///< recovery speed for MBD
 
 // Dimension of the domain
-Real bxDim = 2.5;
+Real bxDim = 5;
 Real byDim = 0.5;
-Real bzDim = 1.5;
+Real bzDim = 2.5;
 
 // Dimension of the fluid domain
-Real fxDim = 1;
+Real fxDim = 2;
 Real fyDim = byDim;
-Real fzDim = 1;
+Real fzDim = 2;
 
 // Forward declarations
 void SetArgumentsForMbdFromInput(int argc,
@@ -143,8 +144,6 @@ int main(int argc, char* argv[]) {
 #endif
     ChSystemParallelNSC mphysicalSystem;
     fsi::ChSystemFsi myFsiSystem(&mphysicalSystem, mHaveFluid);
-    chrono::ChVector<> CameraLocation = chrono::ChVector<>(-2, -2, 2);
-    chrono::ChVector<> CameraLookAt = chrono::ChVector<>(-0.5, -0.5, 0.8);
 
     chrono::fsi::SimParams* paramsH = myFsiSystem.GetSimParams();
 
@@ -158,7 +157,7 @@ int main(int argc, char* argv[]) {
     // Use a chrono sampler to create a bucket of fluid
     chrono::fsi::Real3 boxCenter =
         chrono::fsi::mR3(-bxDim / 2 + fxDim / 2, 0 * paramsH->HSML, fzDim / 2 + 1 * paramsH->HSML);
-    chrono::fsi::Real3 boxHalfDim = chrono::fsi::mR3(fxDim / 2, fyDim / 2, fzDim / 2);
+    chrono::fsi::Real3 boxHalfDim = chrono::fsi::mR3(fxDim / 2, fyDim / 2+ 3* paramsH->HSML, fzDim / 2);
     utils::Generator::PointVector points = sampler.SampleBox(fsi::ChFsiTypeConvert::Real3ToChVector(boxCenter),
                                                              fsi::ChFsiTypeConvert::Real3ToChVector(boxHalfDim));
     // Add from the sampler points to the FSI system
@@ -207,7 +206,7 @@ int main(int argc, char* argv[]) {
     cout << " -- ChSystem size : " << mphysicalSystem.Get_bodylist()->size() << endl;
 
     // ******************* System Initialize********************************
-    myFsiSystem.InitializeChronoGraphics(CameraLocation, CameraLookAt);
+    // myFsiSystem.InitializeChronoGraphics(CameraLocation, CameraLookAt);
 
     double mTime = 0;
 
@@ -229,25 +228,40 @@ int main(int argc, char* argv[]) {
 
     Real time = 0;
     Real Global_max_dT = paramsH->dT;
-    for (int tStep = 0; tStep < stepEnd + 1; tStep++) {
-        printf("step : %d, time= : %f (s) \n", tStep, time);
-        double frame_time = 1.0 / out_fps;
-        int next_frame = std::floor((time + 1e-6) / frame_time) + 1;
-        double next_frame_time = next_frame * frame_time;
-        double max_allowable_dt = next_frame_time - time;
-        if (max_allowable_dt > 1e-6)
-            paramsH->dT = std::min(Global_max_dT, max_allowable_dt);
-        else
-            paramsH->dT = Global_max_dT;
+#ifdef CHRONO_OPENGL
+    opengl::ChOpenGLWindow& gl_window = opengl::ChOpenGLWindow::getInstance();
+    ChVector<> CameraLocation = chrono::ChVector<>(0, -8, 2);
+    ChVector<> CameraLookAt = chrono::ChVector<>(0, 0, 1);
 
-#if haveFluid
-        myFsiSystem.DoStepDynamics_FSI();
+    gl_window.Initialize(1200, 700, " Chrono::FSI Dam break simulation", &mphysicalSystem, &myFsiSystem);
+    gl_window.SetCamera(CameraLocation, CameraLookAt, ChVector<>(0, 0, 1), 1.f);
+    gl_window.SetRenderMode(opengl::WIREFRAME);
+#endif
+
+	int next_frame=1;
+    for (int tStep = 0; tStep < stepEnd + 1; tStep++) {
+        //printf("step : %d, time= : %f (s) \n", tStep, time);
+        double frame_time = 1.0 / out_fps;
+#ifdef CHRONO_OPENGL
+        if (gl_window.Active()) {
+            gl_window.DoStepDynamics(paramsH->dT);
+            // Note that the rendering the SPH simulation on the fly in chrono::FSI requires GPU memory access which is expensive
+            // To speed up the process you may choose to render less frequently, considering the explicit nature of the solver and the very small time step
+            // You may decrease this anumber t the cost of slower simulation
+            if(tStep%25==0)
+            gl_window.Render();
+        }
 #else
-        myFsiSystem.DoStepDynamics_ChronoRK2();
+        myFsiSystem.DoStepDynamics_FSI();
 #endif
         time += paramsH->dT;
-        if (save_output)
+
+        if (std::abs(time -(double)next_frame*frame_time)<1e-5 && save_output){
+        	double time=paramsH->dT *tStep;
             SaveParaViewFilesMBD(myFsiSystem, mphysicalSystem, paramsH, next_frame, time);
+            next_frame=next_frame+1;
+        }
+
     }
 
     return 0;
@@ -297,8 +311,12 @@ void CreateMbdPhysicalSystemObjects(ChSystemParallelNSC& mphysicalSystem,
     chrono::utils::AddBoxGeometry(ground.get(), sizeBottom, posBottom, chrono::QUNIT, true);
     chrono::utils::AddBoxGeometry(ground.get(), size_YZ, pos_xp, chrono::QUNIT, true);
     chrono::utils::AddBoxGeometry(ground.get(), size_YZ, pos_xn, chrono::QUNIT, true);
-    //chrono::utils::AddBoxGeometry(ground.get(), size_XZ, pos_yp, chrono::QUNIT, true);
-    //chrono::utils::AddBoxGeometry(ground.get(), size_XZ, pos_yn, chrono::QUNIT, true);
+
+    // You may uncomment the following lines to have side walls as well.
+    // To show the use of Periodic boundary condition, these walls are not added
+    // To this end, paramsH->cMin and paramsH->cMax were set up appropriately (see the .h file)
+    // chrono::utils::AddBoxGeometry(ground.get(), size_XZ, pos_yp, chrono::QUNIT, true);
+    // chrono::utils::AddBoxGeometry(ground.get(), size_XZ, pos_yn, chrono::QUNIT, true);
     ground->GetCollisionModel()->BuildModel();
     mphysicalSystem.AddBody(ground);
 
@@ -308,8 +326,10 @@ void CreateMbdPhysicalSystemObjects(ChSystemParallelNSC& mphysicalSystem,
     chrono::fsi::utils::AddBoxBce(myFsiSystem.GetDataManager(), paramsH, ground, posTop, chrono::QUNIT, sizeBottom);
     chrono::fsi::utils::AddBoxBce(myFsiSystem.GetDataManager(), paramsH, ground, pos_xp, chrono::QUNIT, size_YZ, 23);
     chrono::fsi::utils::AddBoxBce(myFsiSystem.GetDataManager(), paramsH, ground, pos_xn, chrono::QUNIT, size_YZ, 23);
-//chrono::fsi::utils::AddBoxBce(myFsiSystem.GetDataManager(), paramsH, ground, pos_yp, chrono::QUNIT, size_XZ, 13);
-//chrono::fsi::utils::AddBoxBce(myFsiSystem.GetDataManager(), paramsH, ground, pos_yn, chrono::QUNIT, size_XZ, 13);
+    // If you uncommented the above lines that add the side walls, you should uncomment the following two lines as well
+    // This is necessary in order to populate the walls with BCE markers for the fluid simulation
+// chrono::fsi::utils::AddBoxBce(myFsiSystem.GetDataManager(), paramsH, ground, pos_yp, chrono::QUNIT, size_XZ, 13);
+// chrono::fsi::utils::AddBoxBce(myFsiSystem.GetDataManager(), paramsH, ground, pos_yn, chrono::QUNIT, size_XZ, 13);
 
 #endif
 }
@@ -325,24 +345,19 @@ void SaveParaViewFilesMBD(fsi::ChSystemFsi& myFsiSystem,
     static double exec_time;
     int out_steps = std::ceil((1.0 / paramsH->dT) / out_fps);
     exec_time += mphysicalSystem.GetTimerStep();
-    int num_contacts = mphysicalSystem.GetNcontacts();
-    double frame_time = 1.0 / out_fps;
     static int out_frame = 0;
-
-    if (save_output && std::abs(mTime - (next_frame)*frame_time) < 0.00001) {
-        // **** out fluid
-        chrono::fsi::utils::PrintToFile(myFsiSystem.GetDataManager()->sphMarkersD2.posRadD,
-                                        myFsiSystem.GetDataManager()->sphMarkersD2.velMasD,
-                                        myFsiSystem.GetDataManager()->sphMarkersD2.rhoPresMuD,
-                                        myFsiSystem.GetDataManager()->fsiGeneralData.referenceArray, demo_dir, true);
-
+    chrono::fsi::utils::PrintToFile(myFsiSystem.GetDataManager()->sphMarkersD2.posRadD,
+                                    myFsiSystem.GetDataManager()->sphMarkersD2.velMasD,
+                                    myFsiSystem.GetDataManager()->sphMarkersD2.rhoPresMuD,
+                                    myFsiSystem.GetDataManager()->fsiGeneralData.referenceArray, demo_dir, true);
         cout << "\n------------ Output frame:   " << next_frame << endl;
-        cout << "             Sim frame:      " << next_frame << endl;
-        cout << "             Time:           " << mTime << endl;
-        cout << "             Avg. contacts:  " << num_contacts / out_steps << endl;
-        cout << "             Execution time: " << exec_time << endl << endl;
-        cout << "\n----------------------------\n" << endl;
-
+        cout << "             Execution time: " << exec_time << endl;
         out_frame++;
-    }
+
 }
+
+
+
+
+
+

--- a/src/demos/fsi/demo_FSI_DamBreak.h
+++ b/src/demos/fsi/demo_FSI_DamBreak.h
@@ -50,11 +50,10 @@ void SetupParamsH(SimParams* paramsH, Real bxDim, Real byDim, Real bzDim, Real f
     paramsH->rho0 = 1000;
     paramsH->markerMass = pow(paramsH->MULT_INITSPACE * paramsH->HSML, 3) * paramsH->rho0;
     paramsH->mu0 = .0001;
-    paramsH->v_Max = 2;  
+    paramsH->v_Max = 1;
     paramsH->EPS_XSPH = .5f;
 
-
-    paramsH->dT = 2e-4;
+    paramsH->dT = 1e-3;
     paramsH->tFinal = 2;
     paramsH->timePause = 0;
     paramsH->kdT = 5; 
@@ -68,8 +67,8 @@ void SetupParamsH(SimParams* paramsH, Real bxDim, Real byDim, Real bzDim, Real f
     paramsH->tweakMultV = 0.1;
     paramsH->tweakMultRho = .00;
     paramsH->bceType = ADAMI;  // ADAMI, mORIGINAL
-    paramsH->cMin = mR3(-bxDim, -byDim, -bzDim) - mR3(paramsH->HSML * 5);
-    paramsH->cMax = mR3(bxDim, byDim, 1.2 * bzDim) + mR3(paramsH->HSML * 5);
+    paramsH->cMin = mR3(-bxDim, -byDim/2, -bzDim) - mR3(paramsH->HSML * 3);
+    paramsH->cMax = mR3(bxDim, byDim/2, 1.2 * bzDim) + mR3(paramsH->HSML * 3);
 
     //****************************************************************************************
     int3 side0 = mI3(floor((paramsH->cMax.x - paramsH->cMin.x) / (2 * paramsH->HSML)),

--- a/src/demos/fsi/params_demo_FSI_cylinderDrop.h
+++ b/src/demos/fsi/params_demo_FSI_cylinderDrop.h
@@ -50,7 +50,7 @@ void SetupParamsH(SimParams *paramsH, Real hdimX, Real hdimY, Real hthick,
   paramsH->epsMinMarkersDis = .001;
   paramsH->NUM_BOUNDARY_LAYERS = 3;
   paramsH->toleranceZone =
-      paramsH->NUM_BOUNDARY_LAYERS * (paramsH->HSML * paramsH->MULT_INITSPACE);
+  paramsH->NUM_BOUNDARY_LAYERS * (paramsH->HSML * paramsH->MULT_INITSPACE);
   paramsH->BASEPRES = 0;
   paramsH->LARGE_PRES = 0;
   paramsH->deltaPress;


### PR DESCRIPTION
### OpenGL visualization support for fluid simulation with chrono_fsi
This PR contains the necessary changes to both Chrono::FSI and Chrono::OpenGL source codes and enables the OpenGL rendering for Chrono::FSI.

- This is necessary because the current state of chrono does not allow for this feature and only the multi-body dynamics system is rendered in openGL even when a FsiSystem is available.

- Note that trying to use ChSystemFsi in the OpenGL source codes will create circular dependency with the old configuration of the chrono_fsi source codes. Hence it is necessary to remove the openGL headers from the chrono_fsi source codes.

- In addition to that, the old configuration of the chrono_fsi **does not** allow for "optional" openGL rendering; the openGL windows gets activated if OpenGL is configured with chrono_fsi. This needed to be modified so that users can make the decision as to whether OpenGL rendering is performed or not in demos. Hence, the OpenGL wrapper functions were removed from Chrono::FSI.

- [ ]  @armanpazouki-- would you be able to confirm the changes in the chrono_fsi side?

- [ ] @hmazhar-- would you be able to confirm the changes in the chrono_opengl side?

- [ ] @rserban-- would you be able to confirm the overall approach? Although there need to be some follow-up cleanups
