### PR TITLE
Remove legacy module_fea from FSI

### DIFF
--- a/src/chrono_fsi/CMakeLists.txt
+++ b/src/chrono_fsi/CMakeLists.txt
@@ -167,12 +167,6 @@ if(ENABLE_MODULE_PARALLEL)
   list(APPEND LIBRARIES ChronoEngine_parallel)
 endif()
 
-if(ENABLE_MODULE_FEA)
-	set(CXX_FLAGS ${CH_FEA_CXX_FLAGS})
-	include_directories(${CH_FEA_INCLUDES})
-	list(APPEND LIBRARIES ChronoEngine_fea)
-endif()
-
 if(ENABLE_MODULE_VEHICLE)
   include_directories(${CH_VEHICLE_INCLUDES})
   list(APPEND LIBRARIES ChronoEngine_vehicle)


### PR DESCRIPTION
FEA module was moved and is now included in libChronoEngine (there's no libChronoEngine_fea library)
Otherwise we have a linker error `/usr/bin/ld: cannot find -lChronoEngine_fea`