### PR TITLE
Elevate module-related CMake messages to warnings

### DIFF
--- a/src/chrono_distributed/CMakeLists.txt
+++ b/src/chrono_distributed/CMakeLists.txt
@@ -15,17 +15,15 @@ message(STATUS "==== Chrono Distributed module ====")
 
 # Return now if MPI is not available
 if(NOT MPI_CXX_FOUND)
-	message("Chrono::Distributed requires MPI")
+    message(WARNING "Chrono::Distributed requires MPI, but MPI not found; disabling Chrono::Distributed")
 	set(ENABLE_MODULE_DISTRIBUTED OFF CACHE BOOL "Enable the Chrono Distributed module" FORCE)
-	message(STATUS "Chrono::Distributed disabled")
 	return()
 endif()
 
 # Return now if Chrono::Parallel is not enabled
 if(NOT ENABLE_MODULE_PARALLEL)
-    message("Chrono::Distributed depends on Chrono::Parallel")
+    message(WARNING "Chrono::Distributed depends on Chrono::Parallel which is disabled; disabling Chrono::Distributed")
     set(ENABLE_MODULE_DISTRIBUTED OFF CACHE BOOL "Enable the Chrono Distributed module" FORCE)
-    message(STATUS "Chrono::Distributed disabled")
     return()
 endif()
 

--- a/src/chrono_fsi/CMakeLists.txt
+++ b/src/chrono_fsi/CMakeLists.txt
@@ -14,23 +14,18 @@ ENDIF()
 
 message(STATUS "==== Chrono FSI module ====")
 
-
-
+# Return now if Eigen version < 3.3.6
 if(EIGEN3_VERSION VERSION_LESS "3.3.6")
-  message("Chrono::FSI requires Eigen version 3.3.6 or better")
-  message("Current Eigen version: ${EIGEN3_VERSION}")
-  message("Chrono::FSI disabled")
-  set(ENABLE_MODULE_FSI OFF CACHE BOOL "Enable the Chrono FSI module" FORCE)
-  return()
+    message(WARNING "Eigen version (${EIGEN3_VERSION}) is less than the required version (3.3.6); disabling Chrono::FSI")
+    set(ENABLE_MODULE_FSI OFF CACHE BOOL "Enable the Chrono FSI module" FORCE)
+    return()
 endif()
 
 # Return now if CUDA is not available
 if(NOT CUDA_FOUND)
-  message("Chrono::FSI requires CUDA")
-  message(STATUS "Chrono::FSI disabled")
-  #mark_as_advanced(FORCE USE_FSI_DOUBLE)
-  set(ENABLE_MODULE_FSI OFF CACHE BOOL "Enable the Chrono FSI module" FORCE)
-  return()
+    message(WARNING "Chrono::FSI requires CUDA, but CUDA was not found; disabling Chrono::FSI")
+    set(ENABLE_MODULE_FSI OFF CACHE BOOL "Enable the Chrono FSI module" FORCE)
+    return()
 endif()
 
 #mark_as_advanced(CLEAR USE_FSI_DOUBLE)

--- a/src/chrono_granular/CMakeLists.txt
+++ b/src/chrono_granular/CMakeLists.txt
@@ -14,12 +14,18 @@ endif()
 
 message(STATUS "==== Chrono Granular module ====")
 
+# Return now if Eigen version < 3.3.6
 if(EIGEN3_VERSION VERSION_LESS "3.3.6")
-  message("Chrono::Granular requires Eigen version 3.3.6 or better")
-  message("Current Eigen version: ${EIGEN3_VERSION}")
-  message("Chrono::Granular disabled")
-  set(ENABLE_MODULE_GRANULAR OFF CACHE BOOL "Enable the Chrono Granular module" FORCE)
-  return()
+    message(WARNING "Eigen version (${EIGEN3_VERSION}) is less than the required version (3.3.6); disabling Chrono::Granular")
+    set(ENABLE_MODULE_GRANULAR OFF CACHE BOOL "Enable the Chrono Granular module" FORCE)
+    return()
+endif()
+
+# Return now if CUDA is not available
+if(NOT CUDA_FOUND)
+    message(WARNING "Chrono::Granular requires CUDA, but CUDA was not found; disabling Chrono::Granular")
+    set(ENABLE_MODULE_GRANULAR OFF CACHE BOOL "Enable the Chrono Granular module" FORCE)
+    return()
 endif()
 
 # ------------------------------------------------------------------------------
