### PR TITLE
Catch polymorphic exceptions by reference.

### DIFF
--- a/src/chrono/collision/ChCollisionModel.cpp
+++ b/src/chrono/collision/ChCollisionModel.cpp
@@ -118,7 +118,7 @@ bool ChCollisionModel::AddConvexHullsFromFile(std::shared_ptr<ChMaterialSurface>
         while (!mstream.End_of_stream()) {
             try {
                 mstream >> bufdata[linechar];
-            } catch (ChException mex) {
+            } catch (const ChException &mex) {
             };
             if ((bufdata[linechar] == (char)13) || (bufdata[linechar] == (char)10)) {
                 bufdata[linechar] = 0;

--- a/src/chrono/core/ChBezierCurve.cpp
+++ b/src/chrono/core/ChBezierCurve.cpp
@@ -189,7 +189,7 @@ std::shared_ptr<ChBezierCurve> ChBezierCurve::read(const std::string& filename) 
     try {
         ifile.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
         ifile.open(filename.c_str());
-    } catch (std::exception) {
+    } catch (const std::exception &) {
         throw ChException("Cannot open input file");
     }
 

--- a/src/chrono/core/ChFilePS.cpp
+++ b/src/chrono/core/ChFilePS.cpp
@@ -145,7 +145,7 @@ ChFile_ps::ChFile_ps(char m_name[], double x, double y, double w, double h, char
             *this << mch;
             copied++;
         }
-    } catch (std::exception pollo) {
+    } catch (const std::exception &pollo) {
         if (!copied) {
             throw ChException("Could not include the 'prolog.ps'. Is the prolog.ps file properly installed?");
         }

--- a/src/chrono/serialization/ChArchive.h
+++ b/src/chrono/serialization/ChArchive.h
@@ -470,7 +470,7 @@ public:
           }
           try {
               return ChClassFactory::GetClassTagName(typeid(*_ptr_to_val));
-          }catch (ChException myex) {
+          }catch (const ChException &myex) {
               return nostring;
           }
         }
@@ -1092,7 +1092,7 @@ class  ChArchiveOut : public ChArchive {
               const char* class_name = "";
                   try {
                       class_name = ChClassFactory::GetClassTagName(mtype).c_str(); // registered
-                  } catch(ChException mex) {   
+                  } catch(const ChException &mex) {   
                       class_name = mtype.name();
                   }
 				  std::string class_name_polished = class_name;
@@ -1381,7 +1381,7 @@ class  ChArchiveIn : public ChArchive {
             const char* class_name = "";
             try {
                 class_name = ChClassFactory::GetClassTagName(mtype).c_str(); // registered
-            } catch(ChException mex) {   
+            } catch(const ChException &mex) {   
                 class_name = mtype.name();
             }
 			std::string class_name_polished = class_name;

--- a/src/chrono/serialization/ChArchiveXML.h
+++ b/src/chrono/serialization/ChArchiveXML.h
@@ -307,7 +307,7 @@ class  ChArchiveInXML : public ChArchiveIn {
 			try {
 				document.parse<0>(&buffer[0]);
 			}
-			catch (rapidxml::parse_error merror) {
+			catch (const rapidxml::parse_error &merror) {
 				std::string line(merror.where<char>());
 				line.erase(std::find_if(line.begin(), line.end(), [](int c) {return (c==*"\n");}), line.end());
 				throw ChExceptionArchive(std::string("XML parsing error: ") + merror.what() + " at: \n" + line + "\n");

--- a/src/chrono/solver/ChSystemDescriptor.cpp
+++ b/src/chrono/solver/ChSystemDescriptor.cpp
@@ -328,7 +328,7 @@ void ChSystemDescriptor::DumpLastMatrices(bool assembled, const char* path) {
             file_fric.SetNumFormat(numformat);
             StreamOUTdenseMatlabFormat(mdfric, file_fric);
         }
-    } catch (chrono::ChException myexc) {
+    } catch (const chrono::ChException &myexc) {
         chrono::GetLog() << myexc.what();
     }
 }

--- a/src/chrono_irrlicht/ChIrrAppInterface.cpp
+++ b/src/chrono_irrlicht/ChIrrAppInterface.cpp
@@ -674,7 +674,7 @@ void ChIrrAppInterface::DoStep() {
         system->DoStepDynamics(timestep);
         if (try_realtime)
             m_realtime_timer.Spin(timestep);
-    } catch (ChException my_exception) {
+    } catch (const ChException &my_exception) {
         GetLog() << my_exception.what() << "\n";
     }
 }
@@ -919,7 +919,7 @@ void ChIrrAppInterface::DumpSystemMatrices() {
         // Save M mass matrix, K stiffness matrix, R damping matrix, Cq jacobians:
         GetSystem()->DumpSystemMatrices(true, true, true, true, "dump_");
 
-    } catch (ChException myexc) {
+    } catch (const ChException &myexc) {
         GetLog() << myexc.what();
     }
 }

--- a/src/demos/core/demo_CH_archive.cpp
+++ b/src/demos/core/demo_CH_archive.cpp
@@ -738,7 +738,7 @@ int main(int argc, char* argv[]) {
 
 		
 
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         GetLog() << "ERROR: " << myex.what() << "\n\n";
     }
 

--- a/src/demos/core/demo_CH_solver.cpp
+++ b/src/demos/core/demo_CH_solver.cpp
@@ -164,7 +164,7 @@ void test_1(const std::string& out_dir) {
         ChStreamOutAsciiFile fileCq(filename.c_str());
         StreamOUTsparseMatlabFormat(matrM, fileM);
         StreamOUTsparseMatlabFormat(matrCq, fileCq);
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         GetLog() << "FILE ERROR: " << myex.what();
     }
 
@@ -260,7 +260,7 @@ void test_2(const std::string& out_dir) {
         filename = out_dir + "/dump_fric_2.dat";
         chrono::ChStreamOutAsciiFile file_fric(filename.c_str());
         StreamOUTdenseMatlabFormat(mdfric, file_fric);
-    } catch (chrono::ChException myexc) {
+    } catch (const chrono::ChException &myexc) {
         chrono::GetLog() << myexc.what();
     }
 

--- a/src/demos/core/demo_CH_stream.cpp
+++ b/src/demos/core/demo_CH_stream.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[]) {
         // basic types (double, int, string, etc.).
         mfileo << "test_token  " << 123 << " " << 0.123437;
 
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         // Ops.. file could not be opened or written.. echo what happened!
         GetLog() << "ERROR: " << myex.what();
     }
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
         // Write to the console the values which have been read from file..
         GetLog() << "\nResult of ascii  I/O:  " << sbuff << " " << mint << " " << mdouble << "\n";
 
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         // Ops.. file could not be opened or read.. echo what happened!
         GetLog() << "ERROR: " << myex.what();
     }
