### PR TITLE
Refactor out irrlicht dependency from chrono_vehicle

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -332,6 +332,7 @@ add_subdirectory(chrono_parallel)
 add_subdirectory(chrono_opengl)
 #add_subdirectory(chrono_ogre)
 add_subdirectory(chrono_vehicle)
+add_subdirectory(chrono_irrVehicle)
 add_subdirectory(chrono_fsi)
 
 # Add directories for model libraries
@@ -439,6 +440,12 @@ if(ENABLE_MODULE_VEHICLE)
   set(CHRONO_VEHICLE "#define CHRONO_VEHICLE")
 else()
   set(CHRONO_VEHICLE "#undef CHRONO_VEHICLE")
+endif()
+
+if(ENABLE_MODULE_IRRVEHICLE)
+  set(CHRONO_IRRVEHICLE "#define CHRONO_IRRVEHICLE")
+else()
+  set(CHRONO_IRRVEHICLE "#undef CHRONO_IRRVEHICLE")
 endif()
 
 if(ENABLE_MODULE_FSI)

--- a/src/chrono_irrVehicle/CMakeLists.txt
+++ b/src/chrono_irrVehicle/CMakeLists.txt
@@ -1,0 +1,288 @@
+#=============================================================================
+# CMake configuration file for Chrono IrrVehicle module
+#
+# Cannot be used stand-alone (it is loaded by parent CMake configuration file)
+#=============================================================================
+
+option(ENABLE_MODULE_IRRVEHICLE "Enable the Chrono IrrVehicle module" OFF)
+
+# Return now if this module is not enabled
+if(NOT ENABLE_MODULE_IRRVEHICLE)
+   mark_as_advanced(ENABLE_OPENCRG)
+   mark_as_advanced(FORCE ENABLE_IRRKLANG)
+   mark_as_advanced(FORCE CH_IRRKLANG_SDKDIR)
+   mark_as_advanced(FORCE CH_IRRKLANGLIB)
+   return()
+endif()
+
+message(STATUS "==== Chrono Irrlicht Vehicle module ====")
+
+mark_as_advanced(CLEAR ENABLE_OPENCRG)
+mark_as_advanced(CLEAR ENABLE_IRRKLANG)
+mark_as_advanced(CLEAR CH_IRRKLANG_SDKDIR)
+mark_as_advanced(CLEAR CH_IRRKLANGLIB)
+
+# Provide option to add OpenCRG support.
+option(ENABLE_OPENCRG "Enable OpenCRG terrain library support" OFF)
+
+# If Irrlicht support was enabled, provide option to add Irrklang support.
+cmake_dependent_option(ENABLE_IRRKLANG "Enable Irrklang library for sound" OFF
+                       "ENABLE_MODULE_IRRLICHT" OFF)
+
+# ----------------------------------------------------------------------------
+# Find the OpenCRG library
+# ----------------------------------------------------------------------------
+if (ENABLE_OPENCRG)
+   
+   if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+      set(OPENCRG_INCLUDE_DIR ""  CACHE PATH   "The directory where crgBaseLib.h resides")
+      set(OPENCRG_LIBRARY   "" CACHE FILEPATH "The OpenCRG library")
+      set(OPENCRG_DLL  "" CACHE FILEPATH "The OpenCRG DLL")
+   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+      find_path(OPENCRG_INCLUDE_DIR NAMES crgBaseLib.h PATHS "/usr/local/include")
+      find_library(OPENCRG_LIBRARY NAMES OpenCRG PATHS "/usr/local/lib")
+   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      find_path(OPENCRG_INCLUDE_DIR NAMES crgBaseLib.h PATHS "/usr/local/include")
+      find_library(OPENCRG_LIBRARY NAMES OpenCRG PATHS "/usr/local/lib")
+   endif()
+
+   mark_as_advanced(CLEAR OPENCRG_INCLUDE_DIR)
+   mark_as_advanced(CLEAR OPENCRG_LIBRARY)
+   if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+     mark_as_advanced(CLEAR OPENCRG_DLL)
+   endif()
+
+   if(EXISTS "${OPENCRG_INCLUDE_DIR}/crgBaseLib.h" AND EXISTS "${OPENCRG_LIBRARY}")
+     set(HAVE_OPENCRG ON)
+  else()
+     set(HAVE_OPENCRG OFF)
+   endif()
+
+else()
+
+   mark_as_advanced(FORCE OPENCRG_INCLUDE_DIR)
+   mark_as_advanced(FORCE OPENCRG_LIBRARY)
+   if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+     mark_as_advanced(FORCE OPENCRG_DLL)
+   endif()
+
+   set(HAVE_OPENCRG OFF)
+
+endif()
+
+SET(HAVE_OPENCRG "${HAVE_OPENCRG}" PARENT_SCOPE)
+
+# ----------------------------------------------------------------------------
+# Find IrrKlang library
+# ----------------------------------------------------------------------------
+if(ENABLE_IRRKLANG)
+
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+      set(CH_IRRKLANG_SDKDIR ""  CACHE PATH   "Where is your IrrKlang SDK installed?")
+      set(CH_IRRKLANGLIB   "" CACHE FILEPATH "Where is your Irrklang library?")
+  elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+      FIND_PATH(CH_IRRKLANG_SDKDIR NAMES irrlicht.h PATHS "/usr/include/irrklang" "/usr/local/include/irrklang")
+      FIND_LIBRARY(CH_IRRKLANGLIB NAMES Irrklang PATHS "/usr/local/lib" ${CH_IRRKLANG_SDKDIR}/lib/Linux)
+  endif()
+
+  if(EXISTS "${CH_IRRKLANG_SDKDIR}/include")
+      set(CH_IRRKLANGINC "${CH_IRRKLANG_SDKDIR}/include")
+  else()
+      set(CH_IRRKLANGINC "${CH_IRRKLANG_SDKDIR}")
+  endif()
+
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    if("${CH_COMPILER}" STREQUAL "COMPILER_MSVC")
+        set(CH_IRRKLANG_DLL "${CH_IRRKLANG_SDKDIR}/bin/Win32-VisualStudio/irrKlang.dll")
+    elseif("${CH_COMPILER}" STREQUAL "COMPILER_MSVC_X64")
+        set(CH_IRRKLANG_DLL "${CH_IRRKLANG_SDKDIR}/bin/Winx64-VisualStudio/irrKlang.dll")
+    endif()
+  endif()
+
+  mark_as_advanced(CLEAR CH_IRRKLANG_SDKDIR)
+  mark_as_advanced(CLEAR CH_IRRKLANGLIB)
+
+else()
+
+  mark_as_advanced(FORCE CH_IRRKLANG_SDKDIR)
+  mark_as_advanced(FORCE CH_IRRKLANGLIB)
+
+endif()
+
+# ----------------------------------------------------------------------------
+# Generate and install configuration file
+# ----------------------------------------------------------------------------
+
+# Prepare replacement variables
+if(HAVE_OPENCRG)
+  set(CHRONO_OPENCRG "#define CHRONO_OPENCRG")
+else()
+  set(CHRONO_OPENCRG "#undef CHRONO_OPENCRG")
+endif()
+
+if(ENABLE_IRRKLANG)
+  set(CHRONO_IRRKLANG "#define CHRONO_IRRKLANG")
+else()
+  set(CHRONO_IRRKLANG "#undef CHRONO_IRRKLANG")
+endif()
+
+
+# ----------------------------------------------------------------------------
+# List the files in the ChronoEngine_irrVehicle library
+# ----------------------------------------------------------------------------
+
+# --------------- COMMON FILES
+
+
+if(ENABLE_MODULE_IRRLICHT)
+    set(CVIRR_DRIVER_FILES
+        driver/ChIrrGuiDriver.h
+        driver/ChIrrGuiDriver.cpp
+    )
+else()
+    set(CVIRR_DRIVER_FILES "")
+endif()
+source_group("driver" FILES ${CVIRR_DRIVER_FILES})
+
+
+if(ENABLE_MODULE_IRRLICHT)
+    set(CVIRR_UTILS_FILES
+        utils/ChVehicleIrrApp.h
+        utils/ChVehicleIrrApp.cpp
+    )
+else()
+    set(CVIRR_UTILS_FILES "")
+endif()
+source_group("utils" FILES ${CVIRR_UTILS_FILES})
+
+# --------------- WHEELED VEHICLE FILES
+
+if(ENABLE_MODULE_IRRLICHT)
+    set(CVIRR_WV_TEST_RIG_FILES
+        wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.h
+        wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.cpp
+    )
+else()
+    set(CVIRR_WV_TEST_RIG_FILES "")
+endif()
+source_group("wheeled_vehicle\\test_rig" FILES ${CVIRR_WV_TEST_RIG_FILES})
+
+
+if(ENABLE_MODULE_IRRLICHT)
+    set(CVIRR_WV_UTILS_FILES
+        wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h
+        wheeled_vehicle/utils/ChWheeledVehicleIrrApp.cpp
+    )
+else()
+    set(CVIRR_WV_UTILS_FILES "")
+endif()
+source_group("wheeled_vehicle\\utils" FILES ${CVIRR_WV_UTILS_FILES})
+
+
+# --------------- TRACKED VEHICLE FILES
+
+
+if(ENABLE_MODULE_IRRLICHT)
+    set(CVIRR_TV_UTILS_FILES
+        tracked_vehicle/utils/ChTrackedVehicleIrrApp.h
+        tracked_vehicle/utils/ChTrackedVehicleIrrApp.cpp
+        tracked_vehicle/utils/ChIrrGuiDriverTTR.h
+        tracked_vehicle/utils/ChIrrGuiDriverTTR.cpp
+    )
+else()
+    set(CVIRR_TV_UTILS_FILES "")
+endif()
+source_group("tracked_vehicle\\utils" FILES ${CVIRR_TV_UTILS_FILES})
+
+
+# ----------------------------------------------------------------------------
+# Add the ChronoEngine_irrVehicle library
+# ----------------------------------------------------------------------------
+
+set(CXX_FLAGS ${CH_CXX_FLAGS})
+set(COMPILE_DEFS "CH_API_COMPILE_IRRVEHICLE")
+set(LINK_FLAGS ${CH_LINKERFLAG_SHARED})
+set(LIBRARIES "ChronoEngine")
+
+if(ENABLE_MODULE_IRRLICHT)
+    set(CXX_FLAGS "${CXX_FLAGS} ${CH_IRRLICHT_CXX_FLAGS}")
+    list(APPEND LIBRARIES ChronoEngine_vehicle ChronoEngine_irrlicht) 
+    include_directories(${CH_IRRLICHTINC})
+endif()
+
+if(ENABLE_MODULE_FEA)
+    list(APPEND LIBRARIES ChronoEngine_fea)
+endif()
+
+if(MPI_CXX_FOUND)
+    set(CXX_FLAGS "${CXX_FLAGS} ${MPI_CXX_COMPILE_FLAGS}")
+    set(LINK_FLAGS "${LINK_FLAGS} ${MPI_CXX_LINK_FLAGS}")
+    include_directories(${MPI_CXX_INCLUDE_PATH})
+    list(APPEND LIBRARIES ${MPI_CXX_LIBRARIES})
+endif()
+
+if(HDF5_FOUND)
+    set(COMPILE_DEFS "${COMPILE_DEFS} ${H5_BUILT_AS_DYNAMIC_LIB}")
+    include_directories(${HDF5_INCLUDE_DIRS})
+    list(APPEND LIBRARIES ${HDF5_CXX_LIBRARIES})
+endif()
+
+if(HAVE_OPENCRG)
+    include_directories(${OPENCRG_INCLUDE_DIR})
+    list(APPEND LIBRARIES ${OPENCRG_LIBRARY})
+endif()
+
+if(ENABLE_IRRKLANG)
+    include_directories(${CH_IRRKLANGINC})
+    list(APPEND LIBRARIES ${CH_IRRKLANGLIB})
+endif()
+
+add_library(ChronoEngine_irrVehicle SHARED
+#
+    ${CVIRR_DRIVER_FILES}
+    ${CVIRR_UTILS_FILES}
+#
+    ${CVIRR_WV_TEST_RIG_FILES}
+    ${CVIRR_WV_UTILS_FILES}
+#
+    ${CVIRR_TV_UTILS_FILES}
+#
+)
+
+set_target_properties(ChronoEngine_irrVehicle PROPERTIES
+                      COMPILE_FLAGS "${CXX_FLAGS}"
+                      LINK_FLAGS "${CH_LINKERFLAG_SHARED}"
+                      COMPILE_DEFINITIONS "CH_API_COMPILE_IRRVEHICLE")
+
+target_link_libraries(ChronoEngine_irrVehicle ${LIBRARIES})
+
+install(TARGETS ChronoEngine_irrVehicle
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib64
+        ARCHIVE DESTINATION lib64)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+        DESTINATION include/chrono_irrVehicle
+        FILES_MATCHING PATTERN "*.h")
+
+#-------------------------------------------------------------------------------
+# On Windows, copy DLLs (if specified)
+#-------------------------------------------------------------------------------
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+
+    if(EXISTS ${CH_IRRKLANG_DLL})
+        add_custom_command(TARGET ChronoEngine_irrVehicle POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CH_IRRKLANG_DLL}"
+            "${PROJECT_BINARY_DIR}/bin/$<CONFIGURATION>")
+    endif()
+
+    if(EXISTS ${OPENCRG_DLL})
+        add_custom_command(TARGET ChronoEngine_irrVehicle POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${OPENCRG_DLL}"
+            "${PROJECT_BINARY_DIR}/bin/$<CONFIGURATION>")
+    endif()
+
+endif()

