### PR TITLE
Provide more access to ANCF shell elements strain and stress vectors

### DIFF
--- a/src/chrono/fea/ChElementBase.h
+++ b/src/chrono/fea/ChElementBase.h
@@ -27,6 +27,11 @@ namespace fea {
 /// @addtogroup fea_elements
 /// @{
 
+struct ChStrainStress3D {
+    ChVectorN<double, 6> strain;
+    ChVectorN<double, 6> stress;
+};
+
 /// Base class for all finite elements, that can be used in the ChMesh physics item.
 class ChApi ChElementBase {
   public:

--- a/src/chrono/fea/ChElementShellANCF.h
+++ b/src/chrono/fea/ChElementShellANCF.h
@@ -176,10 +176,9 @@ class ChApi ChElementShellANCF : public ChElementShell, public ChLoadableUV, pub
     /// it stores only the four values in a 1 row, 8 columns matrix!
     void ShapeFunctionsDerivativeZ(ShapeVector& Nz, double x, double y, double z);
 
-	/// Return a an array with 6-component strain and stress vectors evaluated at a
+    /// Return a struct with 6-component strain and stress vectors evaluated at a
     /// given quadrature point and layer number.
-    const std::array<ChVectorN<double, 6>, 2> EvaluateSectionStrains(
-			double x, double y, double z, int layer_number);
+    ChStrainStress3D EvaluateSectionStrainStress(const ChVector<>& loc, int layer_id);
 	void EvaluateDeflection(double &defVec);
 
   public:

--- a/src/chrono/fea/ChElementShellANCF.h
+++ b/src/chrono/fea/ChElementShellANCF.h
@@ -176,9 +176,11 @@ class ChApi ChElementShellANCF : public ChElementShell, public ChLoadableUV, pub
     /// it stores only the four values in a 1 row, 8 columns matrix!
     void ShapeFunctionsDerivativeZ(ShapeVector& Nz, double x, double y, double z);
 
-    /// Return a vector with three strain components
-    ChVector<> EvaluateSectionStrains();
-    void EvaluateDeflection(double& defVec);
+	/// Return a an array with 6-component strain and stress vectors evaluated at a
+    /// given quadrature point and layer number.
+    const std::array<ChVectorN<double, 6>, 2> EvaluateSectionStrains(
+			double x, double y, double z, int layer_number);
+	void EvaluateDeflection(double &defVec);
 
   public:
     // Interface to ChElementBase base class

--- a/src/chrono/fea/ChElementShellANCF_8.cpp
+++ b/src/chrono/fea/ChElementShellANCF_8.cpp
@@ -1360,10 +1360,8 @@ void ChElementShellANCF_8::CalcCoordDerivMatrix(ChVectorN<double, 72>& dt) {
     dt(71) = ddH_dt.z();
 }
 
-// -----------------------------------------------------------------------------
-// Interface to ChElementShell base class
-// -----------------------------------------------------------------------------
-ChVector<> ChElementShellANCF_8::EvaluateSectionStrains() {
+const std::array<ChVectorN<double, 6>, 2> ChElementShellANCF_8::EvaluateSectionStrains(
+		double x, double y, double z, int layer_number) {
     // Element shape function
     ShapeVector N;
     this->ShapeFunctions(N, 0, 0, 0);
@@ -1492,7 +1490,10 @@ ChVector<> ChElementShellANCF_8::EvaluateSectionStrains() {
                 strain_til(4) * (beta(2) * beta(7) + beta(1) * beta(8)) +
                 strain_til(5) * (beta(5) * beta(7) + beta(4) * beta(8));
 
-    return ChVector<>(strain(0), strain(1), strain(2));
+    const ChMatrixNM<double, 6, 6>& E_eps = GetLayer(layer_number).GetMaterial()->Get_E_eps();
+    const ChVectorN<double, 6>& stress = E_eps * strain;
+    const std::array<ChVectorN<double, 6>, 2> strainStressOut{{strain, stress}};
+    return strainStressOut;
 }
 void ChElementShellANCF_8::EvaluateSectionDisplacement(const double u,
                                                        const double v,

--- a/src/chrono/fea/ChElementShellANCF_8.cpp
+++ b/src/chrono/fea/ChElementShellANCF_8.cpp
@@ -1360,11 +1360,10 @@ void ChElementShellANCF_8::CalcCoordDerivMatrix(ChVectorN<double, 72>& dt) {
     dt(71) = ddH_dt.z();
 }
 
-const std::array<ChVectorN<double, 6>, 2> ChElementShellANCF_8::EvaluateSectionStrains(
-		double x, double y, double z, int layer_number) {
+ChStrainStress3D ChElementShellANCF_8::EvaluateSectionStrainStress(const ChVector<>& loc, int layer_id) {
     // Element shape function
     ShapeVector N;
-    this->ShapeFunctions(N, 0, 0, 0);
+    this->ShapeFunctions(N, loc.x(), loc.y(), loc.z());
 
     // Determinant of position vector gradient matrix: Initial configuration
     ChMatrixNM<double, 1, 24> Nx;
@@ -1373,7 +1372,7 @@ const std::array<ChVectorN<double, 6>, 2> ChElementShellANCF_8::EvaluateSectionS
     ChMatrixNM<double, 1, 3> Nx_d0;
     ChMatrixNM<double, 1, 3> Ny_d0;
     ChMatrixNM<double, 1, 3> Nz_d0;
-    double detJ0 = this->Calc_detJ0(0, 0, 0, Nx, Ny, Nz, Nx_d0, Ny_d0, Nz_d0);
+    double detJ0 = this->Calc_detJ0(loc.x(), loc.y(), loc.z(), Nx, Ny, Nz, Nx_d0, Ny_d0, Nz_d0);
 
     // Transformation : Orthogonal transformation (A and J)
     ChVector<double> G1xG2;  // Cross product of first and second column of
@@ -1444,9 +1443,9 @@ const std::array<ChVectorN<double, 6>, 2> ChElementShellANCF_8::EvaluateSectionS
     beta(8) = Vdot(AA3, j03);
 
     // Transformation matrix, function of fiber angle
-    const ChMatrixNM<double, 6, 6>& T0 = this->GetLayer(0).Get_T0();
+    const ChMatrixNM<double, 6, 6>& T0 = this->GetLayer(layer_id).Get_T0();
     // Determinant of the initial position vector gradient at the element center
-    double detJ0C = this->GetLayer(0).Get_detJ0C();
+    double detJ0C = this->GetLayer(layer_id).Get_detJ0C();
 
     ChVectorN<double, 24> ddNx = m_ddT * Nx.transpose();
     ChVectorN<double, 24> ddNy = m_ddT * Ny.transpose();
@@ -1490,11 +1489,13 @@ const std::array<ChVectorN<double, 6>, 2> ChElementShellANCF_8::EvaluateSectionS
                 strain_til(4) * (beta(2) * beta(7) + beta(1) * beta(8)) +
                 strain_til(5) * (beta(5) * beta(7) + beta(4) * beta(8));
 
-    const ChMatrixNM<double, 6, 6>& E_eps = GetLayer(layer_number).GetMaterial()->Get_E_eps();
+    const ChMatrixNM<double, 6, 6>& E_eps = GetLayer(layer_id).GetMaterial()->Get_E_eps();
     const ChVectorN<double, 6>& stress = E_eps * strain;
-    const std::array<ChVectorN<double, 6>, 2> strainStressOut{{strain, stress}};
+    const ChStrainStress3D strainStressOut {strain, stress};
+
     return strainStressOut;
 }
+
 void ChElementShellANCF_8::EvaluateSectionDisplacement(const double u,
                                                        const double v,
                                                        ChVector<>& u_displ,

--- a/src/chrono/fea/ChElementShellANCF_8.h
+++ b/src/chrono/fea/ChElementShellANCF_8.h
@@ -199,10 +199,10 @@ class ChApi ChElementShellANCF_8 : public ChElementShell, public ChLoadableUV, p
     /// it stores only the four values in a 1 row, 24 columns matrix!
     void ShapeFunctionsDerivativeZ(ShapeVector& Nz, double x, double y, double z);
 
-	/// Return a an array with 6-component strain and stress vectors evaluated at a
+    /// Return a struct with 6-component strain and stress vectors evaluated at a
     /// given quadrature point and layer number.
-	const std::array<ChVectorN<double, 6>, 2> EvaluateSectionStrains(double x,
-			double y, double z, int layer_number);
+    ChStrainStress3D EvaluateSectionStrainStress(const ChVector<>& loc, int layer_id);
+
   public:
     // Interface to ChElementBase base class
     // -------------------------------------

--- a/src/chrono/fea/ChElementShellANCF_8.h
+++ b/src/chrono/fea/ChElementShellANCF_8.h
@@ -198,9 +198,11 @@ class ChApi ChElementShellANCF_8 : public ChElementShell, public ChLoadableUV, p
     /// NOTE! to avoid wasting zero and repeated elements, here
     /// it stores only the four values in a 1 row, 24 columns matrix!
     void ShapeFunctionsDerivativeZ(ShapeVector& Nz, double x, double y, double z);
-    /// Return a vector with three strain components
-    ChVector<> EvaluateSectionStrains();
 
+	/// Return a an array with 6-component strain and stress vectors evaluated at a
+    /// given quadrature point and layer number.
+	const std::array<ChVectorN<double, 6>, 2> EvaluateSectionStrains(double x,
+			double y, double z, int layer_number);
   public:
     // Interface to ChElementBase base class
     // -------------------------------------

--- a/src/chrono/fea/ChMeshExporter.cpp
+++ b/src/chrono/fea/ChMeshExporter.cpp
@@ -12,6 +12,7 @@
 // Authors: Milad Rakhsha
 // =============================================================================
 #include "chrono/fea/ChMeshExporter.h"
+
 namespace chrono {
 namespace fea {
 
@@ -180,8 +181,8 @@ void ChMeshExporter::writeFrame(std::shared_ptr<ChMesh> my_mesh, char SaveAsBuff
         if (auto element = std::dynamic_pointer_cast<ChElementCableANCF>(my_mesh->GetElement(iele)))
             element->EvaluateSectionStrain(0.0, StrainV);
         else if (auto element = std::dynamic_pointer_cast<ChElementShellANCF>(my_mesh->GetElement(iele))) {
-             const std::array<ChVectorN<double, 6>, 2> strainStressOut = element->EvaluateSectionStrains(0,0,0,0);
-             StrainV.Set(strainStressOut[0][0], strainStressOut[0][1], strainStressOut[0][3]);
+             const ChStrainStress3D strainStressOut = element->EvaluateSectionStrainStress(ChVector<double>(0,0,0),0);
+             StrainV.Set(strainStressOut.strain[0], strainStressOut.strain[1], strainStressOut.strain[3]);
         }
         StrainV += ChVector<>(1e-20);
         output << StrainV.x() << " " << StrainV.y() << " " << StrainV.z() << "\n";

--- a/src/chrono/fea/ChMeshExporter.cpp
+++ b/src/chrono/fea/ChMeshExporter.cpp
@@ -179,9 +179,10 @@ void ChMeshExporter::writeFrame(std::shared_ptr<ChMesh> my_mesh, char SaveAsBuff
     for (unsigned int iele = 0; iele < my_mesh->GetNelements(); iele++) {
         if (auto element = std::dynamic_pointer_cast<ChElementCableANCF>(my_mesh->GetElement(iele)))
             element->EvaluateSectionStrain(0.0, StrainV);
-        else if (auto element = std::dynamic_pointer_cast<ChElementShellANCF>(my_mesh->GetElement(iele)))
-            StrainV = element->EvaluateSectionStrains();
-
+        else if (auto element = std::dynamic_pointer_cast<ChElementShellANCF>(my_mesh->GetElement(iele))) {
+             const std::array<ChVectorN<double, 6>, 2> strainStressOut = element->EvaluateSectionStrains(0,0,0,0);
+             StrainV.Set(strainStressOut[0][0], strainStressOut[0][1], strainStressOut[0][3]);
+        }
         StrainV += ChVector<>(1e-20);
         output << StrainV.x() << " " << StrainV.y() << " " << StrainV.z() << "\n";
     }

--- a/src/demos/fea/demo_FEA_ancfShell_8.cpp
+++ b/src/demos/fea/demo_FEA_ancfShell_8.cpp
@@ -270,20 +270,22 @@ int main(int argc, char* argv[]) {
 			nodetip2->SetForce(ChVector<>(0, 0, -2 / 3.0));
 			nodetip3->SetForce(ChVector<>(0, 0, -2 / 3.0));
 		}
-		// std::cout << "Node tip vertical position: " << nodetip1->GetPos().z << "\n";
-		GetLog() << "Node tip vertical position: " << nodetip1->GetPos().z()
+
+        GetLog() << "Node tip vertical position: " << nodetip1->GetPos().z()
 				<< "\n";
 
 		auto element = std::dynamic_pointer_cast<ChElementShellANCF_8>(
 				my_mesh->GetElement(TotalNumElements - 1));
-		const std::array<ChVectorN<double, 6>, 2> strainStressOut =
-				element->EvaluateSectionStrains(0, 0, 0, 0);
+		const ChStrainStress3D strainStressOut =
+				element->EvaluateSectionStrainStress(ChVector<double> (0, 0, 0), 0);
 
-		std::cout << "Strain xx: " << strainStressOut.at(0)[0] << " \n";
-		std::cout << "Stress xx: " << strainStressOut.at(1)[0] << " \n";
-		std::cout << "Stress yy: " << strainStressOut.at(1)[1] << " \n";
-		std::cout << "Stress xy: " << strainStressOut.at(1)[2] << " \n";
+		std::cout << "Strain xx: " << strainStressOut.strain[0] << " \n";
+		std::cout << "Strain yy: " << strainStressOut.strain[1] << " \n";
+		std::cout << "Strain xy: " << strainStressOut.strain[2] << " \n";
 
+		std::cout << "Stress xx: " << strainStressOut.stress[0] << " \n";
+		std::cout << "Stress yy: " << strainStressOut.stress[1] << " \n";
+		std::cout << "Stress xy: " << strainStressOut.stress[2] << " \n";
 
         application.BeginScene();
         application.DrawAll();

--- a/src/demos/fea/demo_FEA_ancfShell_8.cpp
+++ b/src/demos/fea/demo_FEA_ancfShell_8.cpp
@@ -15,8 +15,8 @@
 // Demo on using 8-node ANCF shell elements. These demo reproduces the example
 // 3.3 of the paper: 'Analysis of higher-order quadrilateral plate elements based
 // on the absolute nodal coordinate formulation for three-dimensional elasticity'
-// H.C.J. Ebel, M.K.Matikainen, V.V.T. Hurskainen, A.M.Mikkola, Multibody System
-// Dynamics, To be published, 2017
+// H.C.J. Ebel, M.K.Matikainen, V.V.T. Hurskainen, A.M.Mikkola, Advances in
+// Mechanical Engineering, 2017
 //
 // =============================================================================
 
@@ -265,13 +265,26 @@ int main(int argc, char* argv[]) {
             nodetip1->SetForce(ChVector<>(0, 0, -20.0/3 * my_system.GetChTime()));
             nodetip2->SetForce(ChVector<>(0, 0, -20.0/3 * my_system.GetChTime()));
             nodetip3->SetForce(ChVector<>(0, 0, -20.0/3 * my_system.GetChTime()));
-        } else {
-            nodetip1->SetForce(ChVector<>(0, 0, -2/3.0));
-            nodetip2->SetForce(ChVector<>(0, 0, -2/3.0));
-            nodetip3->SetForce(ChVector<>(0, 0, -2/3.0));
-        }
-        // std::cout << "Node tip vertical position: " << nodetip1->GetPos().z << "\n";
-        GetLog() << "Node tip vertical position: " << nodetip1->GetPos().z() << "\n";
+		} else {
+			nodetip1->SetForce(ChVector<>(0, 0, -2 / 3.0));
+			nodetip2->SetForce(ChVector<>(0, 0, -2 / 3.0));
+			nodetip3->SetForce(ChVector<>(0, 0, -2 / 3.0));
+		}
+		// std::cout << "Node tip vertical position: " << nodetip1->GetPos().z << "\n";
+		GetLog() << "Node tip vertical position: " << nodetip1->GetPos().z()
+				<< "\n";
+
+		auto element = std::dynamic_pointer_cast<ChElementShellANCF_8>(
+				my_mesh->GetElement(TotalNumElements - 1));
+		const std::array<ChVectorN<double, 6>, 2> strainStressOut =
+				element->EvaluateSectionStrains(0, 0, 0, 0);
+
+		std::cout << "Strain xx: " << strainStressOut.at(0)[0] << " \n";
+		std::cout << "Stress xx: " << strainStressOut.at(1)[0] << " \n";
+		std::cout << "Stress yy: " << strainStressOut.at(1)[1] << " \n";
+		std::cout << "Stress xy: " << strainStressOut.at(1)[2] << " \n";
+
+
         application.BeginScene();
         application.DrawAll();
         application.DoStep();

--- a/src/tests/unit_tests/fea/utest_FEA_ANCFShell_OrtGrav.cpp
+++ b/src/tests/unit_tests/fea/utest_FEA_ANCFShell_OrtGrav.cpp
@@ -211,14 +211,6 @@ int main(int argc, char* argv[]) {
         // std::cout << "mystepper->GetNumIterations()= " << mystepper->GetNumIterations() << "\n";
         // Check vertical displacement of the shell tip
         double AbsVal = std::abs(nodetip->pos.z() - FileInputMat(it, 1));
-
-        /*auto element = std::dynamic_pointer_cast<ChElementShellANCF>(my_mesh->GetElement(TotalNumElements - 1));
-        const std::array<ChVectorN<double, 6>, 2> strainStressOut = element->EvaluateSectionStrains(0,0,0,0);
-
-        std::cout << "Strain xx: " << strainStressOut.at(0)[0] << " \n";
-        std::cout << "Stress xx: " << strainStressOut.at(1)[0] << " \n";
-        std::cout << "Stress xy: " << strainStressOut.at(1)[2] << " \n"; */
-
         if (AbsVal > precision) {
             std::cout << "Unit test check failed \n";
             return 1;

--- a/src/tests/unit_tests/fea/utest_FEA_ANCFShell_OrtGrav.cpp
+++ b/src/tests/unit_tests/fea/utest_FEA_ANCFShell_OrtGrav.cpp
@@ -211,6 +211,14 @@ int main(int argc, char* argv[]) {
         // std::cout << "mystepper->GetNumIterations()= " << mystepper->GetNumIterations() << "\n";
         // Check vertical displacement of the shell tip
         double AbsVal = std::abs(nodetip->pos.z() - FileInputMat(it, 1));
+
+        /*auto element = std::dynamic_pointer_cast<ChElementShellANCF>(my_mesh->GetElement(TotalNumElements - 1));
+        const std::array<ChVectorN<double, 6>, 2> strainStressOut = element->EvaluateSectionStrains(0,0,0,0);
+
+        std::cout << "Strain xx: " << strainStressOut.at(0)[0] << " \n";
+        std::cout << "Stress xx: " << strainStressOut.at(1)[0] << " \n";
+        std::cout << "Stress xy: " << strainStressOut.at(1)[2] << " \n"; */
+
         if (AbsVal > precision) {
             std::cout << "Unit test check failed \n";
             return 1;


### PR DESCRIPTION
The purpose of this PR is to increase strain and stress information provided by the API for the ANCF shell elements. Example of how to use this method is shown in the ANCF shell 8 demo. The user can now obtain any stress or strain component by prescribing the integration point and the layer number.