@@ -125,7 +125,7 @@ int main(int argc, char* argv[]) {
         mfileo << m_int;     // store data n.3
         mfileo << m_string;  // store data n.4
 
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         GetLog() << "ERROR: " << myex.what();
     }
 
@@ -149,7 +149,7 @@ int main(int argc, char* argv[]) {
 
         GetLog() << "\nResult of binary I/O: " << m_text << " " << m_int << " " << m_double << "\n";
         
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         // Ops.. file could not be opened or read.. echo what happened!
         GetLog() << "ERROR: " << myex.what();
     }
@@ -179,7 +179,7 @@ int main(int argc, char* argv[]) {
 
         GetLog() << "\nResult of binary I/O from wrapped std::stream: " << md_in << "\n";
 
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         // Ops.. some error.. echo what happened!
         GetLog() << "ERROR: " << myex.what();
     }

--- a/src/demos/fea/demo_FEA_contacts.cpp
+++ b/src/demos/fea/demo_FEA_contacts.cpp
@@ -189,7 +189,7 @@ int main(int argc, char* argv[]) {
                 ChMatrix33<> mrot(ctot.rot);
                 ChMeshFileLoader::FromTetGenFile(my_mesh, GetChronoDataFile("fea/beam.node").c_str(),
                                                  GetChronoDataFile("fea/beam.ele").c_str(), mmaterial, ctot.pos, mrot);
-            } catch (ChException myerr) {
+            } catch (const ChException &myerr) {
                 GetLog() << myerr.what();
                 return 0;
             }

