### PR TITLE
Modified contact point calculation to improve handling of (constant) …

### DIFF
--- a/src/chrono_vehicle/wheeled_vehicle/ChTire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/ChTire.cpp
@@ -96,6 +96,10 @@ void ChTire::CalculateKinematics(double time, const WheelState& state, const ChT
 // This function returns false if no contact occurs. Otherwise, it sets the
 // contact points on the disc (ptD) and on the terrain (ptT), the normal contact
 // direction, and the resulting penetration depth (a positive value).
+//
+// NOTE: uses terrain normal at disc center for approximative calculation. 
+// Hence only valid for terrains with constant slope. A completely accurate 
+// solution would require an iterative calculation of the contact point.
 // -----------------------------------------------------------------------------
 bool ChTire::disc_terrain_contact(const ChTerrain& terrain,
                                   const ChVector<>& disc_center,
@@ -111,7 +115,8 @@ bool ChTire::disc_terrain_contact(const ChTerrain& terrain,
 
     // Find the lowest point on the disc. There is no contact if the disc is
     // (almost) horizontal.
-    ChVector<> dir1 = Vcross(disc_normal, ChVector<>(0, 0, 1));
+	ChVector<> nhelp = terrain.GetNormal(disc_center.x(), disc_center.y());
+    ChVector<> dir1 = Vcross(disc_normal, nhelp); 
     double sinTilt2 = dir1.Length2();
 
     if (sinTilt2 < 1e-3)


### PR DESCRIPTION
…terrain slopes. In the current implementation, the calculated contact point always lies vertically below the wheel disc center (seen from the global reference frame). For a wheeled vehicle dirving on a slope, this will lead to an incorrect propel torque being induced by the tire model normal force (which is always pointing in the direction of the local z-axis). As a result, the vehicle may accelerate when driving uphill and decelerate when driving downhill. The proposed fix eliminates this problem (at least for terrains with constant slope) by enforcing that both the wheel center and the calculated contact point will lie on the z-axis of the local tire model reference frame (which is assumed to point in the direction of the terrain normal).
![chtirecontactpoint](https://user-images.githubusercontent.com/46994475/51692362-0f932800-1ffd-11e9-981c-3d521535d35c.png)
