### PR TITLE
Normalize quaternion returned by chrono::Q_from_Vect_to_Vect

### DIFF
--- a/src/chrono/core/ChQuaternion.cpp
+++ b/src/chrono/core/ChQuaternion.cpp
@@ -152,7 +152,7 @@ ChQuaternion<double> Q_from_Vect_to_Vect(const ChVector<double>& fr_vect, const 
         quat.e2() = ChClamp(axis.y(), -1.0, +1.0);
         quat.e3() = ChClamp(axis.z(), -1.0, +1.0);
     }
-    return (quat);
+    return (quat.GetNormalized());
 }
 
 ChQuaternion<double> Q_from_AngZ(double angleZ) {


### PR DESCRIPTION
Currently the quaternion returned by  Q_from_Vect_to_Vect is not normalized, therefore making it not ready to rotate vectors or other quaternions. i.e.
```
std::cout << chrono::Q_from_Vect_to_Vect(chrono::VECT_Z, chrono::VECT_Y).Rotate(chrono::VECT_Z) << std::endl;
```
would output `0  2  1`.

Normalizing the returned quaternion solved the problem and made the output be `0  1  -2.22045e-16`