### PR TITLE
Fix demo_WheeledGeneric when Irrlicht is not available

### DIFF
--- a/src/chrono_vehicle/terrain/GranularTerrain.h
+++ b/src/chrono_vehicle/terrain/GranularTerrain.h
@@ -186,7 +186,7 @@ class CH_VEHICLE_API GranularTerrain : public ChTerrain {
     unsigned int GetNumParticles() const { return m_num_particles; }
 
     /// Get the terrain height at the specified (x,y) location.
-    /// This function returns the heighest point over all granular particles.
+    /// This function returns the highest point over all granular particles.
     virtual double GetHeight(double x, double y) const override;
 
     /// Get the terrain normal at the specified (x,y) location.

--- a/src/demos/vehicle/demo_ArticulatedVehicle/CMakeLists.txt
+++ b/src/demos/vehicle/demo_ArticulatedVehicle/CMakeLists.txt
@@ -1,5 +1,6 @@
 #=============================================================================
 # CMake configuration file for the ARTICULATED_VEHICLE demo.
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_CRGTerrain/CMakeLists.txt
+++ b/src/demos/vehicle/demo_CRGTerrain/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the CRGTerrain demos.
-# These example programs requires Irrlicht run-time visualization
+# These example programs require Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT OR NOT HAVE_OPENCRG)

--- a/src/demos/vehicle/demo_CityBus/CMakeLists.txt
+++ b/src/demos/vehicle/demo_CityBus/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the CITYBUS demos.
-# These example programs requires Irrlicht run-time visualization
+# These example programs require Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_DeformableSoil/CMakeLists.txt
+++ b/src/demos/vehicle/demo_DeformableSoil/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the DEFORMABLE_SOIL demo.
-# This example program works only with Irrlicht run-time visualization
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_DeformableSoilAndTire/CMakeLists.txt
+++ b/src/demos/vehicle/demo_DeformableSoilAndTire/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the DEFORMABLE_SOIL demo.
-# This example program works only with Irrlicht run-time visualization
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_GranularTerrain/CMakeLists.txt
+++ b/src/demos/vehicle/demo_GranularTerrain/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 # CMake configuration file for the GRANULAR_TERRAIN demo.
 # This example program requires Chrono:Parallel and the OpenGL module for
-# run-time visualization
+# run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_OPENGL OR NOT ENABLE_MODULE_PARALLEL)

--- a/src/demos/vehicle/demo_HMMWV/CMakeLists.txt
+++ b/src/demos/vehicle/demo_HMMWV/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the HMMWV demos.
-# These example programs requires Irrlicht run-time visualization
+# These example programs require Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_HMMWV9/CMakeLists.txt
+++ b/src/demos/vehicle/demo_HMMWV9/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the HMMWV_9BODY demo.
-# This example program requires Irrlicht run-time visualization
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_ISO2631/CMakeLists.txt
+++ b/src/demos/vehicle/demo_ISO2631/CMakeLists.txt
@@ -1,10 +1,7 @@
 #=============================================================================
 # CMake configuration file for the ISO2631 demos.
+# These example programs work with and without Irrlicht run-time visualization.
 #=============================================================================
-
-IF(NOT ENABLE_MODULE_IRRLICHT)
-    RETURN()
-ENDIF()
 
 #--------------------------------------------------------------
 # List all ISO2631 demos
@@ -22,7 +19,27 @@ IF(ENABLE_MODULE_IRRLICHT)
 ENDIF()
 
 #--------------------------------------------------------------
+# List of all required libraries
+
+SET(LIBRARIES
+    ChronoEngine
+    ChronoEngine_vehicle
+    ChronoModels_vehicle)
+
+IF(ENABLE_MODULE_IRRLICHT)
+    SET(LIBRARIES_IRR ChronoEngine_irrlicht)
+ELSE()
+    SET(LIBRARIES_IRR "")
+ENDIF()
+
+#--------------------------------------------------------------
 # Create the executables
+
+if(ENABLE_MODULE_IRRLICHT)
+  set(MY_CXX_FLAGS "${CH_CXX_FLAGS} ${CH_IRRLICHT_CXX_FLAGS}")
+else()
+  set(MY_CXX_FLAGS "${CH_CXX_FLAGS}")
+endif()
 
 FOREACH(DEMO ${DEMOS})
 
@@ -31,13 +48,9 @@ FOREACH(DEMO ${DEMOS})
     ADD_EXECUTABLE(${DEMO} ${DEMO}.cpp)
     SOURCE_GROUP("" FILES ${DEMO}.cpp)
     SET_TARGET_PROPERTIES(${DEMO} PROPERTIES 
-                          COMPILE_FLAGS "${CH_CXX_FLAGS} ${CH_IRRLICHT_CXX_FLAGS}"
+                          COMPILE_FLAGS "${MY_CXX_FLAGS}"
                           LINK_FLAGS "${CH_LINKERFLAG_EXE}")
-    TARGET_LINK_LIBRARIES(${DEMO}
-                          ChronoEngine
-                          ChronoEngine_irrlicht
-                          ChronoEngine_vehicle
-                          ChronoModels_vehicle)
+    TARGET_LINK_LIBRARIES(${DEMO} ${LIBRARIES} ${LIBRARIES_IRR})
     INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})
 
 ENDFOREACH()

