### PR TITLE
[gcc] inline lambdas and remove captures

### DIFF
--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenko.h
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenko.h
@@ -80,9 +80,9 @@ struct AverageSectionParameters {
     DampingCoefficients rdamping_coeff;
 };
 
-auto GetAverageValue = [&](const double mv1, const double mv2) { return (mv1 + mv2) / 2.0; };
+inline auto GetAverageValue = [](const double mv1, const double mv2) { return (mv1 + mv2) / 2.0; };
 
-auto GetAverageValue3 = [&](const double mv1, const double mv2) { 
+inline auto GetAverageValue3 = [](const double mv1, const double mv2) { 
     if (mv1 * mv2 < 0.) {
         // GetLog() << "WARNING: negative value, error!\n";
         return GetAverageValue(mv1, mv2);
@@ -90,7 +90,7 @@ auto GetAverageValue3 = [&](const double mv1, const double mv2) {
     return (mv1 + pow(mv1 * mv2, 0.5) + mv2) / 3.0; 
 };
 
-auto GetAverageValue5 = [&](const double mv1, const double mv2) {
+inline auto GetAverageValue5 = [](const double mv1, const double mv2) {
     if (mv1 * mv2 < 0.) {
         // GetLog() << "WARNING: negative value, error!\n";
         return GetAverageValue(mv1, mv2);


### PR DESCRIPTION
Unable to build on Linux host.

Both [gcc:11.1.0] and [clang:12.0.0] throws error:
```cpp
error: non-local lambda expression cannot have a capture-default
auto GetAverageValue = [&](const double mv1, const double mv2) { return (mv1 + mv2) / 2.0; };
```

Moreover without `inline` GCC complains about `GetAverageValue{,3,5}` breaking ODR.