--- a/src/chrono_irrVehicle/ChApiIrrVehicle.h
+++ b/src/chrono_irrVehicle/ChApiIrrVehicle.h
@@ -1,0 +1,88 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+
+#ifndef CH_IRRAPISUBSYS_H
+#define CH_IRRAPISUBSYS_H
+
+#include "chrono/ChVersion.h"
+#include "chrono/core/ChPlatform.h"
+
+// When compiling this library, remember to define CH_API_COMPILE_VEHICLE
+// (so that the symbols with 'CH_VEHICLE_API' in front of them will be marked as
+// exported). Otherwise, just do not define it if you link the library to your
+// code, and the symbols will be imported.
+
+#if defined(CH_API_COMPILE_IRRVEHICLE)
+#define CH_IRRVEHICLE_API ChApiEXPORT
+#else
+#define CH_IRRVEHICLE_API ChApiIMPORT
+#endif
+
+
+/**
+    @defgroup vehicle VEHICLE module
+    @brief Ground vehicle modeling
+
+    This module introduces template-based modeling tools
+    for creating wheeled and tracked vehicles.
+
+    For additional information, see:
+    - the [installation guide](@ref module_vehicle_installation)
+    - the [tutorials](@ref tutorial_table_of_content_chrono_vehicle)
+
+    @{
+        @defgroup vehicle_driver Driver models
+        @defgroup vehicle_powertrain Powertrain models
+        @defgroup vehicle_terrain Terrain models
+        @defgroup vehicle_utils Utility classes
+        
+        @defgroup vehicle_wheeled Wheeled vehicles
+        @{
+            @defgroup vehicle_wheeled_suspension Suspension subsystem
+            @defgroup vehicle_wheeled_steering Steering subsystem
+            @defgroup vehicle_wheeled_tire Tire subsystem
+            @defgroup vehicle_wheeled_driveline Driveline subsystem
+            @defgroup vehicle_wheeled_antirollbar Anti-roll bar subsystem
+            @defgroup vehicle_wheeled_wheel Wheel subsystem
+            @defgroup vehicle_wheeled_brake Brake subsystem
+            @defgroup vehicle_wheeled_test_rig Suspension test rig classes
+            @defgroup vehicle_wheeled_utils Utility classes
+        @}
+
+        @defgroup vehicle_tracked Tracked vehicles
+        @{
+            @defgroup vehicle_tracked_idler Idler subsystem
+            @defgroup vehicle_tracked_suspension Suspension subsystem
+            @defgroup vehicle_tracked_roller Roller subsystem
+            @defgroup vehicle_tracked_sprocket Sprocket subsystem
+            @defgroup vehicle_tracked_brake Brake subsystem
+            @defgroup vehicle_tracked_driveline Driveline subsystem
+            @defgroup vehicle_tracked_shoe Track-shoe subsystem
+            @defgroup vehicle_tracked_utils Utility classes
+        @}
+    @}
+*/
+
+
+namespace chrono {
+
+/// @addtogroup vehicle
+/// @{
+
+/// Namespace with classes for the VEHICLE module.
+namespace vehicle {}
+
+/// @}
+
+}
+
+#endif

