### PR TITLE
feature/extra-ci

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -1,17 +1,10 @@
-### Project CHRONO _feature/multiarch_
+### Project CHRONO Platform Testing
 
-This branch introduces changes which aim to make Chrono behave more predictably when building for
-a greater variety of platforms and architectures. 
+This document tracks changes which aim to make Chrono behave more predictably when building for a greater variety of platforms and architectures. 
 
-Chrono with _feature/multiarch_ includes existing support for 64-bit x86 CPUs and has also been known to
-build on AArch64 and POWER8/9 under Linux.
+Chrono currently includes existing support for 64-bit x86 CPUs and has also been known to build on AArch64 and POWER8/9 under Linux.
 
-##### Additional Features
-- Some x86 compilers which are not able to build Chrono releases or the develop branch may work with _feature/multiarch_
-- AArch64 experimental support includes some integration of NEON vectorization instructions
-- POWER 8/9 experimental support has been tested for GCC 7 or newer and XLC 16.1 and newer
-
-##### Previously Tested Architectures and Compilers
+##### Previously Tested Architectures and Compilers (Windows / Linux)
 - x86_64 / GCC 6 and newer
 - x86_64 / Clang 6.0.0 and newer
 - x86_64 / MSVC 14 and newer
@@ -20,12 +13,11 @@ build on AArch64 and POWER8/9 under Linux.
 - POWER / XLC 16.1._x_
 
 
+##### Additional Platforms
+- FreeBSD 12.0 / LLVM 6
+
 
 ##### **DISCLAIMER**
 
-Chrono is primarily an x86-based software. While _feature/multiarch_ may enable the use of Chrono
-on a wider variety of platforms, these additional platforms are not officially supported by the developers. 
-To be absolutely clear; the developers will not provide online support for these platforms.
-Any additional platforms or architectures mentioned by the developers in any documentation have only been through a
-minimum of testing and come with absolutely no guarantees as to their performance or validity. 
-_Caveat emptor_, your mileage may vary, etc.
+Chrono is primarily an x86-based software. While the configurations listed above may enable the use of Chrono on a wider variety of platforms, these additional platforms are not officially supported by the developers. To be absolutely clear; the developers will not provide online support for these platforms.
+Any additional platforms or architectures mentioned by the developers in any documentation have only been through a minimum of testing and come with absolutely no guarantees as to their performance or validity. _Caveat emptor_, your mileage may vary, etc.

--- a/README.md
+++ b/README.md
@@ -71,5 +71,7 @@ Project Chrono represents a community effort aimed at producing a physics-based 
 - Makefile system based on CMake (cross-platform, on Windows 32/64 bit, Linux, OSX).
 
 ## CI/CD Status
