### PR TITLE
mingw+windows patches

### DIFF
--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -1145,6 +1145,10 @@ set(ChronoEngine_FILES
 # Add the ChronoEngine library to the project
 add_library(ChronoEngine SHARED ${ChronoEngine_FILES})
 
+if(WIN32)
+  target_link_libraries(ChronoEngine winmm)
+endif()
+
 if (UNIX)
   target_link_libraries(ChronoEngine pthread)
 endif()

--- a/src/chrono/collision/convexdecomposition/HACDv2/dgTypes.h
+++ b/src/chrono/collision/convexdecomposition/HACDv2/dgTypes.h
@@ -51,7 +51,7 @@ class dgBigVector;
 
 #define dgApi __cdecl 	
 //#ifdef _DEBUG
-#ifdef _WINDOWS
+#if defined(_WINDOWS) && !defined(__GNUC__)
 #define dgCheckFloat(x) (_finite(x) && !_isnan(x))
 #else
 #define dgCheckFloat(x) (isfinite(x) && !isnan(x))

--- a/src/chrono/core/ChCoordsys.cpp
+++ b/src/chrono/core/ChCoordsys.cpp
@@ -14,8 +14,8 @@
 
 namespace chrono {
 
-ChApi const ChCoordsys<double> CSYSNULL(VNULL, QNULL);
-ChApi const ChCoordsys<double> CSYSNORM(VNULL, QUNIT);
+const ChCoordsys<double> CSYSNULL(VNULL, QNULL);
+const ChCoordsys<double> CSYSNORM(VNULL, QUNIT);
 
 Coordsys Force2Dcsys(const Coordsys& cs) {
     Coordsys res;

--- a/src/chrono/core/ChQuaternion.cpp
+++ b/src/chrono/core/ChQuaternion.cpp
@@ -19,19 +19,19 @@
 
 namespace chrono {
 
-ChApi const ChQuaternion<double> QNULL(0., 0., 0., 0.);
-ChApi const ChQuaternion<double> QUNIT(1., 0., 0., 0.);
+const ChQuaternion<double> QNULL(0., 0., 0., 0.);
+const ChQuaternion<double> QUNIT(1., 0., 0., 0.);
 
-ChApi const ChQuaternion<double> Q_ROTATE_Y_TO_X(CH_C_SQRT_1_2,				0,				0, -CH_C_SQRT_1_2 );
-ChApi const ChQuaternion<double> Q_ROTATE_Y_TO_Z(CH_C_SQRT_1_2, CH_C_SQRT_1_2,				0,				0 );
-ChApi const ChQuaternion<double> Q_ROTATE_X_TO_Y(CH_C_SQRT_1_2,				0,				0,	CH_C_SQRT_1_2 );
-ChApi const ChQuaternion<double> Q_ROTATE_X_TO_Z(CH_C_SQRT_1_2,				0, -CH_C_SQRT_1_2,				0 );
-ChApi const ChQuaternion<double> Q_ROTATE_Z_TO_Y(CH_C_SQRT_1_2,-CH_C_SQRT_1_2,				0,				0 );
-ChApi const ChQuaternion<double> Q_ROTATE_Z_TO_X(CH_C_SQRT_1_2,				0,  CH_C_SQRT_1_2,				0 );
+const ChQuaternion<double> Q_ROTATE_Y_TO_X(CH_C_SQRT_1_2,				0,				0, -CH_C_SQRT_1_2 );
+const ChQuaternion<double> Q_ROTATE_Y_TO_Z(CH_C_SQRT_1_2, CH_C_SQRT_1_2,				0,				0 );
+const ChQuaternion<double> Q_ROTATE_X_TO_Y(CH_C_SQRT_1_2,				0,				0,	CH_C_SQRT_1_2 );
+const ChQuaternion<double> Q_ROTATE_X_TO_Z(CH_C_SQRT_1_2,				0, -CH_C_SQRT_1_2,				0 );
+const ChQuaternion<double> Q_ROTATE_Z_TO_Y(CH_C_SQRT_1_2,-CH_C_SQRT_1_2,				0,				0 );
+const ChQuaternion<double> Q_ROTATE_Z_TO_X(CH_C_SQRT_1_2,				0,  CH_C_SQRT_1_2,				0 );
 
-ChApi const ChQuaternion<double> Q_FLIP_AROUND_X(0., 1., 0., 0.);
-ChApi const ChQuaternion<double> Q_FLIP_AROUND_Y(0., 0., 1., 0.);
-ChApi const ChQuaternion<double> Q_FLIP_AROUND_Z(0., 0., 0., 1.);
+const ChQuaternion<double> Q_FLIP_AROUND_X(0., 1., 0., 0.);
+const ChQuaternion<double> Q_FLIP_AROUND_Y(0., 0., 1., 0.);
+const ChQuaternion<double> Q_FLIP_AROUND_Z(0., 0., 0., 1.);
 
 // -----------------------------------------------------------------------------
 // QUATERNION OPERATIONS

--- a/src/chrono/core/ChVector.cpp
+++ b/src/chrono/core/ChVector.cpp
@@ -16,9 +16,9 @@
 
 namespace chrono {
 
-ChApi const ChVector<double> VNULL(0., 0., 0.);
-ChApi const ChVector<double> VECT_X(1., 0., 0.);
-ChApi const ChVector<double> VECT_Y(0., 1., 0.);
-ChApi const ChVector<double> VECT_Z(0., 0., 1.);
+const ChVector<double> VNULL(0., 0., 0.);
+const ChVector<double> VECT_X(1., 0., 0.);
+const ChVector<double> VECT_Y(0., 1., 0.);
+const ChVector<double> VECT_Z(0., 0., 1.);
 
 }  // end namespace chrono

--- a/src/chrono/parallel/ChThreadsSync.h
+++ b/src/chrono/parallel/ChThreadsSync.h
@@ -33,7 +33,7 @@ Modified by: Alessandro Tasora
 #ifdef _XBOX
 #include <Xtl.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #include <intrin.h>
 #endif
 

--- a/src/chrono/parallel/ChThreadsWIN32.cpp
+++ b/src/chrono/parallel/ChThreadsWIN32.cpp
@@ -13,7 +13,7 @@
 #if defined _WIN32
 
 #include <cstdio>
-#include <Windows.h>
+#include <windows.h>
 
 #include "chrono/parallel/ChThreadsWIN32.h"
 #include "chrono/core/ChLog.h"

--- a/src/chrono/physics/ChGlobal.cpp
+++ b/src/chrono/physics/ChGlobal.cpp
@@ -17,7 +17,7 @@
 #include "chrono_thirdparty/filesystem/path.h"
 
 #if defined(_WIN32) || defined(_WIN64)
-#include "Windows.h"
+#include "windows.h"
 #endif
 
 #if defined(__APPLE__)


### PR DESCRIPTION
Please consider merging the following set of patches that fix some compilation errors that cannot be noticed when compiling for windows with VisualStudio.

I found them while cross-compiling from linux with mingw-gcc 8.3.