### PR TITLE
Undefine B0

### DIFF
--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
@@ -28,6 +28,8 @@
 #include "chrono_vehicle/wheeled_vehicle/ChTire.h"
 #include "chrono_vehicle/ChTerrain.h"
 
+#undef B0
+
 namespace chrono {
 namespace vehicle {
 

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
@@ -28,6 +28,10 @@
 #include "chrono_vehicle/wheeled_vehicle/ChTire.h"
 #include "chrono_vehicle/ChTerrain.h"
 
+// The following undef is required in order to compile in conda-forge
+// on OSX for Python 3.6 (somehow termios.h gets included and defines
+// B0 to be 0, leading to a syntax error).
+// see https://github.com/projectchrono/chrono/pull/222
 #undef B0
 
 namespace chrono {


### PR DESCRIPTION
This fixes a compilation error we have in conda-forge on OSX for Python 3.6 (https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=119056&view=logs&jobId=9c5ef928-2cd6-52e5-dbe6-9d173a7d951b&j=9c5ef928-2cd6-52e5-dbe6-9d173a7d951b&t=113b264d-9551-5065-da10-7eb3bdeaf1bc):
```
In file included from /usr/local/miniconda/conda-bld/pychrono_1581179344207/work/build/swig/ChModuleVehiclePYTHON_wrap.cxx:7332:
/usr/local/miniconda/conda-bld/pychrono_1581179344207/work/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h:128:16: error: expected member name or ';' after declaration specifiers
        double B0;
        ~~~~~~ ^
/Applications/Xcode_10.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/usr/include/sys/termios.h:291:12: note: expanded from macro 'B0'
#define B0      0
                ^
```