+| Branch | Status |
+| ------ | ------ |
+| develop | [![pipeline status](https://gitlab.com/uwsbel/chrono/badges/develop/pipeline.svg)](https://gitlab.com/uwsbel/chrono/commits/develop) |
 
-#### Gitlab CI [![pipeline status](https://gitlab.com/uwsbel/chrono/badges/develop/pipeline.svg)](https://gitlab.com/uwsbel/chrono/commits/develop)

--- a/README.md
+++ b/README.md
@@ -70,4 +70,6 @@ Project Chrono represents a community effort aimed at producing a physics-based 
 - Scripting via Python.
 - Makefile system based on CMake (cross-platform, on Windows 32/64 bit, Linux, OSX).
 
+## CI/CD Status
 
+#### Gitlab CI [![pipeline status](https://gitlab.com/uwsbel/chrono/badges/develop/pipeline.svg)](https://gitlab.com/uwsbel/chrono/commits/develop)

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -96,11 +96,11 @@ linux:arch-llvm:test:
   - yum -y update && yum -y install epel-release
   - yum -y groupinstall "Development Tools"
   - yum -y install centos-release-scl
-  - yum -y install devtoolset-6
+  - yum -y install devtoolset-8
   # The normal "scl enable ..." route creates a new bash session which will 
   # cause the script to hang. We need to activate the environment in the
   # _current_ shell instead
-  - source /opt/rh/devtoolset-6/enable
+  - source /opt/rh/devtoolset-8/enable
   - yum -y install cmake3 eigen3 irrlicht-devel glew-devel glfw-devel glfw-devel libGLEW glm-devel sudo boost-devel freeglut-devel wget fish python python-devel python-pip pcre-devel openmpi openmpi-devel
   - alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 --family cmake
   # SWIG will have been mysteriously installed, we install a newer version later
@@ -124,7 +124,7 @@ linux:centos:build:
   - git submodule init
   - git submodule update
   - cd build
-  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DENABLE_MODULE_DISTRIBUTED=TRUE -DENABLE_MODULE_FSI=TRUE -DCMAKE_C_COMPILER=/opt/rh/devtoolset-6/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-6/root/usr/bin/g++ -DCUDA_HOST_COMPILER=/opt/rh/devtoolset-6/root/usr/bin/gcc
+  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DENABLE_MODULE_DISTRIBUTED=TRUE -DENABLE_MODULE_FSI=TRUE -DCMAKE_C_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/g++ -DCUDA_HOST_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc
   - make -j 8
   artifacts:
     expire_in: 30m

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -25,8 +25,8 @@ stages:
   - wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.5.tar.gz
   - tar -xf blaze-3.5.tar.gz
   - cp blaze-3.5/blaze -r /usr/local/include
-  - git submodule update
   - git submodule init
+  - git submodule update
   - mkdir -p build
 
 linux:arch-gcc:build:
@@ -238,7 +238,7 @@ windows:vs2019:deploy:
   - mkdir -p build
 
 
-freebsd:llvm:build:
+.freebsd:llvm:build:
   stage: build
   extends: .freebsd
   script:
@@ -255,7 +255,7 @@ freebsd:llvm:build:
     - build/
 
 
-freebsd:llvm:test:
+.freebsd:llvm:test:
   stage: test
   needs: ["freebsd:llvm:build"]
   extends: .freebsd

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -50,7 +50,7 @@ linux:arch-llvm:build:
   stage: build
   extends: .archlinux
   script:
-  - pacman -S llvm clang openmp
+  - pacman -S --noconfirm llvm clang openmp
   - git submodule update
   - git submodule init
   - cd build
@@ -66,7 +66,7 @@ linux:arch-llvm:test:
   stage: test
   extends: .archlinux
   script:
-  - pacman -S llvm clang openmp
+  - pacman -S --noconfirm llvm clang openmp
   - cd build
   - make test
   dependencies:

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -25,21 +25,21 @@ stages:
   - wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.5.tar.gz
   - tar -xf blaze-3.5.tar.gz
   - cp blaze-3.5/blaze -r /usr/local/include
+  - git submodule update
+  - git submodule init
   - mkdir -p build
 
 linux:arch-gcc:build:
   stage: build
   extends: .archlinux
   script:
-  - git submodule update
-  - git submodule init
   - cd build
   - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DENABLE_MODULE_DISTRIBUTED=TRUE -DENABLE_MODULE_FSI=TRUE -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DCUDA_HOST_COMPILER=/usr/bin/gcc-8 -DEIGEN3_INCLUDE_DIR=/usr/include/eigen3
   - make -j 8
   artifacts:
     expire_in: 30m
     paths:
-    - build
+    - build/
     
 
 linux:arch-gcc:test:
@@ -49,24 +49,20 @@ linux:arch-gcc:test:
   script:
   - cd build
   - make test
-  dependencies:
-  - linux:arch-gcc:build
-
+  dependencies: ["linux:arch-gcc:build"]
 
 linux:arch-llvm:build:
   stage: build
   extends: .archlinux
   script:
   - pacman -S --noconfirm llvm clang openmp
-  - git submodule update
-  - git submodule init
   - cd build
   - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DENABLE_MODULE_DISTRIBUTED=TRUE -DENABLE_MODULE_FSI=TRUE -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DCUDA_HOST_COMPILER=/usr/bin/gcc-8 -DEIGEN3_INCLUDE_DIR=/usr/include/eigen3
   - make -j 8
   artifacts:
     expire_in: 30m
     paths:
-    - build
+    - build/
 
 
 linux:arch-llvm:test:
@@ -77,8 +73,7 @@ linux:arch-llvm:test:
   - pacman -S --noconfirm llvm clang openmp
   - cd build
   - make test
-  dependencies:
-  - linux:arch-llvm:build
+  dependencies: ["linux:arch-llvm:build"]
 
 
 #----------------#
@@ -101,8 +96,14 @@ linux:arch-llvm:test:
   # cause the script to hang. We need to activate the environment in the
   # _current_ shell instead
   - source /opt/rh/devtoolset-8/enable
-  - yum -y install cmake3 eigen3 irrlicht-devel glew-devel glfw-devel glfw-devel libGLEW glm-devel sudo boost-devel freeglut-devel wget fish python python-devel python-pip pcre-devel openmpi openmpi-devel
-  - alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 --family cmake
+  - yum -y install cmake3 eigen3 irrlicht-devel glew-devel glfw-devel glfw-devel
+      libGLEW glm-devel sudo boost-devel freeglut-devel wget fish python 
+      python-devel python-pip pcre-devel openmpi openmpi-devel
+  - alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 
+      --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 
+      --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 
+      --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 
+      --family cmake
   # SWIG will have been mysteriously installed, we install a newer version later
   - yum -y remove swig
   - ldconfig
@@ -115,21 +116,30 @@ linux:arch-llvm:test:
   - wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.5.tar.gz
   - tar -xf blaze-3.5.tar.gz
   - cp blaze-3.5/blaze -r /usr/local/include
+  - git submodule init
+  - git submodule update
   - mkdir -p build
 
 linux:centos:build:
   stage: build
   extends: .centos
   script:
-  - git submodule init
-  - git submodule update
   - cd build
-  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DENABLE_MODULE_DISTRIBUTED=TRUE -DENABLE_MODULE_FSI=TRUE -DCMAKE_C_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/g++ -DCUDA_HOST_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc
+  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE 
+      -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE 
+      -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE 
+      -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE 
+      -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE 
+      -DENABLE_MODULE_DISTRIBUTED=TRUE
+      -DCMAKE_C_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc 
+      -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/g++ 
+#      -DCUDA_HOST_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc
+#      -DENABLE_MODULE_FSI=TRUE 
   - make -j 8
   artifacts:
     expire_in: 30m
     paths:
-    - build
+    - build/
 
 linux:centos:test:
   stage: test
@@ -138,8 +148,7 @@ linux:centos:test:
   script:
   - cd build
   - make test
-  dependencies:
-  - linux:centos:build
+  dependencies: ["linux:centos:build"]
 
 
 #-----------------#
@@ -150,8 +159,10 @@ linux:centos:test:
   tags:
   - windows
   before_script:
-#  - wget -UseBasicParsing https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.5.tar.gz -OutFile blaze-3.5.tar.gz
-#  - tar -xf .\blaze-3.5.tar.gz blaze-3.5/blaze
+    #  - wget -UseBasicParsing https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.5.tar.gz -OutFile blaze-3.5.tar.gz
+    #  - tar -xf .\blaze-3.5.tar.gz blaze-3.5/blaze
+  - git submodule init
+  - git submodule update
   - mkdir -Force build
 
 
@@ -160,13 +171,31 @@ windows:vs2019:build:
   extends: .windows
   script:
   - cd build
-  - cmake ../ -G "Visual Studio 16 2019" -A x64 -T v142 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DBLAZE_DIR=C:/Users/Public/Documents/blaze-3.1 -DSWIG_EXECUTABLE=C:/Users/Public/Documents/swigwin-3.0.12/swig.exe -DBOOST_ROOT=C:/Users/Public/Documents/boost_1_68_0 -DGLM_INCLUDE_DIR=C:/Users/Public/Documents/glm-0.9.9.5 -DGLEW_DLL=C:/Users/Public/Documents/glew-2.1.0/bin/Release/x64/glew32.dll -DGLEW_INCLUDE_DIR=C:/Users/Public/Documents/glew-2.1.0/include -DIRRLICHT_LIBRARY=C:/Users/Public/Documents/irrlicht-1.8.4/lib/Win64-visualStudio/Irrlicht.lib -DIRRLICHT_ROOT=C:/Users/Public/Documents/irrlicht-1.8.4 -DUSE_PARALLEL_CUDA=OFF -DGLEW_LIBRARY=C:/Users/Public/Documents/glew-2.1.0/lib/Release/x64/glew32.lib -DGLFW_DLL=C:/Users/Public/Documents/glfw-3.3/lib-vc2015/glfw3.dll -DGLFW_INCLUDE_DIR=C:/Users/Public/Documents/glfw-3.3/include/GLFW -DGLFW_LIBRARY=C:/Users/Public/Documents/glfw-3.3/lib-vc2015/glfw3dll.lib -DENABLE_MODULE_FSI=TRUE -DEIGEN3_INCLUDE_DIR=C:/Users/Public/Documents/eigen-3.3.7
+  - cmake ../ -G "Visual Studio 16 2019" -A x64 -T v142 
+    -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE 
+    -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE 
+    -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE 
+    -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE 
+    -DENABLE_MODULE_OPENGL=TRUE -DUSE_PARALLEL_CUDA=OFF -DENABLE_MODULE_FSI=TRUE 
+    -DBLAZE_DIR=C:/Users/Public/Documents/blaze-3.1 
+    -DSWIG_EXECUTABLE=C:/Users/Public/Documents/swigwin-3.0.12/swig.exe 
+    -DBOOST_ROOT=C:/Users/Public/Documents/boost_1_68_0 
+    -DGLM_INCLUDE_DIR=C:/Users/Public/Documents/glm-0.9.9.5 
+    -DGLEW_DLL=C:/Users/Public/Documents/glew-2.1.0/bin/Release/x64/glew32.dll 
+    -DGLEW_INCLUDE_DIR=C:/Users/Public/Documents/glew-2.1.0/include 
+    -DGLEW_LIBRARY=C:/Users/Public/Documents/glew-2.1.0/lib/Release/x64/glew32.lib 
+    -DGLFW_DLL=C:/Users/Public/Documents/glfw-3.3/lib-vc2015/glfw3.dll 
+    -DGLFW_INCLUDE_DIR=C:/Users/Public/Documents/glfw-3.3/include/GLFW 
+    -DGLFW_LIBRARY=C:/Users/Public/Documents/glfw-3.3/lib-vc2015/glfw3dll.lib 
+    -DIRRLICHT_LIBRARY=C:/Users/Public/Documents/irrlicht-1.8.4/lib/Win64-visualStudio/Irrlicht.lib 
+    -DIRRLICHT_ROOT=C:/Users/Public/Documents/irrlicht-1.8.4 
+    -DEIGEN3_INCLUDE_DIR=C:/Users/Public/Documents/eigen-3.3.7
   #- Invoke-Expression "& `'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\devenv.com`' Chrono.sln -Build `"Release|x64`" -log buildlog.txt"
   - '& "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" Chrono.sln -maxcpucount:8 -property:Configuration=Release'
   artifacts:
     expire_in: 30m
     paths:
-      - build
+      - build/
 
 
 windows:vs2019:test:
@@ -176,10 +205,19 @@ windows:vs2019:test:
   script:
   - cd build
   - ctest
-  dependencies:
-  - windows:vs2019:build
+  dependencies: ["windows:vs2019:build"]
 
 
-
+windows:vs2019:deploy:
+  stage: deploy
+  needs: ["windows:vs2019:test"]
+  extends: .windows
+  script:
+    - Out-Host "Build PyChrono and deploy via Anaconda..."
+    - Out-Host "**NOT YET IMPLEMENTED**"
+  environment:
+    name: pychrono-win64
+    url: https://anaconda.org/projectchrono/pychrono
+  when: manual
     
 

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -219,5 +219,47 @@ windows:vs2019:deploy:
     name: pychrono-win64
     url: https://anaconda.org/projectchrono/pychrono
   when: manual
-    
 
+
+#-----------------#
+# FreeBSD Builder #
+#-----------------#
+
+.freebsd:
+  tags:
+  - freebsd
+  before_script:
+  - uname -a
+  - wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.5.tar.gz
+  - tar -xf blaze-3.5.tar.gz
+  - cp blaze-3.5/blaze -r /usr/local/include
+  - git submodule update
+  - git submodule init
+  - mkdir -p build
+
+
+freebsd:llvm:build:
+  stage: build
+  extends: .freebsd
+  script:
+  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE 
+    -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE 
+    -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE 
+    -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE 
+    -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE 
+    -DENABLE_MODULE_DISTRIBUTED=TRUE -DEIGEN3_INCLUDE_DIR=/usr/include/eigen3
+  - make -j 8
+  artifacts:
+    expire_in: 30m
+    paths:
+    - build/
+
+
+freebsd:llvm:test:
+  stage: test
+  needs: ["freebsd:llvm:build"]
+  extends: .freebsd
+  script:
+  - cd build
+  - make test
+  dependencies: ["freebsd:llvm:build"]

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -2,6 +2,12 @@
 ## ProjectChrono Default CI Config ##
 #####################################
 
+# Build Stages (shared by each platform)
+stages:
+  - build
+  - test
+  - deploy
+
 #---------------------#
 # Arch Linux Builders #
 #---------------------#
@@ -38,6 +44,7 @@ linux:arch-gcc:build:
 
 linux:arch-gcc:test:
   stage: test
+  needs: ["linux:arch-gcc:build"]
   extends: .archlinux
   script:
   - cd build
@@ -64,6 +71,7 @@ linux:arch-llvm:build:
 
 linux:arch-llvm:test:
   stage: test
+  needs: ["linux:arch-llvm:build"]
   extends: .archlinux
   script:
   - pacman -S --noconfirm llvm clang openmp
@@ -89,7 +97,10 @@ linux:arch-llvm:test:
   - yum -y groupinstall "Development Tools"
   - yum -y install centos-release-scl
   - yum -y install devtoolset-6
-  - source scl_source enable devtoolset-6
+  # The normal "scl enable ..." route creates a new bash session which will 
+  # cause the script to hang. We need to activate the environment in the
+  # _current_ shell instead
+  - source /opt/rh/devtoolset-6/enable
   - yum -y install cmake3 eigen3 irrlicht-devel glew-devel glfw-devel glfw-devel libGLEW glm-devel sudo boost-devel freeglut-devel wget fish python python-devel python-pip pcre-devel openmpi openmpi-devel
   - alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 --family cmake
   # SWIG will have been mysteriously installed, we install a newer version later
@@ -122,6 +133,7 @@ linux:centos:build:
 
 linux:centos:test:
   stage: test
+  needs: ["linux:centos:build"]
   extends: .centos
   script:
   - cd build
@@ -143,7 +155,7 @@ linux:centos:test:
   - mkdir -Force build
 
 
-windows:build:
+windows:vs2019:build:
   stage: build
   extends: .windows
   script:
@@ -157,14 +169,15 @@ windows:build:
       - build
 
 
-windows:test:
+windows:vs2019:test:
   stage: test
+  needs: ["windows:vs2019:build"]
   extends: .windows
   script:
   - cd build
   - ctest
   dependencies:
-  - windows:build
+  - windows:vs2019:build
 
 
 

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -2,11 +2,11 @@
 ## ProjectChrono Default CI Config ##
 #####################################
 
-#---------------#
-# Linux Builder #
-#---------------#
+#---------------------#
+# Arch Linux Builders #
+#---------------------#
 
-.linux:
+.archlinux:
   tags:
   - linux
   image: 
@@ -21,29 +21,113 @@
   - cp blaze-3.5/blaze -r /usr/local/include
   - mkdir -p build
 
-linux:build:
+linux:arch-gcc:build:
   stage: build
-  extends: .linux
+  extends: .archlinux
   script:
   - git submodule update
   - git submodule init
   - cd build
-  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DCUDA_HOST_COMPILER=/usr/bin/gcc
+  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DENABLE_MODULE_DISTRIBUTED=TRUE -DENABLE_MODULE_FSI=TRUE -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DCUDA_HOST_COMPILER=/usr/bin/gcc-8 -DEIGEN3_INCLUDE_DIR=/usr/include/eigen3
   - make -j 8
   artifacts:
     expire_in: 30m
     paths:
-      - build
+    - build
     
 
-linux:test:
+linux:arch-gcc:test:
   stage: test
-  extends: .linux
+  extends: .archlinux
   script:
   - cd build
   - make test
   dependencies:
-  - linux:build
+  - linux:arch-gcc:build
+
+
+linux:arch-llvm:build:
+  stage: build
+  extends: .archlinux
+  script:
+  - pacman -S llvm clang openmp
+  - git submodule update
+  - git submodule init
+  - cd build
+  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DENABLE_MODULE_DISTRIBUTED=TRUE -DENABLE_MODULE_FSI=TRUE -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DCUDA_HOST_COMPILER=/usr/bin/gcc-8 -DEIGEN3_INCLUDE_DIR=/usr/include/eigen3
+  - make -j 8
+  artifacts:
+    expire_in: 30m
+    paths:
+    - build
+
+
+linux:arch-llvm:test:
+  stage: test
+  extends: .archlinux
+  script:
+  - pacman -S llvm clang openmp
+  - cd build
+  - make test
+  dependencies:
+  - linux:arch-llvm:build
+
+
+#----------------#
+# CentOS Builder #
+#----------------#
+
+.centos:
+  tags:
+  - linux
+  image:
+    name: nvidia/cuda:10.0-devel-centos7
+    entrypoint: ["/usr/bin/bash", "-c"]
+  before_script:
+  - uname -a
+  - yum -y update && yum -y install epel-release
+  - yum -y groupinstall "Development Tools"
+  - yum -y install centos-release-scl
+  - yum -y install devtoolset-6
+  - source scl_source enable devtoolset-6
+  - yum -y install cmake3 eigen3 irrlicht-devel glew-devel glfw-devel glfw-devel libGLEW glm-devel sudo boost-devel freeglut-devel wget fish python python-devel python-pip pcre-devel openmpi openmpi-devel
+  - alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 --family cmake
+  # SWIG will have been mysteriously installed, we install a newer version later
+  - yum -y remove swig
+  - ldconfig
+  - wget https://sourceforge.net/projects/swig/files/swig/swig-3.0.12/swig-3.0.12.tar.gz
+  - tar -xf swig-3.0.12.tar.gz
+  - cd swig-3.0.12
+  - ./configure && make && make install
+  - ldconfig
+  - cd ../
+  - wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.5.tar.gz
+  - tar -xf blaze-3.5.tar.gz
+  - cp blaze-3.5/blaze -r /usr/local/include
+  - mkdir -p build
+
+linux:centos:build:
+  stage: build
+  extends: .centos
+  script:
+  - git submodule init
+  - git submodule update
+  - cd build
+  - cmake ../ -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=TRUE -DBUILD_BENCHMARKING=TRUE -DENABLE_MODULE_POSTPROCESS=TRUE -DENABLE_MODULE_PYTHON=TRUE -DENABLE_MODULE_COSIMULATION=FALSE -DENABLE_MODULE_IRRLICHT=TRUE -DENABLE_MODULE_VEHICLE=TRUE -DENABLE_MODULE_PARALLEL=TRUE -DENABLE_MODULE_OPENGL=TRUE -DENABLE_MODULE_DISTRIBUTED=TRUE -DENABLE_MODULE_FSI=TRUE -DCMAKE_C_COMPILER=/opt/rh/devtoolset-6/root/usr/bin/gcc -DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-6/root/usr/bin/g++ -DCUDA_HOST_COMPILER=/opt/rh/devtoolset-6/root/usr/bin/gcc
+  - make -j 8
+  artifacts:
+    expire_in: 30m
+    paths:
+    - build
+
+linux:centos:test:
+  stage: test
+  extends: .centos
+  script:
+  - cd build
+  - make test
+  dependencies:
+  - linux:centos:build
 
 
 #-----------------#


### PR DESCRIPTION
Adds more CI testing through a mirror repository on [GitLab](https://gitlab.com/uwsbel/chrono/pipelines).

This will also provide a reasonable alternative to Buildbot for builds on outdated or otherwise unsupported platforms since it handles image deployment natively within the runner. For the time being, Buildbot will still handle metrics builds since I haven't implemented that yet.

Developers who are working on feature branches can merge "contrib/.gitlab-ci.yml" or cherry-pick the PR commit to have their branches tested via GitLab CI.