@@ -163,13 +169,6 @@ mark_as_advanced(FORCE
 # ------------------------------------------------------------------------------
 
 # ----- CUDA support -----
-# Return now if CUDA is not available
-if(NOT CUDA_FOUND)
-  message("Chrono::Granular requires CUDA")
-  message(STATUS "Chrono::Granular disabled")
-  set(ENABLE_MODULE_GRANULAR OFF CACHE BOOL "Enable the Chrono Granular module" FORCE)
-  return()
-endif()
 
 option(GRANULAR_VERBOSE_PTXAS "Enable verbose output from ptxas during compilation" OFF)
 mark_as_advanced(GRANULAR_VERBOSE_PTXAS)

--- a/src/chrono_sensor/CMakeLists.txt
+++ b/src/chrono_sensor/CMakeLists.txt
@@ -14,10 +14,9 @@ message(STATUS "==== Chrono Sensor module ====")
 
 # Return now if CUDA is not available
 if(NOT CUDA_FOUND)
-  message("Chrono::Sensor requires CUDA")
-  message(STATUS "Chrono::Sensor disabled")
-  set(ENABLE_MODULE_SENSOR OFF CACHE BOOL "Enable the Chrono Sensor module" FORCE)
-  return()
+    message(WARNING "Chrono::Sensor requires CUDA, but CUDA was not found; disabling Chrono::Sensor")
+    set(ENABLE_MODULE_SENSOR OFF CACHE BOOL "Enable the Chrono Sensor module" FORCE)
+    return()
 endif()
 
 #Check for GLFW to use as window to display data for debug purposes

--- a/src/chrono_synchrono/CMakeLists.txt
+++ b/src/chrono_synchrono/CMakeLists.txt
@@ -14,17 +14,15 @@ message(STATUS "==== SynChrono module ====")
 
 # Return now if MPI is not available
 if(NOT MPI_CXX_FOUND)
-	message("Chrono::SynChrono requires MPI")
+	message(WARNING "Chrono::SynChrono requires MPI, but MPI not found; disabling Chrono::SynChrono")
 	set(ENABLE_MODULE_SYNCHRONO OFF CACHE BOOL "Enable the SynChrono module" FORCE)
-	message(STATUS "Chrono::SynChrono disabled")
 	return()
 endif()
 
 # Return now if Chrono::Vehicle is not enabled
 if(NOT ENABLE_MODULE_VEHICLE)
-    message("Chrono::SynChrono depends on Chrono::Vehicle")
+    message(WARNING "Chrono::SynChrono depends on Chrono::Vehicle which is disabled; disabling Chrono::SynChrono")
     set(ENABLE_MODULE_SYNCHRONO OFF CACHE BOOL "Enable the SynChrono module" FORCE)
-    message(STATUS "Chrono::SynChrono disabled")
     return()
 endif()
 


### PR DESCRIPTION
-- log warnings when we disable a module the user wanted
-- e.g. building Distributed with no Granular
-- In some editors (e.g. VS Code) notice (the standard warning level) just displays as plain text

```CMake
# Displays with normal output in VS Code - Displays a red line in CMake-GUI
message("No CUDA -> disabling Chrono::Sensor")        
message(NOTICE "No CUDA -> disabling Chrono::Sensor") # Equivalent to above (NOTICE is the default level)

# Logs to the "Problems" tab in VS Code - Displays in red, with additional spacing and message in CMake-GUI
message(WARNING "No CUDA -> disabling Chrono::Sensor")
```