--- a/src/demos/vehicle/demo_ISO2631/demo_VEH_Ride.cpp
+++ b/src/demos/vehicle/demo_ISO2631/demo_VEH_Ride.cpp
@@ -300,7 +300,7 @@ int main(int argc, char* argv[]) {
         // Update modules (process inputs from other modules)
         double time = vehicle.GetSystem()->GetChTime();
         driver.Synchronize(time);
-        vehicle.Synchronize(time, driver_inputs);
+        vehicle.Synchronize(time, driver_inputs, terrain);
         terrain.Synchronize(time);
 
         // Advance simulation for one timestep for all modules

--- a/src/demos/vehicle/demo_M113/CMakeLists.txt
+++ b/src/demos/vehicle/demo_M113/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the M113 demos.
-# These example programs requires Irrlicht run-time visualization
+# These example programs require Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_M113_Band/CMakeLists.txt
+++ b/src/demos/vehicle/demo_M113_Band/CMakeLists.txt
@@ -1,13 +1,8 @@
 #=============================================================================
 # CMake configuration file for the M113 with continuous band track demos.
-# These example programs requires Irrlicht run-time visualization and the
-# MKL or MUMPS Chrono modules.
+# This example program works with and without Irrlicht run-time visualization
+# and requires the MKL or MUMPS Chrono modules.
 #=============================================================================
-
-# Irrlicht required
-if(NOT ENABLE_MODULE_IRRLICHT)
-    return()
-endif()
 
 # MUMPS or MKL required
 if (NOT ENABLE_MODULE_MKL AND NOT ENABLE_MODULE_MUMPS)

--- a/src/demos/vehicle/demo_M113_Parallel/CMakeLists.txt
+++ b/src/demos/vehicle/demo_M113_Parallel/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 # CMake configuration file for the M113_PARALLEL demo.
 # This example program requires Chrono:Parallel and the OpenGL module for
-# run-time visualization
+# run-time visualization.
 #=============================================================================
 
 #--------------------------------------------------------------

--- a/src/demos/vehicle/demo_RigidTerrain/CMakeLists.txt
+++ b/src/demos/vehicle/demo_RigidTerrain/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the RigidTerrain demos.
-# These example programs requires Irrlicht run-time visualization
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_Sedan/CMakeLists.txt
+++ b/src/demos/vehicle/demo_Sedan/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the Sedan demos.
-# These example programs requires Irrlicht run-time visualization
+# These example programs require Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_SteeringController/CMakeLists.txt
+++ b/src/demos/vehicle/demo_SteeringController/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the STEERING_CONTROLLER demo.
-# This example program works only with Irrlicht run-time visualization
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_SuspensionTest/CMakeLists.txt
+++ b/src/demos/vehicle/demo_SuspensionTest/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the SUSPENSION_TEST_RIG demo.
-# This example program works only with Irrlicht run-time visualization
+# These example programs require Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_TireTest/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TireTest/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the TIRE_TEST_RIG demo.
-# This example program works only with Irrlicht run-time visualization
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 if(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_TrackTestRig/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TrackTestRig/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the SUSPENSION_TEST_RIG demo.
-# This example program works only with Irrlicht run-time visualization
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_TrackTestRig_Band/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TrackTestRig_Band/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 # CMake configuration file for the test rig with continuous band track demo.
-# This example program works only with Irrlicht run-time visualization and 
-# requires the MKL or MUMPS Chrono modules.
+# This example program requires Irrlicht run-time visualization and the
+# MKL or MUMPS Chrono modules.
 #=============================================================================
 
 # Irrlicht required

--- a/src/demos/vehicle/demo_TrackedJSON/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TrackedJSON/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 # CMake configuration file for the VEHICLE demo - an example program for using
 # a tracked vehicle model specified entirely through JSON specification files.
-# This example program works with and without Irrlicht run-time visualization
+# This example program works with and without Irrlicht run-time visualization.
 #=============================================================================
 
 #--------------------------------------------------------------

--- a/src/demos/vehicle/demo_TrackedJSON_Band/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TrackedJSON_Band/CMakeLists.txt
@@ -2,14 +2,9 @@
 # CMake configuration file for the VEHICLE demo - example programs for using
 # a tracked vehicle model with continuous-band track, specified entirely
 # through JSON specification files.
-# These example programs requires Irrlicht run-time visualization and the
-# MKL or MUMPS Chrono modules.
+# This example program works with and without Irrlicht run-time visualization
+# and requires the MKL or MUMPS Chrono modules.
 #=============================================================================
-
-# Irrlicht required
-if(NOT ENABLE_MODULE_IRRLICHT)
-    return()
-endif()
 
 # MUMPS or MKL required
 if (NOT ENABLE_MODULE_MKL AND NOT ENABLE_MODULE_MUMPS)

--- a/src/demos/vehicle/demo_TractorTrailer/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TractorTrailer/CMakeLists.txt
@@ -1,5 +1,6 @@
 #=============================================================================
 # CMake configuration file for the TRACTOR_TRAILER demo.
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_TwoCars/CMakeLists.txt
+++ b/src/demos/vehicle/demo_TwoCars/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the TwoCars demo.
-# This example program requires Irrlicht run-time visualization
+# This example program requires Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_UAZ/CMakeLists.txt
+++ b/src/demos/vehicle/demo_UAZ/CMakeLists.txt
@@ -1,6 +1,6 @@
 #=============================================================================
 # CMake configuration file for the UAZBUS demos.
-# These example programs requires Irrlicht run-time visualization
+# These example programs require Irrlicht run-time visualization.
 #=============================================================================
 
 IF(NOT ENABLE_MODULE_IRRLICHT)

--- a/src/demos/vehicle/demo_WheeledGeneric/CMakeLists.txt
+++ b/src/demos/vehicle/demo_WheeledGeneric/CMakeLists.txt
@@ -1,11 +1,7 @@
 #=============================================================================
 # CMake configuration file for the GENERIC_VEHICLE demo.
-# This example program works with and without Irrlicht run-time visualization
+# This example program works with and without Irrlicht run-time visualization.
 #=============================================================================
-
-IF(NOT ENABLE_MODULE_IRRLICHT)
-    RETURN()
-ENDIF()
 
 #--------------------------------------------------------------
 # List all model files for this demo
@@ -13,25 +9,45 @@ ENDIF()
 SET(DEMO
     demo_VEH_WheeledGeneric
 )
+
 SOURCE_GROUP("" FILES ${DEMO}.cpp)
 
 #--------------------------------------------------------------
 # Additional include directories
 
-INCLUDE_DIRECTORIES(${CH_IRRLICHTINC})
+IF(ENABLE_MODULE_IRRLICHT)
+    INCLUDE_DIRECTORIES(${CH_IRRLICHTINC})
+ENDIF()
+
+#--------------------------------------------------------------
+# List of all required libraries
+
+SET(LIBRARIES
+    ChronoEngine
+    ChronoEngine_vehicle
+    ChronoModels_vehicle)
+
+IF(ENABLE_MODULE_IRRLICHT)
+    SET(LIBRARIES_IRR ChronoEngine_irrlicht)
+ELSE()
+    SET(LIBRARIES_IRR "")
+ENDIF()
 
 #--------------------------------------------------------------
 # Create the executable
 
 MESSAGE(STATUS "...add ${DEMO}")
 
+if(ENABLE_MODULE_IRRLICHT)
+  set(MY_CXX_FLAGS "${CH_CXX_FLAGS} ${CH_IRRLICHT_CXX_FLAGS}")
+else()
+  set(MY_CXX_FLAGS "${CH_CXX_FLAGS}")
+endif()
+
 ADD_EXECUTABLE(${DEMO} ${DEMO}.cpp)
 SET_TARGET_PROPERTIES(${DEMO} PROPERTIES 
-                      COMPILE_FLAGS "${CH_CXX_FLAGS} ${CH_IRRLICHT_CXX_FLAGS}"
+                      COMPILE_FLAGS "${MY_CXX_FLAGS}"
                       LINK_FLAGS "${LINKERFLAG_EXE}")
-TARGET_LINK_LIBRARIES(${DEMO}
-                      ChronoEngine
-                      ChronoEngine_irrlicht
-                      ChronoEngine_vehicle
-                      ChronoModels_vehicle)
+TARGET_LINK_LIBRARIES(${DEMO} ${LIBRARIES} ${LIBRARIES_IRR})
 INSTALL(TARGETS ${DEMO} DESTINATION ${CH_INSTALL_DEMO})
+

--- a/src/demos/vehicle/demo_WheeledGeneric/demo_VEH_WheeledGeneric.cpp
+++ b/src/demos/vehicle/demo_WheeledGeneric/demo_VEH_WheeledGeneric.cpp
@@ -50,7 +50,9 @@
 //#define DEBUG_LOG
 
 using namespace chrono;
+#ifdef USE_IRRLICHT
 using namespace chrono::irrlicht;
+#endif
 using namespace chrono::vehicle;
 using namespace chrono::vehicle::generic;
 

--- a/src/demos/vehicle/demo_WheeledJSON/CMakeLists.txt
+++ b/src/demos/vehicle/demo_WheeledJSON/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 # CMake configuration file for the VEHICLE demo - an example program for using
 # a wheeled vehicle model specified entirely through JSON specification files.
-# This example program works with and without Irrlicht run-time visualization
+# This example program works with and without Irrlicht run-time visualization.
 #=============================================================================
 
 #--------------------------------------------------------------


### PR DESCRIPTION
There was a reference to Irrlicht that was not `#ifdef`'d. I also `#ifdef`d some of the visualization configuration to better show what is not needed when visualization is unused.