--- a/src/demos/fea/demo_FEA_cosimulate_load.cpp
+++ b/src/demos/fea/demo_FEA_cosimulate_load.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) {
         ChMeshFileLoader::FromAbaqusFile(my_mesh,
                                          GetChronoDataFile("models/tractor_wheel/tractor_wheel_coarse.INP").c_str(),
                                          mmaterial, node_sets, tire_center, tire_alignment);
-    } catch (ChException myerr) {
+    } catch (const ChException &myerr) {
         GetLog() << myerr.what();
         return 0;
     }

--- a/src/demos/fea/demo_FEA_electrostatics.cpp
+++ b/src/demos/fea/demo_FEA_electrostatics.cpp
@@ -83,7 +83,7 @@ int main(int argc, char* argv[]) {
     try {
         ChMeshFileLoader::FromAbaqusFile(my_mesh, GetChronoDataFile("fea/electrostatics.INP").c_str(), mmaterial,
                                          node_sets);
-    } catch (ChException myerr) {
+    } catch (const ChException &myerr) {
         GetLog() << myerr.what();
         return 1;
     }

--- a/src/demos/fea/demo_FEA_thermal.cpp
+++ b/src/demos/fea/demo_FEA_thermal.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]) {
     try {
         ChMeshFileLoader::FromTetGenFile(my_mesh, GetChronoDataFile("fea/beam.node").c_str(),
                                          GetChronoDataFile("fea/beam.ele").c_str(), mmaterial);
-    } catch (ChException myerr) {
+    } catch (const ChException &myerr) {
         GetLog() << myerr.what();
         return 0;
     }

--- a/src/demos/fea/demo_FEA_visualize.cpp
+++ b/src/demos/fea/demo_FEA_visualize.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
     try {
         ChMeshFileLoader::FromTetGenFile(my_mesh, GetChronoDataFile("fea/beam.node").c_str(),
                                          GetChronoDataFile("fea/beam.ele").c_str(), mmaterial);
-    } catch (ChException myerr) {
+    } catch (const ChException &myerr) {
         GetLog() << myerr.what();
         return 0;
     }

--- a/src/demos/irrlicht/demo_IRR_decomposition.cpp
+++ b/src/demos/irrlicht/demo_IRR_decomposition.cpp
@@ -138,7 +138,7 @@ void SaveHullsWavefront(ChIrrAppInterface* application, const char* filename) {
     try {
         ChStreamOutAsciiFile decomposed_objfile(filename);
         mydecompositionHACDv2.WriteConvexHullsAsWavefrontObj(decomposed_objfile);
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         application->GetIGUIEnvironment()->addMessageBox(L"Save file error", L"Impossible to write into file.");
     }
 }
@@ -150,7 +150,7 @@ void SaveHullsChulls(ChIrrAppInterface* application, const char* filename) {
     try {
         ChStreamOutAsciiFile decomposed_objfile(filename);
         mydecompositionHACDv2.WriteConvexHullsAsChullsFile(decomposed_objfile);
-    } catch (ChException myex) {
+    } catch (const ChException &myex) {
         application->GetIGUIEnvironment()->addMessageBox(L"Save file error", L"Impossible to write into file.");
     }
 }


### PR DESCRIPTION
Hi, there are many places in the code where exceptions are caught by value.  Aside from the myriad of warnings this issues, it is not recommended because when polymorphic types are used, slicing can happen:

https://blog.knatten.org/2010/04/02/always-catch-exceptions-by-reference/