--- a/src/chrono_irrVehicle/driver/ChIrrGuiDriver.cpp
+++ b/src/chrono_irrVehicle/driver/ChIrrGuiDriver.cpp
@@ -28,7 +28,7 @@
 #include <sstream>
 #include <climits>
 
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
 
 using namespace irr;
 

--- a/src/chrono_irrVehicle/driver/ChIrrGuiDriver.h
+++ b/src/chrono_irrVehicle/driver/ChIrrGuiDriver.h
@@ -27,11 +27,11 @@
 
 #include <string>
 
-#include "chrono_vehicle/ChApiVehicle.h"
-#include "chrono_vehicle/ChDriver.h"
+#include "chrono_irrVehicle/ChApiIrrVehicle.h"
+#include "chrono_irrVehicle/utils/ChVehicleIrrApp.h"
 
+#include "chrono_vehicle/ChDriver.h"
 #include "chrono_vehicle/driver/ChDataDriver.h"
-#include "chrono_vehicle/utils/ChVehicleIrrApp.h"
 
 namespace chrono {
 namespace vehicle {
@@ -47,7 +47,7 @@ namespace vehicle {
 /// the default no-op Advance() virtual method.
 ///
 /// @sa ChDataDriver
-class CH_VEHICLE_API ChIrrGuiDriver : public ChDriver, public irr::IEventReceiver {
+class CH_IRRVEHICLE_API ChIrrGuiDriver : public ChDriver, public irr::IEventReceiver {
   public:
     /// Functioning modes for a ChIrrGuiDriver
     enum InputMode {

--- a/src/chrono_irrVehicle/tracked_vehicle/utils/ChIrrGuiDriverTTR.cpp
+++ b/src/chrono_irrVehicle/tracked_vehicle/utils/ChIrrGuiDriverTTR.cpp
@@ -12,18 +12,15 @@
 // Authors: Radu Serban
 // =============================================================================
 //
-// Irrlicht-based GUI driver for the a suspension test rig.
-// This class implements the functionality required by its base ChDriverSTR
-// class using keyboard inputs.
-// As an Irrlicht event receiver, its OnEvent() callback is used to keep track
-// and update the current driver inputs. As such it does not need to override
-// the default no-op Advance() virtual method.
+// Irrlicht-based GUI driver for the a track test rig. This class extends
+// the ChIrrGuiDriver for a vehicle with controls for the shaker post.
 //
 // =============================================================================
 
 #include <algorithm>
 
-#include "chrono_vehicle/wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.h"
+#include "chrono/core/ChMathematics.h"
+#include "chrono_irrVehicle/tracked_vehicle/utils/ChIrrGuiDriverTTR.h"
 
 using namespace irr;
 
@@ -32,17 +29,21 @@ namespace vehicle {
 
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-ChIrrGuiDriverSTR::ChIrrGuiDriverSTR(ChVehicleIrrApp& app)
-    : ChDriverSTR(*static_cast<ChSuspensionTestRig*>(app.m_vehicle)),
-      m_app(app),
-      m_displDelta(1.0 / 50),
-      m_steeringDelta(1.0 / 50) {
-    app.SetUserEventReceiver(this);
+ChIrrGuiDriverTTR::ChIrrGuiDriverTTR(ChVehicleIrrApp& app, double displacement_limit)
+    : ChIrrGuiDriver(app),
+      m_displacement(0),
+      m_displacementDelta(displacement_limit / 50),
+      m_minDisplacement(-displacement_limit),
+      m_maxDisplacement(displacement_limit) {
 }
 
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-bool ChIrrGuiDriverSTR::OnEvent(const SEvent& event) {
+bool ChIrrGuiDriverTTR::OnEvent(const SEvent& event) {
+    // Allow the base class to first interpret events.
+    if (ChIrrGuiDriver::OnEvent(event))
+        return true;
+
     // Only interpret keyboard inputs.
     if (event.EventType != EET_KEY_INPUT_EVENT)
         return false;
@@ -50,22 +51,10 @@ bool ChIrrGuiDriverSTR::OnEvent(const SEvent& event) {
     if (event.KeyInput.PressedDown) {
         switch (event.KeyInput.Key) {
             case KEY_KEY_T:  // left post up
-                SetDisplacementLeft(m_displLeft + m_displDelta);
+                SetDisplacement(m_displacement + m_displacementDelta);
                 return true;
             case KEY_KEY_G:  // left post down
-                SetDisplacementLeft(m_displLeft - m_displDelta);
-                return true;
-            case KEY_KEY_Y:  // right post up
-                SetDisplacementRight(m_displRight + m_displDelta);
-                return true;
-            case KEY_KEY_H:  // right post down
-                SetDisplacementRight(m_displRight - m_displDelta);
-                return true;
-            case KEY_KEY_A:
-                SetSteering(m_steering - m_steeringDelta);
-                return true;
-            case KEY_KEY_D:
-                SetSteering(m_steering + m_steeringDelta);
+                SetDisplacement(m_displacement - m_displacementDelta);
                 return true;
             default:
                 break;
@@ -73,6 +62,12 @@ bool ChIrrGuiDriverSTR::OnEvent(const SEvent& event) {
     }
 
     return false;
+}
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+void ChIrrGuiDriverTTR::SetDisplacement(double vertical_disp) {
+    m_displacement = ChClamp(vertical_disp, m_minDisplacement, m_maxDisplacement);
 }
 
 }  // end namespace vehicle

--- a/src/chrono_irrVehicle/tracked_vehicle/utils/ChIrrGuiDriverTTR.h
+++ b/src/chrono_irrVehicle/tracked_vehicle/utils/ChIrrGuiDriverTTR.h
@@ -22,8 +22,8 @@
 
 #include <string>
 
-#include "chrono_vehicle/ChApiVehicle.h"
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/ChApiIrrVehicle.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
 
 namespace chrono {
 namespace vehicle {
@@ -33,7 +33,7 @@ namespace vehicle {
 
 /// Irrlicht-based GUI driver for the a track test rig.
 /// This class extends the ChIrrGuiDriver for a vehicle with controls for the shaker posts.
-class CH_VEHICLE_API ChIrrGuiDriverTTR : public ChIrrGuiDriver {
+class CH_IRRVEHICLE_API ChIrrGuiDriverTTR : public ChIrrGuiDriver {
   public:
     ChIrrGuiDriverTTR(ChVehicleIrrApp& app,            ///< handle to the vehicle Irrlicht application
                       double displacement_limit = 0.1  ///< limits for post displacement

--- a/src/chrono_irrVehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.cpp
+++ b/src/chrono_irrVehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.cpp
@@ -19,7 +19,7 @@
 
 #include "chrono/core/ChMathematics.h"
 
-#include "chrono_vehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h"
+#include "chrono_irrVehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h"
 #include "chrono_vehicle/tracked_vehicle/driveline/ChSimpleTrackDriveline.h"
 
 using namespace irr;

--- a/src/chrono_irrVehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h
+++ b/src/chrono_irrVehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h
@@ -20,7 +20,8 @@
 #ifndef CH_TRACKED_VEHICLE_IRRAPP_H
 #define CH_TRACKED_VEHICLE_IRRAPP_H
 
-#include "chrono_vehicle/utils/ChVehicleIrrApp.h"
+#include "chrono_irrVehicle/ChApiIrrVehicle.h"
+#include "chrono_irrVehicle/utils/ChVehicleIrrApp.h"
 #include "chrono_vehicle/tracked_vehicle/ChTrackedVehicle.h"
 
 namespace chrono {
@@ -30,7 +31,7 @@ namespace vehicle {
 /// @{
 
 /// Customized Chrono Irrlicht application for tracked vehicle visualization.
-class CH_VEHICLE_API ChTrackedVehicleIrrApp : public ChVehicleIrrApp {
+class CH_IRRVEHICLE_API ChTrackedVehicleIrrApp : public ChVehicleIrrApp {
   public:
     /// Construct a tracked vehicle Irrlicht application.
     ChTrackedVehicleIrrApp(

--- a/src/chrono_irrVehicle/utils/ChVehicleIrrApp.cpp
+++ b/src/chrono_irrVehicle/utils/ChVehicleIrrApp.cpp
@@ -22,7 +22,7 @@
 
 #include <algorithm>
 
-#include "chrono_vehicle/utils/ChVehicleIrrApp.h"
+#include "chrono_irrVehicle/utils/ChVehicleIrrApp.h"
 
 #include "chrono_vehicle/powertrain/ChShaftsPowertrain.h"
 

--- a/src/chrono_irrVehicle/utils/ChVehicleIrrApp.h
+++ b/src/chrono_irrVehicle/utils/ChVehicleIrrApp.h
@@ -25,12 +25,12 @@
 
 #include <string>
 
+#include "chrono_irrVehicle/ChApiIrrVehicle.h"
+
 #include "chrono/physics/ChSystem.h"
 #include "chrono/utils/ChUtilsChaseCamera.h"
 
 #include "chrono_irrlicht/ChIrrApp.h"
-
-#include "chrono_vehicle/ChApiVehicle.h"
 #include "chrono_vehicle/ChPowertrain.h"
 #include "chrono_vehicle/ChVehicle.h"
 
@@ -53,7 +53,7 @@ class ChCameraEventReceiver;  ///< custom event receiver for chase-cam control
 ///   - rendering of the entire Irrlicht scene
 ///   - implements a custom chase-camera (which can be controlled with keyboard)
 ///   - optional rendering of links, springs, stats, etc.
-class CH_VEHICLE_API ChVehicleIrrApp : public irrlicht::ChIrrApp {
+class CH_IRRVEHICLE_API ChVehicleIrrApp : public irrlicht::ChIrrApp {
   public:
     /// Construct a vehicle Irrlicht application.
     ChVehicleIrrApp(

--- a/src/chrono_irrVehicle/wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.cpp
+++ b/src/chrono_irrVehicle/wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.cpp
@@ -12,15 +12,18 @@
 // Authors: Radu Serban
 // =============================================================================
 //
-// Irrlicht-based GUI driver for the a track test rig. This class extends
-// the ChIrrGuiDriver for a vehicle with controls for the shaker post.
+// Irrlicht-based GUI driver for the a suspension test rig.
+// This class implements the functionality required by its base ChDriverSTR
+// class using keyboard inputs.
+// As an Irrlicht event receiver, its OnEvent() callback is used to keep track
+// and update the current driver inputs. As such it does not need to override
+// the default no-op Advance() virtual method.
 //
 // =============================================================================
 
 #include <algorithm>
 
-#include "chrono/core/ChMathematics.h"
-#include "chrono_vehicle/tracked_vehicle/utils/ChIrrGuiDriverTTR.h"
+#include "chrono_irrVehicle/wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.h"
 
 using namespace irr;
 
@@ -29,21 +32,17 @@ namespace vehicle {
 
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-ChIrrGuiDriverTTR::ChIrrGuiDriverTTR(ChVehicleIrrApp& app, double displacement_limit)
-    : ChIrrGuiDriver(app),
-      m_displacement(0),
-      m_displacementDelta(displacement_limit / 50),
-      m_minDisplacement(-displacement_limit),
-      m_maxDisplacement(displacement_limit) {
+ChIrrGuiDriverSTR::ChIrrGuiDriverSTR(ChVehicleIrrApp& app)
+    : ChDriverSTR(*static_cast<ChSuspensionTestRig*>(app.m_vehicle)),
+      m_app(app),
+      m_displDelta(1.0 / 50),
+      m_steeringDelta(1.0 / 50) {
+    app.SetUserEventReceiver(this);
 }
 
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-bool ChIrrGuiDriverTTR::OnEvent(const SEvent& event) {
-    // Allow the base class to first interpret events.
-    if (ChIrrGuiDriver::OnEvent(event))
-        return true;
-
+bool ChIrrGuiDriverSTR::OnEvent(const SEvent& event) {
     // Only interpret keyboard inputs.
     if (event.EventType != EET_KEY_INPUT_EVENT)
         return false;
@@ -51,10 +50,22 @@ bool ChIrrGuiDriverTTR::OnEvent(const SEvent& event) {
     if (event.KeyInput.PressedDown) {
         switch (event.KeyInput.Key) {
             case KEY_KEY_T:  // left post up
-                SetDisplacement(m_displacement + m_displacementDelta);
+                SetDisplacementLeft(m_displLeft + m_displDelta);
                 return true;
             case KEY_KEY_G:  // left post down
-                SetDisplacement(m_displacement - m_displacementDelta);
+                SetDisplacementLeft(m_displLeft - m_displDelta);
+                return true;
+            case KEY_KEY_Y:  // right post up
+                SetDisplacementRight(m_displRight + m_displDelta);
+                return true;
+            case KEY_KEY_H:  // right post down
+                SetDisplacementRight(m_displRight - m_displDelta);
+                return true;
+            case KEY_KEY_A:
+                SetSteering(m_steering - m_steeringDelta);
+                return true;
+            case KEY_KEY_D:
+                SetSteering(m_steering + m_steeringDelta);
                 return true;
             default:
                 break;
@@ -62,12 +73,6 @@ bool ChIrrGuiDriverTTR::OnEvent(const SEvent& event) {
     }
 
     return false;
-}
-
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
-void ChIrrGuiDriverTTR::SetDisplacement(double vertical_disp) {
-    m_displacement = ChClamp(vertical_disp, m_minDisplacement, m_maxDisplacement);
 }
 
 }  // end namespace vehicle

--- a/src/chrono_irrVehicle/wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.h
+++ b/src/chrono_irrVehicle/wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.h
@@ -26,8 +26,9 @@
 
 #include <string>
 
-#include "chrono_vehicle/ChApiVehicle.h"
-#include "chrono_vehicle/utils/ChVehicleIrrApp.h"
+#include "chrono_irrVehicle/ChApiIrrVehicle.h"
+#include "chrono_irrVehicle/utils/ChVehicleIrrApp.h"
+
 #include "chrono_vehicle/wheeled_vehicle/test_rig/ChDriverSTR.h"
 
 namespace chrono {
@@ -40,7 +41,7 @@ namespace vehicle {
 /// the functionality required by its base ChDriverSTR class using keyboard inputs.
 /// As an Irrlicht event receiver, its OnEvent() callback is used to keep track
 /// and update the current driver inputs.
-class CH_VEHICLE_API ChIrrGuiDriverSTR : public ChDriverSTR, public irr::IEventReceiver {
+class CH_IRRVEHICLE_API ChIrrGuiDriverSTR : public ChDriverSTR, public irr::IEventReceiver {
   public:
     ChIrrGuiDriverSTR(ChVehicleIrrApp& app  ///< handle to the vehicle Irrlicht application
                       );

--- a/src/chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.cpp
+++ b/src/chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.cpp
@@ -17,7 +17,7 @@
 //
 // =============================================================================
 
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "chrono_vehicle/wheeled_vehicle/driveline/ChShaftsDriveline2WD.h"
 #include "chrono_vehicle/wheeled_vehicle/driveline/ChShaftsDriveline4WD.h"

--- a/src/chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h
+++ b/src/chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h
@@ -20,7 +20,8 @@
 #ifndef CH_WHEELED_VEHICLE_IRRAPP_H
 #define CH_WHEELED_VEHICLE_IRRAPP_H
 
-#include "chrono_vehicle/utils/ChVehicleIrrApp.h"
+#include "chrono_irrVehicle/utils/ChVehicleIrrApp.h"
+
 #include "chrono_vehicle/wheeled_vehicle/ChWheeledVehicle.h"
 
 namespace chrono {
@@ -30,7 +31,7 @@ namespace vehicle {
 /// @{
 
 /// Customized Chrono Irrlicht application for wheeled vehicle visualization.
-class CH_VEHICLE_API ChWheeledVehicleIrrApp : public ChVehicleIrrApp {
+class CH_IRRVEHICLE_API ChWheeledVehicleIrrApp : public ChVehicleIrrApp {
   public:
     /// Construct a wheeled vehicle Irrlicht application.
     ChWheeledVehicleIrrApp(

--- a/src/chrono_vehicle/CMakeLists.txt
+++ b/src/chrono_vehicle/CMakeLists.txt
@@ -9,25 +9,16 @@ option(ENABLE_MODULE_VEHICLE "Enable the Chrono Vehicle module" OFF)
 # Return now if this module is not enabled
 if(NOT ENABLE_MODULE_VEHICLE)
    mark_as_advanced(ENABLE_OPENCRG)
-   mark_as_advanced(FORCE ENABLE_IRRKLANG)
-   mark_as_advanced(FORCE CH_IRRKLANG_SDKDIR)
-   mark_as_advanced(FORCE CH_IRRKLANGLIB)
    return()
 endif()
 
 message(STATUS "==== Chrono Vehicle module ====")
 
 mark_as_advanced(CLEAR ENABLE_OPENCRG)
-mark_as_advanced(CLEAR ENABLE_IRRKLANG)
-mark_as_advanced(CLEAR CH_IRRKLANG_SDKDIR)
-mark_as_advanced(CLEAR CH_IRRKLANGLIB)
 
 # Provide option to add OpenCRG support.
 option(ENABLE_OPENCRG "Enable OpenCRG terrain library support" OFF)
 
-# If Irrlicht support was enabled, provide option to add Irrklang support.
-cmake_dependent_option(ENABLE_IRRKLANG "Enable Irrklang library for sound" OFF
-                       "ENABLE_MODULE_IRRLICHT" OFF)
 
 # ----------------------------------------------------------------------------
 # Find the OpenCRG library
@@ -72,42 +63,6 @@ endif()
 
 SET(HAVE_OPENCRG "${HAVE_OPENCRG}" PARENT_SCOPE)
 
-# ----------------------------------------------------------------------------
-# Find IrrKlang library
-# ----------------------------------------------------------------------------
-if(ENABLE_IRRKLANG)
-
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-      set(CH_IRRKLANG_SDKDIR ""  CACHE PATH   "Where is your IrrKlang SDK installed?")
-      set(CH_IRRKLANGLIB   "" CACHE FILEPATH "Where is your Irrklang library?")
-  elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-      FIND_PATH(CH_IRRKLANG_SDKDIR NAMES irrlicht.h PATHS "/usr/include/irrklang" "/usr/local/include/irrklang")
-      FIND_LIBRARY(CH_IRRKLANGLIB NAMES Irrklang PATHS "/usr/local/lib" ${CH_IRRKLANG_SDKDIR}/lib/Linux)
-  endif()
-
-  if(EXISTS "${CH_IRRKLANG_SDKDIR}/include")
-      set(CH_IRRKLANGINC "${CH_IRRKLANG_SDKDIR}/include")
-  else()
-      set(CH_IRRKLANGINC "${CH_IRRKLANG_SDKDIR}")
-  endif()
-
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    if("${CH_COMPILER}" STREQUAL "COMPILER_MSVC")
-        set(CH_IRRKLANG_DLL "${CH_IRRKLANG_SDKDIR}/bin/Win32-VisualStudio/irrKlang.dll")
-    elseif("${CH_COMPILER}" STREQUAL "COMPILER_MSVC_X64")
-        set(CH_IRRKLANG_DLL "${CH_IRRKLANG_SDKDIR}/bin/Winx64-VisualStudio/irrKlang.dll")
-    endif()
-  endif()
-
-  mark_as_advanced(CLEAR CH_IRRKLANG_SDKDIR)
-  mark_as_advanced(CLEAR CH_IRRKLANGLIB)
-
-else()
-
-  mark_as_advanced(FORCE CH_IRRKLANG_SDKDIR)
-  mark_as_advanced(FORCE CH_IRRKLANGLIB)
-
-endif()
 
 # ----------------------------------------------------------------------------
 # Generate and install configuration file
@@ -118,12 +73,6 @@ if(HAVE_OPENCRG)
   set(CHRONO_OPENCRG "#define CHRONO_OPENCRG")
 else()
   set(CHRONO_OPENCRG "#undef CHRONO_OPENCRG")
-endif()
-
-if(ENABLE_IRRKLANG)
-  set(CHRONO_IRRKLANG "#define CHRONO_IRRKLANG")
-else()
-  set(CHRONO_IRRKLANG "#undef CHRONO_IRRKLANG")
 endif()
 
 # Generate the configuration header file using substitution variables.
@@ -178,15 +127,8 @@ set(CV_DRIVER_FILES
     driver/ChPathFollowerACCDriver.h
     driver/ChPathFollowerACCDriver.cpp
 )
-if(ENABLE_MODULE_IRRLICHT)
-    set(CVIRR_DRIVER_FILES
-        driver/ChIrrGuiDriver.h
-        driver/ChIrrGuiDriver.cpp
-    )
-else()
-    set(CVIRR_DRIVER_FILES "")
-endif()
-source_group("driver" FILES ${CV_DRIVER_FILES} ${CVIRR_DRIVER_FILES})
+
+source_group("driver" FILES ${CV_DRIVER_FILES})
 
 set(CV_POVERTRAIN_FILES
     powertrain/ChSimplePowertrain.h
@@ -243,15 +185,8 @@ set(CV_UTILS_FILES
     utils/ChUtilsJSON.h
     utils/ChUtilsJSON.cpp
 )
-if(ENABLE_MODULE_IRRLICHT)
-    set(CVIRR_UTILS_FILES
-        utils/ChVehicleIrrApp.h
-        utils/ChVehicleIrrApp.cpp
-    )
-else()
-    set(CVIRR_UTILS_FILES "")
-endif()
-source_group("utils" FILES ${CV_UTILS_FILES} ${CVIRR_UTILS_FILES})
+
+source_group("utils" FILES ${CV_UTILS_FILES})
 
 
 set(CV_OUTPUT_FILES
@@ -389,15 +324,8 @@ set(CV_WV_TEST_RIG_FILES
     wheeled_vehicle/test_rig/ChDataDriverSTR.h
     wheeled_vehicle/test_rig/ChDataDriverSTR.cpp
 )
-if(ENABLE_MODULE_IRRLICHT)
-    set(CVIRR_WV_TEST_RIG_FILES
-        wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.h
-        wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.cpp    
-    )
-else()
-    set(CVIRR_WV_TEST_RIG_FILES "")
-endif()
-source_group("wheeled_vehicle\\test_rig" FILES ${CV_WV_TEST_RIG_FILES} ${CVIRR_WV_TEST_RIG_FILES})
+
+source_group("wheeled_vehicle\\test_rig" FILES ${CV_WV_TEST_RIG_FILES})
 
 set(CV_WV_TIRE_FILES
     wheeled_vehicle/tire/ChRigidTire.h
@@ -452,15 +380,8 @@ set(CV_WV_UTILS_FILES
     wheeled_vehicle/utils/ChWheeledVehicleAssembly.h
     wheeled_vehicle/utils/ChWheeledVehicleAssembly.cpp
 )
-if(ENABLE_MODULE_IRRLICHT)
-    set(CVIRR_WV_UTILS_FILES
-        wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h
-        wheeled_vehicle/utils/ChWheeledVehicleIrrApp.cpp
-    )
-else()
-    set(CVIRR_WV_UTILS_FILES "")
-endif()
-source_group("wheeled_vehicle\\utils" FILES ${CV_WV_UTILS_FILES} ${CVIRR_WV_UTILS_FILES})
+
+source_group("wheeled_vehicle\\utils" FILES ${CV_WV_UTILS_FILES})
 
 set(CV_WV_VEHICLE_FILES
     wheeled_vehicle/vehicle/WheeledVehicle.h
@@ -668,17 +589,8 @@ set(CV_TV_UTILS_FILES
     tracked_vehicle/utils/ChTrackTestRig.h
     tracked_vehicle/utils/ChTrackTestRig.cpp
 )
-if(ENABLE_MODULE_IRRLICHT)
-    set(CVIRR_TV_UTILS_FILES
-        tracked_vehicle/utils/ChTrackedVehicleIrrApp.h
-        tracked_vehicle/utils/ChTrackedVehicleIrrApp.cpp
-        tracked_vehicle/utils/ChIrrGuiDriverTTR.h
-        tracked_vehicle/utils/ChIrrGuiDriverTTR.cpp
-    )
-else()
-    set(CVIRR_TV_UTILS_FILES "")
-endif()
-source_group("tracked_vehicle\\utils" FILES ${CV_TV_UTILS_FILES} ${CVIRR_TV_UTILS_FILES})
+
+source_group("tracked_vehicle\\utils" FILES ${CV_TV_UTILS_FILES})
 
 set(CV_TV_VEHICLE_FILES
     tracked_vehicle/vehicle/TrackedVehicle.h
@@ -706,12 +618,6 @@ set(COMPILE_DEFS "CH_API_COMPILE_VEHICLE")
 set(LINK_FLAGS ${CH_LINKERFLAG_SHARED})
 set(LIBRARIES "ChronoEngine")
 
-if(ENABLE_MODULE_IRRLICHT)
-    set(CXX_FLAGS "${CXX_FLAGS} ${CH_IRRLICHT_CXX_FLAGS}")
-    list(APPEND LIBRARIES ChronoEngine_irrlicht) 
-    include_directories(${CH_IRRLICHTINC})
-endif()
-
 if(ENABLE_MODULE_FEA)
     list(APPEND LIBRARIES ChronoEngine_fea)
 endif()
@@ -734,23 +640,16 @@ if(HAVE_OPENCRG)
     list(APPEND LIBRARIES ${OPENCRG_LIBRARY})
 endif()
 
-if(ENABLE_IRRKLANG)
-    include_directories(${CH_IRRKLANGINC})
-    list(APPEND LIBRARIES ${CH_IRRKLANGLIB})
-endif()
-
 add_library(ChronoEngine_vehicle SHARED
 #
     ${CV_BASE_FILES}
     ${CV_CHASSIS_FILES}
     ${CV_DRIVER_FILES}
-    ${CVIRR_DRIVER_FILES}
     ${CV_POVERTRAIN_FILES}
     ${CV_TERRAIN_FILES}
     ${CV_FEATERRAIN_FILES}
     ${CV_OPENCRG_FILES}
     ${CV_UTILS_FILES}
-    ${CVIRR_UTILS_FILES}
     ${CV_OUTPUT_FILES}
     ${CVHDF5_OUTPUT_FILES}
 #
@@ -761,11 +660,9 @@ add_library(ChronoEngine_vehicle SHARED
     ${CV_WV_STEERING_FILES}
     ${CV_WV_SUSPENSION_FILES}
     ${CV_WV_TEST_RIG_FILES}
-    ${CVIRR_WV_TEST_RIG_FILES}
     ${CV_WV_TIRE_FILES}
     ${CV_WV_FEATIRE_FILES}
     ${CV_WV_UTILS_FILES}
-    ${CVIRR_WV_UTILS_FILES}
     ${CV_WV_VEHICLE_FILES}
     ${CV_WV_WHEEL_FILES}
     ${CV_WV_COSIM_FILES}
@@ -783,7 +680,6 @@ add_library(ChronoEngine_vehicle SHARED
     ${CV_TV_TRACKASSEMBLY_FILES}
     ${CV_TV_FEATRACKASSEMBLY_FILES}
     ${CV_TV_UTILS_FILES}
-    ${CVIRR_TV_UTILS_FILES}
     ${CV_TV_VEHICLE_FILES}
 #
     ${CV_EASYBMP_FILES}
@@ -810,13 +706,6 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
 #-------------------------------------------------------------------------------
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-
-    if(EXISTS ${CH_IRRKLANG_DLL})
-        add_custom_command(TARGET ChronoEngine_vehicle POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${CH_IRRKLANG_DLL}"
-            "${PROJECT_BINARY_DIR}/bin/$<CONFIGURATION>")
-    endif()
 
     if(EXISTS ${OPENCRG_DLL})
         add_custom_command(TARGET ChronoEngine_vehicle POST_BUILD

--- a/src/demos/vehicle/demo_ArticulatedVehicle/CMakeLists.txt
+++ b/src/demos/vehicle/demo_ArticulatedVehicle/CMakeLists.txt
@@ -42,5 +42,6 @@ TARGET_LINK_LIBRARIES(${DEMO}
                       ChronoEngine
                       ChronoEngine_irrlicht
                       ChronoEngine_vehicle
+                      ChronoEngine_irrVehicle
                       ChronoModels_vehicle)
 INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})

--- a/src/demos/vehicle/demo_ArticulatedVehicle/demo_VEH_ArticulatedVehicle.cpp
+++ b/src/demos/vehicle/demo_ArticulatedVehicle/demo_VEH_ArticulatedVehicle.cpp
@@ -24,8 +24,8 @@
 
 #include "chrono_vehicle/ChVehicleModelData.h"
 #include "chrono_vehicle/terrain/RigidTerrain.h"
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/generic/Generic_SimplePowertrain.h"
 #include "chrono_models/vehicle/generic/Generic_RigidTire.h"

--- a/src/demos/vehicle/demo_DeformableSoil/CMakeLists.txt
+++ b/src/demos/vehicle/demo_DeformableSoil/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(LIBRARIES
     ChronoEngine
     ChronoEngine_irrlicht
     ChronoEngine_vehicle
+    ChronoEngine_irrVehicle
     ${CH_IRRLICHTLIB}
 )
 

--- a/src/demos/vehicle/demo_HMMWV/CMakeLists.txt
+++ b/src/demos/vehicle/demo_HMMWV/CMakeLists.txt
@@ -36,6 +36,7 @@ FOREACH(DEMO ${DEMOS})
                           ChronoEngine
                           ChronoEngine_irrlicht
                           ChronoEngine_vehicle
+                          ChronoEngine_irrVehicle
                           ChronoModels_vehicle)
     INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})
 

--- a/src/demos/vehicle/demo_HMMWV/demo_VEH_HMMWV.cpp
+++ b/src/demos/vehicle/demo_HMMWV/demo_VEH_HMMWV.cpp
@@ -27,11 +27,11 @@
 #include "chrono_vehicle/ChConfigVehicle.h"
 #include "chrono_vehicle/ChVehicleModelData.h"
 #include "chrono_vehicle/terrain/RigidTerrain.h"
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
 #include "chrono_vehicle/driver/ChDataDriver.h"
 #include "chrono_vehicle/output/ChVehicleOutputASCII.h"
 
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/hmmwv/HMMWV.h"
 

--- a/src/demos/vehicle/demo_HMMWV/demo_VEH_HMMWV_Accel.cpp
+++ b/src/demos/vehicle/demo_HMMWV/demo_VEH_HMMWV_Accel.cpp
@@ -29,7 +29,7 @@
 #include "chrono_vehicle/ChVehicleModelData.h"
 #include "chrono_vehicle/terrain/RigidTerrain.h"
 #include "chrono_vehicle/driver/ChPathFollowerDriver.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/hmmwv/HMMWV.h"
 

--- a/src/demos/vehicle/demo_HMMWV/demo_VEH_HMMWV_DefSoil.cpp
+++ b/src/demos/vehicle/demo_HMMWV/demo_VEH_HMMWV_DefSoil.cpp
@@ -36,7 +36,7 @@
 #include "chrono_vehicle/terrain/SCMDeformableTerrain.h"
 #include "chrono_vehicle/terrain/RigidTerrain.h"
 #include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleAssembly.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/hmmwv/HMMWV.h"
 

--- a/src/demos/vehicle/demo_HMMWV9/CMakeLists.txt
+++ b/src/demos/vehicle/demo_HMMWV9/CMakeLists.txt
@@ -31,5 +31,6 @@ TARGET_LINK_LIBRARIES(${DEMO}
                       ChronoEngine
                       ChronoEngine_irrlicht
                       ChronoEngine_vehicle
+                      ChronoEngine_irrVehicle
                       ChronoModels_vehicle)
 INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})

--- a/src/demos/vehicle/demo_HMMWV9/demo_VEH_HMMWV9.cpp
+++ b/src/demos/vehicle/demo_HMMWV9/demo_VEH_HMMWV9.cpp
@@ -27,10 +27,10 @@
 #include "chrono_vehicle/ChConfigVehicle.h"
 #include "chrono_vehicle/ChVehicleModelData.h"
 #include "chrono_vehicle/terrain/RigidTerrain.h"
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
 #include "chrono_vehicle/output/ChVehicleOutputASCII.h"
 
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/hmmwv/HMMWV.h"
 

--- a/src/demos/vehicle/demo_M113/CMakeLists.txt
+++ b/src/demos/vehicle/demo_M113/CMakeLists.txt
@@ -48,6 +48,7 @@ FOREACH(DEMO ${DEMOS})
                           ChronoEngine_irrlicht
                           ChronoEngine_vehicle
                           ChronoModels_vehicle
+                          ChronoEngine_irrVehicle
                           ${LIBS})
     INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})
     

--- a/src/demos/vehicle/demo_M113/demo_VEH_M113.cpp
+++ b/src/demos/vehicle/demo_M113/demo_VEH_M113.cpp
@@ -20,11 +20,11 @@
 #include "chrono/utils/ChUtilsInputOutput.h"
 
 #include "chrono_vehicle/ChVehicleModelData.h"
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
 #include "chrono_vehicle/terrain/RigidTerrain.h"
 #include "chrono_vehicle/output/ChVehicleOutputASCII.h"
 
-#include "chrono_vehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h"
+#include "chrono_irrVehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/m113/M113_SimplePowertrain.h"
 #include "chrono_models/vehicle/m113/M113_Vehicle.h"

--- a/src/demos/vehicle/demo_M113/demo_VEH_M113_DefSoil.cpp
+++ b/src/demos/vehicle/demo_M113/demo_VEH_M113_DefSoil.cpp
@@ -20,9 +20,9 @@
 #include "chrono/utils/ChUtilsInputOutput.h"
 
 #include "chrono_vehicle/ChVehicleModelData.h"
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
 #include "chrono_vehicle/terrain/SCMDeformableTerrain.h"
-#include "chrono_vehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h"
+#include "chrono_irrVehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/m113/M113_SimplePowertrain.h"
 #include "chrono_models/vehicle/m113/M113_Vehicle.h"

--- a/src/demos/vehicle/demo_RigidTerrain/CMakeLists.txt
+++ b/src/demos/vehicle/demo_RigidTerrain/CMakeLists.txt
@@ -34,6 +34,7 @@ FOREACH(DEMO ${DEMOS})
                           ChronoEngine
                           ChronoEngine_irrlicht
                           ChronoEngine_vehicle
+                          ChronoEngine_irrVehicle
                           ChronoModels_vehicle)
     INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})
 

--- a/src/demos/vehicle/demo_RigidTerrain/demo_VEH_RigidTerrain.cpp
+++ b/src/demos/vehicle/demo_RigidTerrain/demo_VEH_RigidTerrain.cpp
@@ -26,9 +26,9 @@
 
 #include "chrono_vehicle/ChConfigVehicle.h"
 #include "chrono_vehicle/ChVehicleModelData.h"
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
 #include "chrono_vehicle/terrain/RigidTerrain.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/hmmwv/HMMWV.h"
 

--- a/src/demos/vehicle/demo_SteeringController/CMakeLists.txt
+++ b/src/demos/vehicle/demo_SteeringController/CMakeLists.txt
@@ -31,5 +31,6 @@ TARGET_LINK_LIBRARIES(${DEMO}
                       ChronoEngine
                       ChronoEngine_irrlicht
                       ChronoEngine_vehicle
+                      ChronoEngine_irrVehicle
                       ChronoModels_vehicle)
 INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})

--- a/src/demos/vehicle/demo_SteeringController/demo_VEH_SteeringController.cpp
+++ b/src/demos/vehicle/demo_SteeringController/demo_VEH_SteeringController.cpp
@@ -25,10 +25,10 @@
 
 #include "chrono_vehicle/ChVehicleModelData.h"
 #include "chrono_vehicle/terrain/RigidTerrain.h"
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
 #include "chrono_vehicle/driver/ChPathFollowerDriver.h"
 #include "chrono_vehicle/utils/ChVehiclePath.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "chrono_models/vehicle/hmmwv/HMMWV.h"
 

--- a/src/demos/vehicle/demo_SuspensionTest/CMakeLists.txt
+++ b/src/demos/vehicle/demo_SuspensionTest/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(LIBRARIES
     ChronoEngine
     ChronoEngine_irrlicht
     ChronoEngine_vehicle
+    ChronoEngine_irrVehicle
     ${CH_IRRLICHTLIB}
 )
 

--- a/src/demos/vehicle/demo_SuspensionTest/demo_VEH_SuspensionTestRig.cpp
+++ b/src/demos/vehicle/demo_SuspensionTest/demo_VEH_SuspensionTestRig.cpp
@@ -51,9 +51,10 @@
 #include "chrono_vehicle/ChVehicleModelData.h"
 #include "chrono_vehicle/wheeled_vehicle/tire/RigidTire.h"
 #include "chrono_vehicle/wheeled_vehicle/test_rig/ChSuspensionTestRig.h"
-#include "chrono_vehicle/wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.h"
 #include "chrono_vehicle/wheeled_vehicle/test_rig/ChDataDriverSTR.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+
+#include "chrono_irrVehicle/wheeled_vehicle/test_rig/ChIrrGuiDriverSTR.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 using namespace chrono;
 using namespace chrono::vehicle;

--- a/src/demos/vehicle/demo_TrackTestRig/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TrackTestRig/CMakeLists.txt
@@ -31,6 +31,7 @@ TARGET_LINK_LIBRARIES(${DEMO}
                       ChronoEngine
                       ChronoEngine_irrlicht
                       ChronoEngine_vehicle
+                      ChronoEngine_irrVehicle
                       ChronoModels_vehicle)
 INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})
 

--- a/src/demos/vehicle/demo_TrackTestRig/demo_VEH_TrackTestRig.cpp
+++ b/src/demos/vehicle/demo_TrackTestRig/demo_VEH_TrackTestRig.cpp
@@ -19,9 +19,9 @@
 #include "chrono/utils/ChUtilsInputOutput.h"
 
 #include "chrono_vehicle/ChVehicleModelData.h"
-#include "chrono_vehicle/utils/ChVehicleIrrApp.h"
+#include "chrono_irrVehicle/utils/ChVehicleIrrApp.h"
 #include "chrono_vehicle/tracked_vehicle/utils/ChTrackTestRig.h"
-#include "chrono_vehicle/tracked_vehicle/utils/ChIrrGuiDriverTTR.h"
+#include "chrono_irrVehicle/tracked_vehicle/utils/ChIrrGuiDriverTTR.h"
 
 #include "chrono_vehicle/tracked_vehicle/track_assembly/TrackAssemblySinglePin.h"
 ////#include "chrono_vehicle/tracked_vehicle/track_assembly/TrackAssemblyDoublePin.h"

--- a/src/demos/vehicle/demo_TrackedJSON/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TrackedJSON/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(LIBRARIES
 IF(ENABLE_MODULE_IRRLICHT)
   SET(LIBRARIES_IRR
       ChronoEngine_irrlicht
+      ChronoEngine_irrVehicle
       ${CH_IRRLICHTLIB})
 ELSE()
   SET(LIBRARIES_IRR "")

--- a/src/demos/vehicle/demo_TrackedJSON/demo_VEH_TrackedJSON.cpp
+++ b/src/demos/vehicle/demo_TrackedJSON/demo_VEH_TrackedJSON.cpp
@@ -40,8 +40,8 @@
 // If Irrlicht support is available...
 #ifdef CHRONO_IRRLICHT
 // ...include additional headers
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
-#include "chrono_vehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/tracked_vehicle/utils/ChTrackedVehicleIrrApp.h"
 
 // ...and specify whether the demo should actually use Irrlicht
 #define USE_IRRLICHT

--- a/src/demos/vehicle/demo_TractorTrailer/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TractorTrailer/CMakeLists.txt
@@ -44,5 +44,6 @@ TARGET_LINK_LIBRARIES(${DEMO}
                       ChronoEngine
                       ChronoEngine_irrlicht
                       ChronoEngine_vehicle
+                      ChronoEngine_irrVehicle
                       ChronoModels_vehicle)
 INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})

--- a/src/demos/vehicle/demo_TractorTrailer/demo_VEH_TractorTrailer.cpp
+++ b/src/demos/vehicle/demo_TractorTrailer/demo_VEH_TractorTrailer.cpp
@@ -37,8 +37,8 @@
 #include "chrono_models/vehicle/generic/Generic_RigidTire.h"
 #include "chrono_models/vehicle/generic/Generic_FuncDriver.h"
 
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 #include "subsystems/TT_Tractor.h"
 #include "subsystems/TT_Trailer.h"

--- a/src/demos/vehicle/demo_WheeledGeneric/CMakeLists.txt
+++ b/src/demos/vehicle/demo_WheeledGeneric/CMakeLists.txt
@@ -33,5 +33,6 @@ TARGET_LINK_LIBRARIES(${DEMO}
                       ChronoEngine
                       ChronoEngine_irrlicht
                       ChronoEngine_vehicle
+                      ChronoEngine_irrVehicle
                       ChronoModels_vehicle)
 INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})

--- a/src/demos/vehicle/demo_WheeledGeneric/demo_VEH_WheeledGeneric.cpp
+++ b/src/demos/vehicle/demo_WheeledGeneric/demo_VEH_WheeledGeneric.cpp
@@ -41,8 +41,8 @@
 // If Irrlicht support is available...
 #ifdef CHRONO_IRRLICHT
 // ...include additional headers
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 // ...and specify whether the demo should actually use Irrlicht
 #define USE_IRRLICHT

--- a/src/demos/vehicle/demo_WheeledJSON/CMakeLists.txt
+++ b/src/demos/vehicle/demo_WheeledJSON/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(LIBRARIES
 IF(ENABLE_MODULE_IRRLICHT)
   SET(LIBRARIES_IRR
       ChronoEngine_irrlicht
+      ChronoEngine_irrVehicle
       ${CH_IRRLICHTLIB})
 ELSE()
   SET(LIBRARIES_IRR "")

--- a/src/demos/vehicle/demo_WheeledJSON/demo_VEH_WheeledJSON.cpp
+++ b/src/demos/vehicle/demo_WheeledJSON/demo_VEH_WheeledJSON.cpp
@@ -43,8 +43,8 @@
 // If Irrlicht support is available...
 #ifdef CHRONO_IRRLICHT
 // ...include additional headers
-#include "chrono_vehicle/driver/ChIrrGuiDriver.h"
-#include "chrono_vehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
+#include "chrono_irrVehicle/driver/ChIrrGuiDriver.h"
+#include "chrono_irrVehicle/wheeled_vehicle/utils/ChWheeledVehicleIrrApp.h"
 
 // ...and specify whether the demo should actually use Irrlicht
 #define USE_IRRLICHT


### PR DESCRIPTION
Having Irrlicht dependent classes in the Vehicle library seems like an unnecessary dependency for users of chrono_vehicle, especially ones who want to use official binaries.   Pulling out the Irrlich classes into their own library breaks the dependency and allows me to build/run all the demos for lightweight testing, but still use the same vehicle library in my own system without the dependencies on irrlich (and it's dependencies, which I have different versions of).

This pull request puts all irrlicht specific vehicle classes into a new library called chrono_irrVehicle and updates all demos to use the new library.