### PR TITLE
Use the inertial Ki and Ri (gyroscopic/centrifugal damping) in Timoshenko beams

### DIFF
--- a/src/chrono/core/ChQuadrature.h
+++ b/src/chrono/core/ChQuadrature.h
@@ -128,7 +128,7 @@ class ChApi ChQuadrature {
     static void Integrate1D(T& result,                     ///< result is returned here
                             ChIntegrable1D<T>& integrand,  ///< this is the integrand
                             const double a,                ///< min limit for x domain
-                            const double b,                ///< min limit for x domain
+                            const double b,                ///< max limit for x domain
                             const int order)               ///< order of integration
     {
         ChQuadratureTables* mtables = 0;
@@ -173,9 +173,9 @@ class ChApi ChQuadrature {
     static void Integrate2D(T& result,                     ///< result is returned here
                             ChIntegrable2D<T>& integrand,  ///< this is the integrand
                             const double Xa,               ///< min limit for x domain
-                            const double Xb,               ///< min limit for x domain
+                            const double Xb,               ///< max limit for x domain
                             const double Ya,               ///< min limit for y domain
-                            const double Yb,               ///< min limit for y domain
+                            const double Yb,               ///< max limit for y domain
                             const int order)               ///< order of integration
     {
         ChQuadratureTables* mtables = 0;
@@ -223,11 +223,11 @@ class ChApi ChQuadrature {
     static void Integrate3D(T& result,                     ///< result is returned here
                             ChIntegrable3D<T>& integrand,  ///< this is the integrand
                             const double Xa,               ///< min limit for x domain
-                            const double Xb,               ///< min limit for x domain
+                            const double Xb,               ///< max limit for x domain
                             const double Ya,               ///< min limit for y domain
-                            const double Yb,               ///< min limit for y domain
+                            const double Yb,               ///< max limit for y domain
                             const double Za,               ///< min limit for z domain
-                            const double Zb,               ///< min limit for z domain
+                            const double Zb,               ///< max limit for z domain
                             const int order)               ///< order of integration
     {
         ChQuadratureTables* mtables = 0;

--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenko.cpp
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenko.cpp
@@ -797,6 +797,62 @@ void ChBeamSectionTaperedTimoshenkoAdvancedGeneric::ComputeInertiaMatrix(ChMatri
     M = Mtmp;  // transform from ChMatrixNM<double, 12, 12> to ChMatrixDynamic<>
 }
 
+void ChBeamSectionTaperedTimoshenkoAdvancedGeneric::ComputeInertiaDampingMatrix(
+    ChMatrixNM<double, 12, 12>& Ri,
+                                                                                const ChVector<>& mW_A,
+                                                                                const ChVector<>& mW_B) {
+    Ri.setZero(12, 12);
+
+    if (this->compute_inertia_damping_matrix == false)
+        return;
+
+    this->sectionA->compute_inertia_damping_matrix = this->compute_inertia_damping_matrix;
+    this->sectionA->compute_inertia_stiffness_matrix = this->compute_inertia_stiffness_matrix;
+    this->sectionA->compute_Ri_Ki_by_num_diff = this->compute_Ri_Ki_by_num_diff;
+
+    this->sectionB->compute_inertia_damping_matrix = this->compute_inertia_damping_matrix;
+    this->sectionB->compute_inertia_stiffness_matrix = this->compute_inertia_stiffness_matrix;
+    this->sectionB->compute_Ri_Ki_by_num_diff = this->compute_Ri_Ki_by_num_diff;
+
+    ChMatrixNM<double, 6, 6> Ri_A;
+    ChMatrixNM<double, 6, 6> Ri_B;
+    this->sectionA->ComputeInertiaDampingMatrix(Ri_A, mW_A);
+    this->sectionB->ComputeInertiaDampingMatrix(Ri_B, mW_B);
+
+    Ri.block<6, 6>(0, 0) = Ri_A;
+    Ri.block<6, 6>(6, 6) = Ri_B;
+}
+
+void ChBeamSectionTaperedTimoshenkoAdvancedGeneric::ComputeInertiaStiffnessMatrix(ChMatrixNM<double, 12, 12>& Ki,
+    const ChVector<>& mWvel_A,  ///< current angular velocity of section of node A, in material frame
+    const ChVector<>& mWacc_A,  ///< current angular acceleration of section of node A, in material frame
+    const ChVector<>& mXacc_A,  ///< current acceleration of section of node A, in material frame) 
+    const ChVector<>& mWvel_B,  ///< current angular velocity of section of node B, in material frame
+    const ChVector<>& mWacc_B,  ///< current angular acceleration of section of node B, in material frame
+    const ChVector<>& mXacc_B   ///< current acceleration of section of node B, in material frame
+    ){
+    Ki.setZero(12, 12);
+
+    if (this->compute_inertia_stiffness_matrix == false)
+        return;
+
+    this->sectionA->compute_inertia_damping_matrix = this->compute_inertia_damping_matrix;
+    this->sectionA->compute_inertia_stiffness_matrix = this->compute_inertia_stiffness_matrix;
+    this->sectionA->compute_Ri_Ki_by_num_diff = this->compute_Ri_Ki_by_num_diff;
+
+    this->sectionB->compute_inertia_damping_matrix = this->compute_inertia_damping_matrix;
+    this->sectionB->compute_inertia_stiffness_matrix = this->compute_inertia_stiffness_matrix;
+    this->sectionB->compute_Ri_Ki_by_num_diff = this->compute_Ri_Ki_by_num_diff;
+
+    ChMatrixNM<double, 6, 6> Ki_A;
+    ChMatrixNM<double, 6, 6> Ki_B;
+    this->sectionA->ComputeInertiaStiffnessMatrix(Ki_A, mWvel_A, mWacc_A, mXacc_A);
+    this->sectionB->ComputeInertiaStiffnessMatrix(Ki_B, mWvel_B, mWacc_B, mXacc_B);
+
+    Ki.block<6, 6>(0, 0) = Ki_A;
+    Ki.block<6, 6>(6, 6) = Ki_B;
+}
+
 DampingCoefficients ChBeamSectionTaperedTimoshenkoAdvancedGeneric::GetBeamRaleyghDamping() const {
     return this->avg_sec_par->rdamping_coeff;
 };

--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenko.h
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenko.h
@@ -294,7 +294,7 @@ class ChApi ChBeamSectionTaperedTimoshenkoAdvancedGeneric {
 
     virtual std::shared_ptr<AverageSectionParameters> GetAverageSectionParameters() const { return this->avg_sec_par; };
 
-        // Optimization flags
+    // Optimization flags
 
     /// Flag that turns on/off the computation of the [Ri] 'gyroscopic' inertial damping matrix.
     /// If false, Ri=0. Can be used for cpu speedup, profiling, tests. Default: true.

--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenko.h
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenko.h
@@ -268,10 +268,45 @@ class ChApi ChBeamSectionTaperedTimoshenkoAdvancedGeneric {
     virtual void ComputeInertiaMatrix(ChMatrixDynamic<>& M  ///< 12x12 sectional mass matrix values here
     );
 
+    // Compute the 12x12 local inertial-damping (gyroscopic damping) matrix
+    // lumped format is usded, need to multiple 0.5 * length to obtain the final inertial-damping matrix
+    virtual void ComputeInertiaDampingMatrix(
+        ChMatrixNM<double, 12, 12>& Ri,  ///< 12x12 sectional inertial-damping matrix values here
+        const ChVector<>& mW_A,          ///< current angular velocity of section of node A, in material frame
+        const ChVector<>& mW_B           ///< current angular velocity of section of node B, in material frame
+        );
+
+    // Compute the 12x12 local inertial-stiffness matrix
+    // lumped format is usded, need to multiple 0.5 * length to obtain the final inertial-stiffness matrix
+    virtual void ComputeInertiaStiffnessMatrix(
+        ChMatrixNM<double, 12, 12>& Ki,  ///< 12x12 sectional inertial-stiffness matrix values here
+        const ChVector<>& mWvel_A,       ///< current angular velocity of section of node A, in material frame
+        const ChVector<>& mWacc_A,       ///< current angular acceleration of section of node A, in material frame
+        const ChVector<>& mXacc_A,       ///< current acceleration of section of node A, in material frame)
+        const ChVector<>& mWvel_B,       ///< current angular velocity of section of node B, in material frame
+        const ChVector<>& mWacc_B,       ///< current angular acceleration of section of node B, in material frame
+        const ChVector<>& mXacc_B        ///< current acceleration of section of node B, in material frame
+        );
+
+
     /// Get the average damping coefficient of this tapered cross-section.
     virtual DampingCoefficients GetBeamRaleyghDamping() const;
 
     virtual std::shared_ptr<AverageSectionParameters> GetAverageSectionParameters() const { return this->avg_sec_par; };
+
+        // Optimization flags
+
+    /// Flag that turns on/off the computation of the [Ri] 'gyroscopic' inertial damping matrix.
+    /// If false, Ri=0. Can be used for cpu speedup, profiling, tests. Default: true.
+    bool compute_inertia_damping_matrix = true;
+
+    /// Flag that turns on/off the computation of the [Ki] inertial stiffness matrix.
+    /// If false, Ki=0. Can be used for cpu speedup, profiling, tests. Default: true.
+    bool compute_inertia_stiffness_matrix = true;
+
+    /// Flag for computing the Ri and Ki matrices via numerical differentiation even if
+    /// an analytical expression is provided. Children calsses must take care of this. Default: false.
+    bool compute_Ri_Ki_by_num_diff = false;
 
   protected:
     double length;
@@ -283,7 +318,6 @@ class ChApi ChBeamSectionTaperedTimoshenkoAdvancedGeneric {
 
     virtual void ComputeLumpedInertiaMatrix(ChMatrixNM<double, 12, 12>& M  ///< 12x12 sectional mass matrix values here
     );
-
 
     // A quick algorithm to do the transformation of stiffness matrxi in case of mass axis orientation and mass cetner offset,
     // But, has been validated to be wrong. 

--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.cpp
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.cpp
@@ -21,9 +21,8 @@ namespace fea {
 void ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::ComputeAverageFPM() {
 
     // the elements off the diagonal are averaged by arithmetic mean
-    this->average_fpm = (this->section_fpmA->GetFullyPopulatedMaterialStiffnessMatrix() +
-                            this->section_fpmB->GetFullyPopulatedMaterialStiffnessMatrix()) *
-                        0.5;
+    this->average_fpm =
+        0.5 * (this->section_fpmA->GetStiffnessMatrixFPM() + this->section_fpmB->GetStiffnessMatrixFPM());
 
     // The diagonal terms are averaged by geometrical mean, to be consistent with previous algorithm
     this->average_fpm(0, 0) = this->avg_sec_par->EA;
@@ -34,6 +33,72 @@ void ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::ComputeAverageFPM() {
     this->average_fpm(5, 5) = this->avg_sec_par->EIzz;
 
 }
+
+
+ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetAverageKlaw() {
+    ChMatrixNM<double, 6, 6> Klaw_average = 
+        0.5 * (this->section_fpmA->GetStiffnessMatrixFPM() + this->section_fpmB->GetStiffnessMatrixFPM());
+    return Klaw_average;
+}
+
+ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetAverageMlaw() {
+    ChMatrixNM<double, 6, 6> Mlaw_average =
+        0.5 * (this->section_fpmA->GetMassMatrixFPM() + this->section_fpmB->GetMassMatrixFPM());
+    return Mlaw_average;
+}
+
+ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetKlawAtPoint(const double eta) {
+    // calculate cross-sectional material stiffness matrix Klaw at dimensionless point eta, by linear interpolation
+    // eta = (-1,1)
+    double Nx1 = (1. / 2.) * (1 - eta);
+    double Nx2 = (1. / 2.) * (1 + eta);
+    ChMatrixNM<double, 6, 6> Klaw_point =
+        Nx1 * this->section_fpmA->GetStiffnessMatrixFPM() + 
+        Nx2 * this->section_fpmB->GetStiffnessMatrixFPM();
+    
+    return Klaw_point;
+}
+
+ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetMlawAtPoint(const double eta) {
+    // calculate cross-sectional material mass matrix Mlaw at dimensionless point eta, by linear interpolation
+    // eta = (-1,1)
+    double Nx1 = (1. / 2.) * (1 - eta);
+    double Nx2 = (1. / 2.) * (1 + eta);
+    ChMatrixNM<double, 6, 6> Mlaw_point =
+        Nx1 * this->section_fpmA->GetMassMatrixFPM() + 
+        Nx2 * this->section_fpmB->GetMassMatrixFPM();
+    
+    return Mlaw_point;
+}
+
+ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetRlawAtPoint(const double eta) {
+    
+    DampingCoefficients rdamping_coeff_A = this->section_fpmA->GetBeamRaleyghDamping();
+    DampingCoefficients rdamping_coeff_B = this->section_fpmB->GetBeamRaleyghDamping();
+
+    // linear interpolation
+    double Nx1 = (1. / 2.) * (1 - eta);
+    double Nx2 = (1. / 2.) * (1 + eta);
+    double mbx = Nx1 * rdamping_coeff_A.bx + Nx2 * rdamping_coeff_B.bx;
+    double mby = Nx1 * rdamping_coeff_A.by + Nx2 * rdamping_coeff_B.by;
+    double mbz = Nx1 * rdamping_coeff_A.bz + Nx2 * rdamping_coeff_B.bz;
+    double mbt = Nx1 * rdamping_coeff_A.bt + Nx2 * rdamping_coeff_B.bt;
+
+    ChMatrixNM<double, 6, 6> mb;
+    mb.setIdentity();
+    mb(0, 0) = mbx;
+    mb(1, 1) = mby;
+    mb(2, 2) = mbz;
+    mb(3, 3) = mbt;
+    mb(4, 4) = mbz;
+    mb(5, 5) = mby;
+
+    ChMatrixNM<double, 6, 6> Klaw_point = this->GetKlawAtPoint(eta);
+    ChMatrixNM<double, 6, 6> Rlaw_point = mb.transpose() * Klaw_point * mb;  // material damping matrix
+
+    return Rlaw_point;
+}
+
 
 
 void ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::ComputeInertiaMatrix(ChMatrixDynamic<>& M) {

--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.cpp
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.cpp
@@ -31,23 +31,22 @@ void ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::ComputeAverageFPM() {
     this->average_fpm(3, 3) = this->avg_sec_par->GJ;
     this->average_fpm(4, 4) = this->avg_sec_par->EIyy;
     this->average_fpm(5, 5) = this->avg_sec_par->EIzz;
-
 }
 
 
-ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetAverageKlaw() {
+ChMatrixNM<double, 6, 6> ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetAverageKlaw() {
     ChMatrixNM<double, 6, 6> Klaw_average = 
         0.5 * (this->section_fpmA->GetStiffnessMatrixFPM() + this->section_fpmB->GetStiffnessMatrixFPM());
     return Klaw_average;
 }
 
-ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetAverageMlaw() {
+ChMatrixNM<double, 6, 6> ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetAverageMlaw() {
     ChMatrixNM<double, 6, 6> Mlaw_average =
         0.5 * (this->section_fpmA->GetMassMatrixFPM() + this->section_fpmB->GetMassMatrixFPM());
     return Mlaw_average;
 }
 
-ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetKlawAtPoint(const double eta) {
+ChMatrixNM<double, 6, 6> ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetKlawAtPoint(const double eta) {
     // calculate cross-sectional material stiffness matrix Klaw at dimensionless point eta, by linear interpolation
     // eta = (-1,1)
     double Nx1 = (1. / 2.) * (1 - eta);
@@ -59,7 +58,7 @@ ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetK
     return Klaw_point;
 }
 
-ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetMlawAtPoint(const double eta) {
+ChMatrixNM<double, 6, 6> ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetMlawAtPoint(const double eta) {
     // calculate cross-sectional material mass matrix Mlaw at dimensionless point eta, by linear interpolation
     // eta = (-1,1)
     double Nx1 = (1. / 2.) * (1 - eta);
@@ -71,7 +70,7 @@ ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetM
     return Mlaw_point;
 }
 
-ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetRlawAtPoint(const double eta) {
+ChMatrixNM<double, 6, 6> ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetRlawAtPoint(const double eta) {
     
     DampingCoefficients rdamping_coeff_A = this->section_fpmA->GetBeamRaleyghDamping();
     DampingCoefficients rdamping_coeff_B = this->section_fpmB->GetBeamRaleyghDamping();
@@ -98,7 +97,6 @@ ChMatrixNM<double, 6, 6>& ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::GetR
 
     return Rlaw_point;
 }
-
 
 
 void ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM::ComputeInertiaMatrix(ChMatrixDynamic<>& M) {

--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.h
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.h
@@ -175,12 +175,12 @@ public:
     std::shared_ptr<ChBeamSectionTimoshenkoAdvancedGenericFPM> GetSectionA() { return section_fpmA; }
     std::shared_ptr<ChBeamSectionTimoshenkoAdvancedGenericFPM> GetSectionB() { return section_fpmB; }
 
-	ChMatrixNM<double, 6, 6>& GetAverageFPM() { return average_fpm; }
-    ChMatrixNM<double, 6, 6>& GetAverageKlaw();
-    ChMatrixNM<double, 6, 6>& GetAverageMlaw();
-    ChMatrixNM<double, 6, 6>& GetKlawAtPoint(const double eta);
-    ChMatrixNM<double, 6, 6>& GetMlawAtPoint(const double eta);
-    ChMatrixNM<double, 6, 6>& GetRlawAtPoint(const double eta);
+	ChMatrixNM<double, 6, 6> GetAverageFPM() { return average_fpm; }
+    ChMatrixNM<double, 6, 6> GetAverageKlaw();
+    ChMatrixNM<double, 6, 6> GetAverageMlaw();
+    ChMatrixNM<double, 6, 6> GetKlawAtPoint(const double eta);
+    ChMatrixNM<double, 6, 6> GetMlawAtPoint(const double eta);
+    ChMatrixNM<double, 6, 6> GetRlawAtPoint(const double eta);
 
 	/// Compute the 12x12 sectional inertia matrix, as in  {x_momentum,w_momentum}=[Mm]{xvel,wvel}
     /// The matrix is computed in the material reference (i.e. it is the sectional mass matrix)

--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.h
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.h
@@ -35,11 +35,16 @@ protected:
 	// the shear principal axis orientation is assumed same as elastic one.
 	ChMatrixNM<double, 6, 6> Klaw;
 
-public:
-	ChBeamSectionTimoshenkoAdvancedGenericFPM() : Klaw(ChMatrixNM<double, 6, 6>::Identity(6, 6)) {}
+	ChMatrixNM<double, 6, 6> Mlaw;
+
+  public:
+    ChBeamSectionTimoshenkoAdvancedGenericFPM()
+        : Klaw(ChMatrixNM<double, 6, 6>::Identity(6, 6)), 
+		Mlaw(ChMatrixNM<double, 6, 6>::Identity(6, 6)) {}
 
 	ChBeamSectionTimoshenkoAdvancedGenericFPM(
 		const ChMatrixNM<double, 6, 6> mKlaw,
+        const ChMatrixNM<double, 6, 6> mMlaw,
 		const double malpha,  ///< section rotation about elastic center [rad]
 		const double mCy,     ///< elastic center y displacement respect to centerline
 		const double mCz,     ///< elastic center z displacement respect to centerline
@@ -58,6 +63,7 @@ public:
 		const double mMz = 0)  ///< mass center z displacement respect to centerline
 	{
 		Klaw = mKlaw;
+        Mlaw = mMlaw;
 		Ax = mKlaw(0, 0);
 		GAyy = mKlaw(1, 1);
 		GAzz = mKlaw(2, 2);
@@ -81,7 +87,7 @@ public:
 
 	virtual ~ChBeamSectionTimoshenkoAdvancedGenericFPM() {}
 
-	virtual void SetFullyPopulatedMaterialStiffnessMatrix(const ChMatrixNM<double, 6, 6> mKlaw) {
+	virtual void SetStiffnessMatrixFPM(const ChMatrixNM<double, 6, 6> mKlaw) {
 		this->Klaw = mKlaw;
 		this->Ax = mKlaw(0, 0);
 		this->GAyy = mKlaw(1, 1);
@@ -91,7 +97,59 @@ public:
 		this->Bzz = mKlaw(5, 5);
 	}
 
-	virtual ChMatrixNM<double, 6, 6>& GetFullyPopulatedMaterialStiffnessMatrix() { return this->Klaw; }
+	virtual ChMatrixNM<double, 6, 6>& GetStiffnessMatrixFPM() { return this->Klaw; }
+
+	// This cross-sectional mass matrix should be given at the centerline
+	virtual void SetMassMatrixFPM(const ChMatrixNM<double, 6, 6> mMlaw) {
+        this->Mlaw = mMlaw;
+
+        this->mu = (mMlaw(0, 0) + mMlaw(1, 1) + mMlaw(2, 2))/3.0;
+		this->Jxx = mMlaw(3, 3);
+        this->Jyy = mMlaw(4, 4);
+        this->Jzz = mMlaw(5, 5);
+        this->Jyz = -mMlaw(4, 5);
+        this->Qy = mMlaw(0, 4);
+        this->Qz = -mMlaw(0, 5);
+    }
+
+	// assign the mass properties at mass center, calcualte the Mlaw automatically
+	virtual void SetMassMatrixFPM(double mmu, double Jmyy, double Jmzz, double Jmyz, double mass_phi, double Qmy, double Qmz, double mMy, double mMz) {
+        this->mu = mmu;
+        this->My = mMy;
+        this->Mz = mMz;
+
+		// transform the mass properties from mass center to centerline
+		this->SetMainInertiasInMassReference(Jmyy,Jmzz,Jmyz,mass_phi,Qmy,Qmz);
+		
+		// fill the cross-sectional mass matrix Mlaw
+        this->Mlaw.row(0) << mu, 0, 0, 0, Qy, -Qz;
+        this->Mlaw.row(1) << 0, mu, 0, -Qy, 0, 0;
+        this->Mlaw.row(2) << 0, 0, mu, Qz, 0, 0;
+        this->Mlaw.row(3) << 0, -Qy, Qz, Jxx, 0, 0;
+        this->Mlaw.row(4) << Qy, 0, 0, 0, Jyy, -Jyz;
+        this->Mlaw.row(5) << -Qz, 0, 0, 0, -Jyz, Jzz;
+    }
+
+    // assign the mass properties at centerline, calcualte the Mlaw automatically
+	virtual void SetMassMatrixFPM(double mmu, double mJyy, double mJzz, double mJyz, double mQy, double mQz) {
+        this->mu = mmu;
+        this->Jxx = mJyy + mJzz;
+        this->Jyy = mJyy;
+        this->Jzz = mJzz;
+        this->Jyz = mJyz;
+        this->Qy = mQy;
+        this->Qz = mQz;
+
+        // fill the cross-sectional mass matrix Mlaw
+        this->Mlaw.row(0) << mu, 0, 0, 0, Qy, -Qz;
+        this->Mlaw.row(1) << 0, mu, 0, -Qy, 0, 0;
+        this->Mlaw.row(2) << 0, 0, mu, Qz, 0, 0;
+        this->Mlaw.row(3) << 0, -Qy, Qz, Jxx, 0, 0;
+        this->Mlaw.row(4) << Qy, 0, 0, 0, Jyy, -Jyz;
+        this->Mlaw.row(5) << -Qz, 0, 0, 0, -Jyz, Jzz;
+    }
+
+    virtual ChMatrixNM<double, 6, 6>& GetMassMatrixFPM() { return this->Mlaw; }
 
 };
 
@@ -118,6 +176,11 @@ public:
     std::shared_ptr<ChBeamSectionTimoshenkoAdvancedGenericFPM> GetSectionB() { return section_fpmB; }
 
 	ChMatrixNM<double, 6, 6>& GetAverageFPM() { return average_fpm; }
+    ChMatrixNM<double, 6, 6>& GetAverageKlaw();
+    ChMatrixNM<double, 6, 6>& GetAverageMlaw();
+    ChMatrixNM<double, 6, 6>& GetKlawAtPoint(const double eta);
+    ChMatrixNM<double, 6, 6>& GetMlawAtPoint(const double eta);
+    ChMatrixNM<double, 6, 6>& GetRlawAtPoint(const double eta);
 
 	/// Compute the 12x12 sectional inertia matrix, as in  {x_momentum,w_momentum}=[Mm]{xvel,wvel}
     /// The matrix is computed in the material reference (i.e. it is the sectional mass matrix)

--- a/src/chrono/fea/ChBuilderBeam.cpp
+++ b/src/chrono/fea/ChBuilderBeam.cpp
@@ -526,6 +526,130 @@ void ChBuilderBeamTaperedTimoshenko::BuildBeam(
 
 
 // ------------------------------------------------------------------
+// ChBuilderBeamTaperedTimoshenkoFPM
+// ------------------------------------------------------------------
+
+void ChBuilderBeamTaperedTimoshenkoFPM::BuildBeam(
+    std::shared_ptr<ChMesh> mesh,                                         // mesh to store the resulting elements
+    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> sect,  // section material for beam elements
+    const int N,                                                          // number of elements in the segment
+    const ChVector<> A,                                                   // starting point
+    const ChVector<> B,                                                   // ending point
+    const ChVector<> Ydir                                                 // the 'up' Y direction of the beam
+) {
+    beam_elems.clear();
+    beam_nodes.clear();
+
+    ChMatrix33<> mrot;
+    mrot.Set_A_Xdir(B - A, Ydir);
+
+    auto nodeA = chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(A, mrot));
+    mesh->AddNode(nodeA);
+    beam_nodes.push_back(nodeA);
+
+    for (int i = 1; i <= N; ++i) {
+        double eta = (double)i / (double)N;
+        ChVector<> pos = A + (B - A) * eta;
+
+        auto nodeB = chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(pos, mrot));
+        mesh->AddNode(nodeB);
+        beam_nodes.push_back(nodeB);
+
+        auto element = chrono_types::make_shared<ChElementBeamTaperedTimoshenkoFPM>();
+        mesh->AddElement(element);
+        beam_elems.push_back(element);
+
+        element->SetNodes(beam_nodes[i - 1], beam_nodes[i]);
+
+        element->SetTaperedSection(sect);
+    }
+}
+
+void ChBuilderBeamTaperedTimoshenkoFPM::BuildBeam(
+    std::shared_ptr<ChMesh> mesh,                                         // mesh to store the resulting elements
+    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> sect,  // section material for beam elements
+    const int N,                                                          // number of elements in the segment
+    std::shared_ptr<ChNodeFEAxyzrot> nodeA,                               // starting point
+    std::shared_ptr<ChNodeFEAxyzrot> nodeB,                               // ending point
+    const ChVector<> Ydir                                                 // the 'up' Y direction of the beam
+) {
+    beam_elems.clear();
+    beam_nodes.clear();
+
+    ChMatrix33<> mrot;
+    mrot.Set_A_Xdir(nodeB->Frame().GetPos() - nodeA->Frame().GetPos(), Ydir);
+
+    beam_nodes.push_back(nodeA);
+
+    for (int i = 1; i <= N; ++i) {
+        double eta = (double)i / (double)N;
+        ChVector<> pos = nodeA->Frame().GetPos() + (nodeB->Frame().GetPos() - nodeA->Frame().GetPos()) * eta;
+
+        std::shared_ptr<ChNodeFEAxyzrot> nodeBi;
+        if (i < N) {
+            nodeBi = chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(pos, mrot));
+            mesh->AddNode(nodeBi);
+        } else
+            nodeBi = nodeB;  // last node: use the one passed as parameter.
+
+        beam_nodes.push_back(nodeBi);
+
+        auto element = chrono_types::make_shared<ChElementBeamTaperedTimoshenkoFPM>();
+        mesh->AddElement(element);
+        beam_elems.push_back(element);
+
+        element->SetNodes(beam_nodes[i - 1], beam_nodes[i]);
+
+        ChQuaternion<> elrot = mrot.Get_A_quaternion();
+        element->SetNodeAreferenceRot(elrot.GetConjugate() % element->GetNodeA()->Frame().GetRot());
+        element->SetNodeBreferenceRot(elrot.GetConjugate() % element->GetNodeB()->Frame().GetRot());
+
+        element->SetTaperedSection(sect);
+    }
+}
+
+void ChBuilderBeamTaperedTimoshenkoFPM::BuildBeam(
+    std::shared_ptr<ChMesh> mesh,                                         // mesh to store the resulting elements
+    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> sect,  // section material for beam elements
+    const int N,                                                          // number of elements in the segment
+    std::shared_ptr<ChNodeFEAxyzrot> nodeA,                               // starting point
+    const ChVector<> B,                                                   // ending point
+    const ChVector<> Ydir                                                 // the 'up' Y direction of the beam
+) {
+    beam_elems.clear();
+    beam_nodes.clear();
+
+    ChMatrix33<> mrot;
+    mrot.Set_A_Xdir(B - nodeA->Frame().GetPos(), Ydir);
+
+    beam_nodes.push_back(nodeA);
+
+    for (int i = 1; i <= N; ++i) {
+        double eta = (double)i / (double)N;
+        ChVector<> pos = nodeA->Frame().GetPos() + (B - nodeA->Frame().GetPos()) * eta;
+
+        auto nodeBi = chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(pos, mrot));
+        mesh->AddNode(nodeBi);
+        beam_nodes.push_back(nodeBi);
+
+        auto element = chrono_types::make_shared<ChElementBeamTaperedTimoshenkoFPM>();
+        mesh->AddElement(element);
+        beam_elems.push_back(element);
+
+        element->SetNodes(beam_nodes[i - 1], beam_nodes[i]);
+
+        ChQuaternion<> elrot = mrot.Get_A_quaternion();
+        element->SetNodeAreferenceRot(elrot.GetConjugate() % element->GetNodeA()->Frame().GetRot());
+        element->SetNodeBreferenceRot(elrot.GetConjugate() % element->GetNodeB()->Frame().GetRot());
+        // GetLog() << "Element n." << i << " with rotations: \n";
+        // GetLog() << "   Qa=" << element->GetNodeAreferenceRot() << "\n";
+        // GetLog() << "   Qb=" << element->GetNodeBreferenceRot() << "\n\n";
+        element->SetTaperedSection(sect);
+    }
+}
+
+
+// ------------------------------------------------------------------
 // ChExtruderBeamEuler
 // ------------------------------------------------------------------
 

--- a/src/chrono/fea/ChBuilderBeam.h
+++ b/src/chrono/fea/ChBuilderBeam.h
@@ -21,6 +21,7 @@
 #include "chrono/fea/ChElementCableANCF.h"
 #include "chrono/fea/ChElementBeamANCF.h"
 #include "chrono/fea/ChElementBeamTaperedTimoshenko.h"
+#include "chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h"
 #include "chrono/fea/ChContactSurfaceNodeCloud.h"
 
 #include "chrono/physics/ChBody.h"
@@ -198,6 +199,8 @@ class ChApi ChBuilderBeamIGA {
     std::vector<std::shared_ptr<ChNodeFEAxyzrot>>& GetLastBeamNodes() { return beam_nodes; }
 };
 
+/// Utility class for creating complex beams using ChElementBeamTaperedTimoshenko elements, for example subdivides a segment in
+/// multiple finite elements.
 class ChApi ChBuilderBeamTaperedTimoshenko {
   protected:
     std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenko>> beam_elems;
@@ -225,7 +228,7 @@ class ChApi ChBuilderBeamTaperedTimoshenko {
     );
 
     /// Add beam FEM elements to the mesh to create a segment beam from one existing node to a point B, using
-    /// ChElementBeamEuler type elements. Before running, each time resets lists of beam_elems and beam_nodes.
+    /// ChElementBeamTaperedTimoshenko type elements. Before running, each time resets lists of beam_elems and beam_nodes.
     void BuildBeam(std::shared_ptr<ChMesh> mesh,              ///< mesh to store the resulting elements
         std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGeneric> sect,  ///< section material for beam elements
                    const int N,                               ///< number of elements in the segment
@@ -238,6 +241,60 @@ class ChApi ChBuilderBeamTaperedTimoshenko {
     /// It can be useful for changing properties afterwards.
     /// This list is reset all times a BuildBeam function is called.
     std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenko>>& GetLastBeamElements() { return beam_elems; }
+
+    /// Access the list of nodes used by the last built beam.
+    /// It can be useful for adding constraints or changing properties afterwards.
+    /// This list is reset all times a BuildBeam function is called.
+    std::vector<std::shared_ptr<ChNodeFEAxyzrot>>& GetLastBeamNodes() { return beam_nodes; }
+};
+
+/// Utility class for creating complex beams using ChElementBeamTaperedTimoshenkoFPM elements, for example subdivides a
+/// segment in multiple finite elements.
+class ChApi ChBuilderBeamTaperedTimoshenkoFPM {
+  protected:
+    std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenkoFPM>> beam_elems;
+    std::vector<std::shared_ptr<ChNodeFEAxyzrot>> beam_nodes;
+
+  public:
+    /// Add beam FEM elements to the mesh to create a segment beam from point A to point B, using
+    /// ChElementBeamTaperedTimoshenkoFPM type elements. Before running, each time resets lists of beam_elems and
+    /// beam_nodes.
+    void BuildBeam(
+        std::shared_ptr<ChMesh> mesh,                                         ///< mesh to store the resulting elements
+        std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> sect,  ///< section material for beam elements
+        const int N,                                                          ///< number of elements in the segment
+        const ChVector<> A,                                                   ///< starting point
+        const ChVector<> B,                                                   ///< ending point
+        const ChVector<> Ydir                                                 ///< the 'up' Y direction of the beam
+    );
+    
+    /// Add beam FEM elements to the mesh to create a segment beam from one existing node to another existing node,
+    /// using ChElementBeamTaperedTimoshenkoFPM type elements. Before running, each time resets lists of beam_elems and
+    /// beam_nodes.
+    void BuildBeam(
+        std::shared_ptr<ChMesh> mesh,                                         ///< mesh to store the resulting elements
+        std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> sect,  ///< section material for beam elements
+        const int N,                                                          ///< number of elements in the segment
+        std::shared_ptr<ChNodeFEAxyzrot> nodeA,                               ///< starting point
+        std::shared_ptr<ChNodeFEAxyzrot> nodeB,                               ///< ending point
+        const ChVector<> Ydir                                                 ///< the 'up' Y direction of the beam
+    );
+
+    /// Add beam FEM elements to the mesh to create a segment beam from one existing node to a point B, using
+    /// ChElementBeamTaperedTimoshenkoFPM type elements. Before running, each time resets lists of beam_elems and beam_nodes.
+    void BuildBeam(
+        std::shared_ptr<ChMesh> mesh,                                         ///< mesh to store the resulting elements
+        std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> sect,  ///< section material for beam elements
+        const int N,                                                          ///< number of elements in the segment
+        std::shared_ptr<ChNodeFEAxyzrot> nodeA,                               ///< starting point
+        const ChVector<> B,                                                   ///< ending point
+        const ChVector<> Ydir                                                 ///< the 'up' Y direction of the beam
+    );
+
+    /// Access the list of elements used by the last built beam.
+    /// It can be useful for changing properties afterwards.
+    /// This list is reset all times a BuildBeam function is called.
+    std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenkoFPM>>& GetLastBeamElements() { return beam_elems; }
 
     /// Access the list of nodes used by the last built beam.
     /// It can be useful for adding constraints or changing properties afterwards.

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenko.cpp
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenko.cpp
@@ -812,8 +812,8 @@ void ChElementBeamTaperedTimoshenko::SetupInitial(ChSystem* system) {
 
     // Compute rest length, mass:
     this->length = (nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos()).Length();
-    this->mass = this->length / 2 * this->tapered_section->GetSectionA()->GetMassPerUnitLength() +
-                 this->length / 2 * this->tapered_section->GetSectionB()->GetMassPerUnitLength();
+    this->mass = 0.5 * this->length * this->tapered_section->GetSectionA()->GetMassPerUnitLength() +
+                 0.5 * this->length * this->tapered_section->GetSectionB()->GetMassPerUnitLength();
 
     // Compute initial rotation
     ChMatrix33<> A0;

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenko.cpp
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenko.cpp
@@ -56,7 +56,7 @@ void ChElementBeamTaperedTimoshenko::SetNodes(std::shared_ptr<ChNodeFEAxyzrot> n
     Kmatr.SetVariables(mvars);
 }
 
-void ChElementBeamTaperedTimoshenko::ShapeFunctions(ShapeVector& N, double eta) {
+void ChElementBeamTaperedTimoshenko::ShapeFunctionsEuler(ShapeVector& N, double eta) {
     double Nx1 = (1. / 2.) * (1 - eta);
     double Nx2 = (1. / 2.) * (1 + eta);
     double Ny1 = (1. / 4.) * pow((1 - eta), 2) * (2 + eta);
@@ -730,7 +730,7 @@ void ChElementBeamTaperedTimoshenko::ComputeGeometricStiffnessMatrix() {
     double PL2_15_z = 2. * L / (15.);  // optional [2]: ...+ 4*IyA /(L);
     double PL_30_y = L / (30.);        // optional [2]: ...+ 2*IyA /(L);
     double PL_30_z = L / (30.);        // optional [2]: ...+ 2*IyA /(L);
-    /*  QUESTION: why the axial geometric stiffness is ignored? I think we should include it. By PENG Chao
+    /*  DONOT use the axial terms:
     this->Kg(0, 0) =  P_L;
     this->Kg(6, 6) =  P_L;
     this->Kg(0, 6) = -P_L;

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenko.cpp
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenko.cpp
@@ -28,14 +28,16 @@ ChElementBeamTaperedTimoshenko::ChElementBeamTaperedTimoshenko()
       disable_corotate(false),
       use_geometric_stiffness(true),
       use_Rc(true),
-      use_Rs(true){
-
+      use_Rs(true) {
     nodes.resize(2);
 
     Km.setZero(this->GetNdofs(), this->GetNdofs());
     Kg.setZero(this->GetNdofs(), this->GetNdofs());
     M.setZero(this->GetNdofs(), this->GetNdofs());
     Rm.setZero(this->GetNdofs(), this->GetNdofs());
+    Ri.setZero(this->GetNdofs(), this->GetNdofs());
+    Ki.setZero(this->GetNdofs(), this->GetNdofs());
+
     T.setZero(this->GetNdofs(), this->GetNdofs());
     Rs.setIdentity(6, 6);
     Rc.setIdentity(6, 6);
@@ -98,14 +100,14 @@ void ChElementBeamTaperedTimoshenko::ShapeFunctionsTimoshenko(ShapeFunctionGroup
     double L = this->length;
     double LL = L * L;
     double LLL = LL * L;
-    double phiy = this->taperedSection->GetAverageSectionParameters()->phiy;
-    double phiz = this->taperedSection->GetAverageSectionParameters()->phiz;
+    double phiy = this->tapered_section->GetAverageSectionParameters()->phiy;
+    double phiz = this->tapered_section->GetAverageSectionParameters()->phiz;
 
     double eta2 = eta * eta;
     double eta3 = eta2 * eta;
 
-    double ay = 1. / (1.+phiy);
-    double by = phiy/ (1. + phiy);
+    double ay = 1. / (1. + phiy);
+    double by = phiy / (1. + phiy);
     double az = 1. / (1. + phiz);
     double bz = phiz / (1. + phiz);
 
@@ -145,7 +147,6 @@ void ChElementBeamTaperedTimoshenko::ShapeFunctionsTimoshenko(ShapeFunctionGroup
     N(3, 3) = Nx1;
     N(3, 9) = Nx2;
 
-
     // Variables named with initial 'k' means block of shape function matrix
     // Variables named with initial 'd' means derivatives respect to x
     // 'd'   --> first derivative
@@ -181,7 +182,7 @@ void ChElementBeamTaperedTimoshenko::ShapeFunctionsTimoshenko(ShapeFunctionGroup
     double dNsu2_dx = 1. / L;
     double dNsr_dx = -1. / 2.;
 
-    double dNbu1_dx = 1. / (2. * L) * ( 3. * eta2 - 3.);
+    double dNbu1_dx = 1. / (2. * L) * (3. * eta2 - 3.);
     double dNbu2_dx = 1. / (2. * L) * (-3. * eta2 + 3.);
 
     double dNbr1_dx = 1. / 4. * (3. * eta2 - 2. * eta - 1.);
@@ -212,16 +213,14 @@ void ChElementBeamTaperedTimoshenko::ShapeFunctionsTimoshenko(ShapeFunctionGroup
     // Continue to fill in the shape functions to finish it.
     // roty
     N(4, 2) = -dNbu1_dx * az;                  // - dNsu1_dx * bz;
-    N(4, 4) =  dNbr1_dx * az + dNbr2_dx * bz;  // + dNsr_dx  * bz;
+    N(4, 4) = dNbr1_dx * az + dNbr2_dx * bz;   // + dNsr_dx  * bz;
     N(4, 8) = -dNbu2_dx * az;                  // - dNsu2_dx * bz;
     N(4, 10) = dNbr3_dx * az + dNbr4_dx * bz;  // + dNsr_dx  * bz;
     // rotz
-    N(5, 1) =  dNbu1_dx * ay;                  // + dNsu1_dx * by;
-    N(5, 5) =  dNbr1_dx * ay + dNbr2_dx * by;  // + dNsr_dx  * by;
-    N(5, 7) =  dNbu2_dx * ay;                  // + dNsu2_dx * by;
+    N(5, 1) = dNbu1_dx * ay;                   // + dNsu1_dx * by;
+    N(5, 5) = dNbr1_dx * ay + dNbr2_dx * by;   // + dNsr_dx  * by;
+    N(5, 7) = dNbu2_dx * ay;                   // + dNsu2_dx * by;
     N(5, 11) = dNbr3_dx * ay + dNbr4_dx * by;  // + dNsr_dx  * by;
-
-
 
     // Second derivatives
     double ddNbu1_dx = 6. * eta / LL;
@@ -240,7 +239,6 @@ void ChElementBeamTaperedTimoshenko::ShapeFunctionsTimoshenko(ShapeFunctionGroup
     ddkNbz_dx.setZero();
     ddkNbz_dx << ddNbu1_dx * az, -ddNbr1_dx * az - ddNbr2_dx * bz, ddNbu2_dx * az, -ddNbr3_dx * az - ddNbr4_dx * bz;
 
-
     // Third derivatives
     double dddNbu1_dx = 12. / LLL;
     double dddNbu2_dx = -12. / LLL;
@@ -252,11 +250,13 @@ void ChElementBeamTaperedTimoshenko::ShapeFunctionsTimoshenko(ShapeFunctionGroup
 
     SFBlock dddkNby_dx;
     dddkNby_dx.setZero();
-    dddkNby_dx << dddNbu1_dx * ay, dddNbr1_dx * ay + dddNbr2_dx * by, dddNbu2_dx * ay, dddNbr3_dx * ay + dddNbr4_dx * by;
+    dddkNby_dx << dddNbu1_dx * ay, dddNbr1_dx * ay + dddNbr2_dx * by, dddNbu2_dx * ay,
+        dddNbr3_dx * ay + dddNbr4_dx * by;
 
     SFBlock dddkNbz_dx;
     dddkNbz_dx.setZero();
-    dddkNbz_dx << dddNbu1_dx * az, -dddNbr1_dx * az - dddNbr2_dx * bz, dddNbu2_dx * az, -dddNbr3_dx * az - dddNbr4_dx * bz;
+    dddkNbz_dx << dddNbu1_dx * az, -dddNbr1_dx * az - dddNbr2_dx * bz, dddNbu2_dx * az,
+        -dddNbr3_dx * az - dddNbr4_dx * bz;
 
     ShapeFunction5Blocks SFblk = std::make_tuple(kNby, kNsy, kNbz, kNsz, kNx);
     ShapeFunction5Blocks SFblk1d = std::make_tuple(dkNby_dx, dkNsy_dx, dkNbz_dx, dkNsz_dx, dkNx_dx);
@@ -269,7 +269,7 @@ void ChElementBeamTaperedTimoshenko::ShapeFunctionsTimoshenko(ShapeFunctionGroup
     std::get<3>(NN) = SFblk2d;
     std::get<4>(NN) = SFblk3d;
 }
-    
+
 void ChElementBeamTaperedTimoshenko::Update() {
     // parent class update:
     ChElementGeneric::Update();
@@ -357,7 +357,6 @@ void ChElementBeamTaperedTimoshenko::GetField_dt(ChVectorDynamic<>& mD_dt) {
     mD_dt.segment(9, 3) = q_element_abs_rot.RotateBack(nodes[1]->Frame().GetWvel_par()).eigen();
 }
 
-
 void ChElementBeamTaperedTimoshenko::GetField_dtdt(ChVectorDynamic<>& mD_dtdt) {
     mD_dtdt.resize(12);
 
@@ -374,19 +373,18 @@ void ChElementBeamTaperedTimoshenko::GetField_dtdt(ChVectorDynamic<>& mD_dtdt) {
     mD_dtdt.segment(9, 3) = q_element_abs_rot.RotateBack(nodes[1]->Frame().GetWacc_par()).eigen();
 }
 
-
 void ChElementBeamTaperedTimoshenko::ComputeTransformMatrix() {
-    double alpha1 = this->taperedSection->GetSectionA()->GetSectionRotation();
-    double Cy1 = this->taperedSection->GetSectionA()->GetCentroidY();
-    double Cz1 = this->taperedSection->GetSectionA()->GetCentroidZ();
-    double Sy1 = this->taperedSection->GetSectionA()->GetShearCenterY();
-    double Sz1 = this->taperedSection->GetSectionA()->GetShearCenterZ();
+    double alpha1 = this->tapered_section->GetSectionA()->GetSectionRotation();
+    double Cy1 = this->tapered_section->GetSectionA()->GetCentroidY();
+    double Cz1 = this->tapered_section->GetSectionA()->GetCentroidZ();
+    double Sy1 = this->tapered_section->GetSectionA()->GetShearCenterY();
+    double Sz1 = this->tapered_section->GetSectionA()->GetShearCenterZ();
 
-    double alpha2 = this->taperedSection->GetSectionB()->GetSectionRotation();
-    double Cy2 = this->taperedSection->GetSectionB()->GetCentroidY();
-    double Cz2 = this->taperedSection->GetSectionB()->GetCentroidZ();
-    double Sy2 = this->taperedSection->GetSectionB()->GetShearCenterY();
-    double Sz2 = this->taperedSection->GetSectionB()->GetShearCenterZ();
+    double alpha2 = this->tapered_section->GetSectionB()->GetSectionRotation();
+    double Cy2 = this->tapered_section->GetSectionB()->GetCentroidY();
+    double Cz2 = this->tapered_section->GetSectionB()->GetCentroidZ();
+    double Sy2 = this->tapered_section->GetSectionB()->GetShearCenterY();
+    double Sz2 = this->tapered_section->GetSectionB()->GetShearCenterZ();
 
     double L = this->length;
 
@@ -421,8 +419,8 @@ void ChElementBeamTaperedTimoshenko::ComputeTransformMatrix() {
     rc(2, 0) = -dCz / LN;
     rc(2, 1) = 0.0;
     rc(2, 2) = LB / LN;
-    //ChMatrixNM<double, 6, 6> Rc;
-    //Rc.setIdentity();
+    // ChMatrixNM<double, 6, 6> Rc;
+    // Rc.setIdentity();
     if (use_Rc) {
         this->Rc.block<3, 3>(0, 0) = rc;
         this->Rc.block<3, 3>(3, 3) = rc;
@@ -472,8 +470,8 @@ void ChElementBeamTaperedTimoshenko::ComputeTransformMatrix() {
     Ts2(1, 3) = -Sz2;
     Ts2(2, 3) = Sy2;
 
-    //ChMatrixNM<double, 6, 6> Rs;
-    //Rs.setIdentity();
+    // ChMatrixNM<double, 6, 6> Rs;
+    // Rs.setIdentity();
     if (use_Rs) {
         this->Rs(3, 3) = C1;
         this->Rs(4, 3) = C2;
@@ -489,19 +487,19 @@ void ChElementBeamTaperedTimoshenko::ComputeTransformMatrix() {
 }
 
 void ChElementBeamTaperedTimoshenko::ComputeTransformMatrixAtPoint(ChMatrixDynamic<>& mT, const double eta) {
-    mT.resize(6,6);
+    mT.resize(6, 6);
 
-    double alpha1 = this->taperedSection->GetSectionA()->GetSectionRotation();
-    double Cy1 = this->taperedSection->GetSectionA()->GetCentroidY();
-    double Cz1 = this->taperedSection->GetSectionA()->GetCentroidZ();
-    double Sy1 = this->taperedSection->GetSectionA()->GetShearCenterY();
-    double Sz1 = this->taperedSection->GetSectionA()->GetShearCenterZ();
+    double alpha1 = this->tapered_section->GetSectionA()->GetSectionRotation();
+    double Cy1 = this->tapered_section->GetSectionA()->GetCentroidY();
+    double Cz1 = this->tapered_section->GetSectionA()->GetCentroidZ();
+    double Sy1 = this->tapered_section->GetSectionA()->GetShearCenterY();
+    double Sz1 = this->tapered_section->GetSectionA()->GetShearCenterZ();
 
-    double alpha2 = this->taperedSection->GetSectionB()->GetSectionRotation();
-    double Cy2 = this->taperedSection->GetSectionB()->GetCentroidY();
-    double Cz2 = this->taperedSection->GetSectionB()->GetCentroidZ();
-    double Sy2 = this->taperedSection->GetSectionB()->GetShearCenterY();
-    double Sz2 = this->taperedSection->GetSectionB()->GetShearCenterZ();
+    double alpha2 = this->tapered_section->GetSectionB()->GetSectionRotation();
+    double Cy2 = this->tapered_section->GetSectionB()->GetCentroidY();
+    double Cz2 = this->tapered_section->GetSectionB()->GetCentroidZ();
+    double Sy2 = this->tapered_section->GetSectionB()->GetShearCenterY();
+    double Sz2 = this->tapered_section->GetSectionB()->GetShearCenterZ();
 
     double L = this->length;
 
@@ -520,7 +518,7 @@ void ChElementBeamTaperedTimoshenko::ComputeTransformMatrixAtPoint(ChMatrixDynam
     double Sy = Nx1 * Sy1 + Nx2 * Sy2;
     double Sz = Nx1 * Sz1 + Nx2 * Sz2;
 
-     // In case the section is rotated:
+    // In case the section is rotated:
     ChMatrix33<> RotsectA;
     RotsectA.Set_A_Rxyz(ChVector<>(alpha, 0, 0));
     ChMatrixNM<double, 6, 6> Rotsect;
@@ -551,92 +549,90 @@ void ChElementBeamTaperedTimoshenko::ComputeTransformMatrixAtPoint(ChMatrixDynam
 }
 
 void ChElementBeamTaperedTimoshenko::ComputeStiffnessMatrix() {
-    assert(taperedSection);
+    assert(tapered_section);
 
     double L = this->length;
     double LL = L * L;
     double LLL = LL * L;
 
-    double EA = this->taperedSection->GetAverageSectionParameters()->EA;
-    double GJ = this->taperedSection->GetAverageSectionParameters()->GJ;
-    double GAyy = this->taperedSection->GetAverageSectionParameters()->GAyy;
-    double GAzz = this->taperedSection->GetAverageSectionParameters()->GAzz;
-    double EIyy = this->taperedSection->GetAverageSectionParameters()->EIyy;
-    double EIzz = this->taperedSection->GetAverageSectionParameters()->EIzz;
+    double EA = this->tapered_section->GetAverageSectionParameters()->EA;
+    double GJ = this->tapered_section->GetAverageSectionParameters()->GJ;
+    double GAyy = this->tapered_section->GetAverageSectionParameters()->GAyy;
+    double GAzz = this->tapered_section->GetAverageSectionParameters()->GAzz;
+    double EIyy = this->tapered_section->GetAverageSectionParameters()->EIyy;
+    double EIzz = this->tapered_section->GetAverageSectionParameters()->EIzz;
 
-    double phiy = this->taperedSection->GetAverageSectionParameters()->phiy;
-    double phiz = this->taperedSection->GetAverageSectionParameters()->phiz;
+    double phiy = this->tapered_section->GetAverageSectionParameters()->phiy;
+    double phiz = this->tapered_section->GetAverageSectionParameters()->phiz;
 
-     double az = 12.0 * EIzz / (LLL * (1 + phiy));
-     double ay = 12.0 * EIyy / (LLL * (1 + phiz));
-     double cz = 6.0 * EIzz / (LL * (1 + phiy));
-     double cy = 6.0 * EIyy / (LL * (1 + phiz));
-     double ez = (4 + phiy) * EIzz / (L * (1 + phiy));
-     double ey = (4 + phiz) * EIyy / (L * (1 + phiz));
-     double fz = (2 - phiy) * EIzz / (L * (1 + phiy));
-     double fy = (2 - phiz) * EIyy / (L * (1 + phiz));
+    double az = 12.0 * EIzz / (LLL * (1 + phiy));
+    double ay = 12.0 * EIyy / (LLL * (1 + phiz));
+    double cz = 6.0 * EIzz / (LL * (1 + phiy));
+    double cy = 6.0 * EIyy / (LL * (1 + phiz));
+    double ez = (4 + phiy) * EIzz / (L * (1 + phiy));
+    double ey = (4 + phiz) * EIyy / (L * (1 + phiz));
+    double fz = (2 - phiy) * EIzz / (L * (1 + phiy));
+    double fy = (2 - phiz) * EIyy / (L * (1 + phiz));
 
-      Km(0, 0) = EA/L;
-      Km(1, 1) = az;
-      Km(2, 2) = ay;
-      Km(3, 3) = GJ/L;
-      Km(4, 4) = ey;
-      Km(5, 5) = ez;
-      Km(6, 6) = EA/L;
-      Km(7, 7) = az;
-      Km(8, 8) = ay;
-      Km(9, 9) = GJ/L;
-      Km(10, 10) = ey;
-      Km(11, 11) = ez;
+    Km(0, 0) = EA / L;
+    Km(1, 1) = az;
+    Km(2, 2) = ay;
+    Km(3, 3) = GJ / L;
+    Km(4, 4) = ey;
+    Km(5, 5) = ez;
+    Km(6, 6) = EA / L;
+    Km(7, 7) = az;
+    Km(8, 8) = ay;
+    Km(9, 9) = GJ / L;
+    Km(10, 10) = ey;
+    Km(11, 11) = ez;
 
-      Km(0, 6) = -EA/L;
-      Km(1, 7) = -az;
-      Km(2, 8) = -ay;
-      Km(3, 9) = -GJ/L;
-      Km(4, 10) = fy;
-      Km(5, 11) = fz;
+    Km(0, 6) = -EA / L;
+    Km(1, 7) = -az;
+    Km(2, 8) = -ay;
+    Km(3, 9) = -GJ / L;
+    Km(4, 10) = fy;
+    Km(5, 11) = fz;
 
-      Km(4, 8) = cy;
-      Km(5, 7) = -cz;
-      Km(1, 11) = cz;
-      Km(2, 10) = -cy;
+    Km(4, 8) = cy;
+    Km(5, 7) = -cz;
+    Km(1, 11) = cz;
+    Km(2, 10) = -cy;
 
-      Km(1, 5) = cz;
-      Km(2, 4) = -cy;
-      Km(7, 11) = -cz;
-      Km(8, 10) = cy;
-    
+    Km(1, 5) = cz;
+    Km(2, 4) = -cy;
+    Km(7, 11) = -cz;
+    Km(8, 10) = cy;
+
     // symmetric part;
     for (int r = 0; r < 12; r++)
         for (int c = r + 1; c < 12; c++)
             Km(c, r) = Km(r, c);
 
-
     Km = this->T.transpose() * Km * this->T;
-
 }
 
 void ChElementBeamTaperedTimoshenko::ComputeDampingMatrix() {
-    assert(taperedSection);
+    assert(tapered_section);
 
     double L = this->length;
     double LL = L * L;
     double LLL = LL * L;
 
-    double EA = this->taperedSection->GetAverageSectionParameters()->EA;
-    double GJ = this->taperedSection->GetAverageSectionParameters()->GJ;
-    double GAyy = this->taperedSection->GetAverageSectionParameters()->GAyy;
-    double GAzz = this->taperedSection->GetAverageSectionParameters()->GAzz;
-    double EIyy = this->taperedSection->GetAverageSectionParameters()->EIyy;
-    double EIzz = this->taperedSection->GetAverageSectionParameters()->EIzz;
+    double EA = this->tapered_section->GetAverageSectionParameters()->EA;
+    double GJ = this->tapered_section->GetAverageSectionParameters()->GJ;
+    double GAyy = this->tapered_section->GetAverageSectionParameters()->GAyy;
+    double GAzz = this->tapered_section->GetAverageSectionParameters()->GAzz;
+    double EIyy = this->tapered_section->GetAverageSectionParameters()->EIyy;
+    double EIzz = this->tapered_section->GetAverageSectionParameters()->EIzz;
 
-    double phiy = this->taperedSection->GetAverageSectionParameters()->phiy;
-    double phiz = this->taperedSection->GetAverageSectionParameters()->phiz;
+    double phiy = this->tapered_section->GetAverageSectionParameters()->phiy;
+    double phiz = this->tapered_section->GetAverageSectionParameters()->phiz;
 
-    double bx2 = pow(this->taperedSection->GetAverageSectionParameters()->rdamping_coeff.bx, 2.0);
-    double by2 = pow(this->taperedSection->GetAverageSectionParameters()->rdamping_coeff.by, 2.0);
-    double bz2 = pow(this->taperedSection->GetAverageSectionParameters()->rdamping_coeff.bz, 2.0);
-    double bt2 = pow(this->taperedSection->GetAverageSectionParameters()->rdamping_coeff.bt, 2.0);
+    double bx2 = pow(this->tapered_section->GetAverageSectionParameters()->rdamping_coeff.bx, 2.0);
+    double by2 = pow(this->tapered_section->GetAverageSectionParameters()->rdamping_coeff.by, 2.0);
+    double bz2 = pow(this->tapered_section->GetAverageSectionParameters()->rdamping_coeff.bz, 2.0);
+    double bt2 = pow(this->tapered_section->GetAverageSectionParameters()->rdamping_coeff.bt, 2.0);
 
     double az = 12.0 * EIzz / (LLL * (1 + phiy));
     double ay = 12.0 * EIyy / (LLL * (1 + phiz));
@@ -686,7 +682,7 @@ void ChElementBeamTaperedTimoshenko::ComputeDampingMatrix() {
 }
 
 void ChElementBeamTaperedTimoshenko::ComputeGeometricStiffnessMatrix() {
-    assert(taperedSection);
+    assert(tapered_section);
 
     // Compute the local geometric stiffness matrix Kg without the P multiplication term, that is Kg*(1/P),
     // so that it is a constant matrix for performance reasons.
@@ -701,14 +697,14 @@ void ChElementBeamTaperedTimoshenko::ComputeGeometricStiffnessMatrix() {
     // Applications of Finite Element Analysis? or in W. McGuire & R.H. Gallagher & R.D. Ziemian, �Matrix Structural
     // Analysis?
 
-    /** 
-    double EA1 = this->taperedSection->GetSectionA()->GetAxialRigidity();
-    double EIyy1 = this->taperedSection->GetSectionA()->GetYbendingRigidity();
-    double EIzz1 = this->taperedSection->GetSectionA()->GetZbendingRigidity();
+    /**
+    double EA1 = this->tapered_section->GetSectionA()->GetAxialRigidity();
+    double EIyy1 = this->tapered_section->GetSectionA()->GetYbendingRigidity();
+    double EIzz1 = this->tapered_section->GetSectionA()->GetZbendingRigidity();
 
-    double EA2 = this->taperedSection->GetSectionB()->GetAxialRigidity();
-    double EIyy2 = this->taperedSection->GetSectionB()->GetYbendingRigidity();
-    double EIzz2 = this->taperedSection->GetSectionB()->GetZbendingRigidity();
+    double EA2 = this->tapered_section->GetSectionB()->GetAxialRigidity();
+    double EIyy2 = this->tapered_section->GetSectionB()->GetYbendingRigidity();
+    double EIzz2 = this->tapered_section->GetSectionB()->GetZbendingRigidity();
 
     double EA = (EA1 + pow(EA1 * EA2, 0.5) + EA2) / 3.0;
     double EIyy = (EIyy1 + pow(EIyy1 * EIyy1 * EIyy1 * EIyy2, 0.25) + pow(EIyy1 * EIyy2, 0.5) +
@@ -722,7 +718,7 @@ void ChElementBeamTaperedTimoshenko::ComputeGeometricStiffnessMatrix() {
     double IyA = EIyy / EA;
     */
 
-    // double L = this->taperedSection->GetLength();
+    // double L = this->tapered_section->GetLength();
     double L = this->length;
 
     double P_L = 1. / L;
@@ -776,13 +772,48 @@ void ChElementBeamTaperedTimoshenko::ComputeGeometricStiffnessMatrix() {
     Kg = this->T.transpose() * Kg * this->T;
 }
 
+void ChElementBeamTaperedTimoshenko::ComputeKiRimatricesLocal(bool inertial_damping, bool inertial_stiffness) {
+    assert(tapered_section);
+
+    if (inertial_damping) {
+        ChVector<> mW_A = this->GetNodeA()->GetWvel_loc();
+        ChVector<> mW_B = this->GetNodeB()->GetWvel_loc();
+        ChMatrixNM<double, 12, 12> mH;
+        this->tapered_section->ComputeInertiaDampingMatrix(mH, mW_A, mW_B);
+        this->Ri = 0.5 * this->length * mH;
+    } else {
+        this->Ri.setZero(this->GetNdofs(), this->GetNdofs());
+    }
+
+    if (inertial_stiffness) {
+        ///< current angular velocity of section of node A, in material frame
+        ChVector<> mWvel_A = this->GetNodeA()->GetWvel_loc();
+        ///< current angular acceleration of section of node A, in material frame
+        ChVector<> mWacc_A = this->GetNodeA()->GetWacc_loc();
+        ///< current acceleration of section of node A, in material frame)
+        ChVector<> mXacc_A = this->GetNodeA()->TransformDirectionParentToLocal(this->GetNodeA()->GetPos_dtdt());
+        ///< current angular velocity of section of node B, in material frame
+        ChVector<> mWvel_B = this->GetNodeB()->GetWvel_loc();
+        ///< current angular acceleration of section of node B, in material frame
+        ChVector<> mWacc_B = this->GetNodeB()->GetWacc_loc();
+        ///< current acceleration of section of node B, in material frame
+        ChVector<> mXacc_B = this->GetNodeB()->TransformDirectionParentToLocal(this->GetNodeB()->GetPos_dtdt());
+
+        ChMatrixNM<double, 12, 12> mH;
+        this->tapered_section->ComputeInertiaStiffnessMatrix(mH, mWvel_A, mWacc_A, mXacc_A, mWvel_B, mWacc_B, mXacc_B);
+        this->Ki = 0.5 * this->length * mH;
+    } else {
+        this->Ki.setZero(this->GetNdofs(), this->GetNdofs());
+    }
+}
+
 void ChElementBeamTaperedTimoshenko::SetupInitial(ChSystem* system) {
-    assert(taperedSection);
+    assert(tapered_section);
 
     // Compute rest length, mass:
     this->length = (nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos()).Length();
-    this->mass = this->length / 2 * this->taperedSection->GetSectionA()->GetMassPerUnitLength() +
-                 this->length / 2 * this->taperedSection->GetSectionB()->GetMassPerUnitLength();
+    this->mass = this->length / 2 * this->tapered_section->GetSectionA()->GetMassPerUnitLength() +
+                 this->length / 2 * this->tapered_section->GetSectionB()->GetMassPerUnitLength();
 
     // Compute initial rotation
     ChMatrix33<> A0;
@@ -795,7 +826,7 @@ void ChElementBeamTaperedTimoshenko::SetupInitial(ChSystem* system) {
     // It could be lumped or consistent mass matrix, depends on SetLumpedMassMatrix(true/false)
     // If it is lumped mass matrix, you need to multiple 0.5 * length to obtain the final mass matrix
     // For consistent mass matrix, don't need to multiple anything.
-    this->taperedSection->ComputeInertiaMatrix(this->M);
+    this->tapered_section->ComputeInertiaMatrix(this->M);
 
     // Compute transformation matrix
     ComputeTransformMatrix();
@@ -808,15 +839,14 @@ void ChElementBeamTaperedTimoshenko::SetupInitial(ChSystem* system) {
 
     // Compute local damping matrix:
     ComputeDampingMatrix();
-
- }
+}
 
 void ChElementBeamTaperedTimoshenko::ComputeKRMmatricesGlobal(ChMatrixRef H,
                                                               double Kfactor,
                                                               double Rfactor,
                                                               double Mfactor) {
     assert((H.rows() == 12) && (H.cols() == 12));
-    assert(taperedSection);
+    assert(tapered_section);
 
     //
     // The K stiffness matrix and R damping matrix of this element:
@@ -880,10 +910,71 @@ void ChElementBeamTaperedTimoshenko::ComputeKRMmatricesGlobal(ChMatrixRef H,
         }
 
         //// For K stiffness matrix and R matrix: scale by factors
-        //CKCt *= Kfactor + Rfactor * this->taperedSection->GetBeamRaleyghDamping();
+        // CKCt *= Kfactor + Rfactor * this->tapered_section->GetBeamRaleyghDamping();
 
         H.block(0, 0, 12, 12) = CKCt * Kfactor + CRCt * Rfactor;
- 
+
+        // Add inertial stiffness matrix and inertial damping matrix (gyroscopic damping),
+        // if enabled in this beam element.
+        // These matrices are not symmetric. Also note.
+        if (this->tapered_section->compute_inertia_damping_matrix ||
+            this->tapered_section->compute_inertia_stiffness_matrix) {
+            ChMatrixNM<double, 12, 12> matr_loc;
+            ChMatrixNM<double, 12, 12> KRi_loc;
+            KRi_loc.setZero();
+            // A lumped version of the inertial damping/stiffness matrix computation is used here, on a per-node basis:
+            double node_multiplier_fact_R = 0.5 * length * Rfactor;
+            double node_multiplier_fact_K = 0.5 * length * Kfactor;
+
+            ///< current angular velocity of section of node A, in material frame
+            ChVector<> mWvel_A = this->GetNodeA()->GetWvel_loc();
+            ///< current angular acceleration of section of node A, in material frame
+            ChVector<> mWacc_A = this->GetNodeA()->GetWacc_loc();
+            ///< current acceleration of section of node A, in material frame)
+            ChVector<> mXacc_A = this->GetNodeA()->TransformDirectionParentToLocal(this->GetNodeA()->GetPos_dtdt());
+            ///< current angular velocity of section of node B, in material frame
+            ChVector<> mWvel_B = this->GetNodeB()->GetWvel_loc();
+            ///< current angular acceleration of section of node B, in material frame
+            ChVector<> mWacc_B = this->GetNodeB()->GetWacc_loc();
+            ///< current acceleration of section of node B, in material frame
+            ChVector<> mXacc_B = this->GetNodeB()->TransformDirectionParentToLocal(this->GetNodeB()->GetPos_dtdt());
+
+            if (this->tapered_section->compute_inertia_damping_matrix) {
+                this->tapered_section->ComputeInertiaDampingMatrix(matr_loc, mWvel_A, mWacc_A);
+                KRi_loc += matr_loc * node_multiplier_fact_R;
+                // check the inertial damping matrix, it should be skew symmetric
+                //if ((matr_loc + matr_loc.transpose()).norm() < 1E-9) {
+                //    std::cout << "Gyroscopic damping matrix is skew symmetric, that's correct！" << std::endl;
+                //} else {
+                //    std::cout << "Gyroscopic damping matrix is NOT skew symmetric, something is wrong!" << std::endl;
+                //}
+            }
+
+            if (this->tapered_section->compute_inertia_stiffness_matrix) {
+                this->tapered_section->ComputeInertiaStiffnessMatrix(matr_loc, mWvel_A, mWacc_A, mXacc_A, mWvel_B,
+                                                                    mWacc_B, mXacc_B);
+                KRi_loc += matr_loc * node_multiplier_fact_K;
+                // check the inertial stiffness matrix, is it must be skew symmetric as the stiffness matrix?
+                //if ((matr_loc + matr_loc.transpose()).norm() < 1E-9) {
+                //    std::cout << "Inertial stiffness matrix is skew symmetric" << std::endl;
+                //} else {
+                //    std::cout << "Inertial stiffness matrix is NOT skew symmetric" << std::endl;
+                //}
+            }
+
+            for (int i = 0; i < nodes.size(); ++i) {
+                int stride = i * 6;
+                // corotate the local damping and stiffness matrices (at once, already scaled) into absolute one
+                // H.block<3, 3>(stride,   stride  ) += nodes[i]->GetA() * KRi_loc.block<3, 3>(0,0) *
+                // (nodes[i]->GetA().transpose()); // NOTE: not needed as KRi_loc.block<3, 3>(0,0) is null by
+                // construction
+                H.block<3, 3>(stride + 3, stride + 3) += KRi_loc.block<3, 3>(3, 3);
+                H.block<3, 3>(stride, stride + 3) += nodes[i]->GetA() * KRi_loc.block<3, 3>(0, 3);
+                // H.block<3, 3>(stride+3, stride)   +=                    KRi_loc.block<3, 3>(3,0) *
+                // (nodes[i]->GetA().transpose()); // NOTE: not needed as KRi_loc.block<3, 3>(3,0) is null by
+                // construction
+            }
+        }
     } else
         H.setZero();
 
@@ -896,9 +987,10 @@ void ChElementBeamTaperedTimoshenko::ComputeKRMmatricesGlobal(ChMatrixRef H,
         Mloc.setZero();
         ChMatrix33<> Mxw;
 
-        // ChMatrixNM<double, 12, 12> sectional_mass = this->M;  // it could be consistent mass matrix, depends on SetLumpedMassMatrix(true/false)
+        // ChMatrixNM<double, 12, 12> sectional_mass = this->M;  // it could be consistent mass matrix, depends on
+        // SetLumpedMassMatrix(true/false)
 
-        if (this->taperedSection->GetLumpedMassMatrixType()) {
+        if (this->tapered_section->GetLumpedMassMatrixType()) {
             double node_multiplier_fact = 0.5 * this->length * Mfactor;
             for (int i = 0; i < nodes.size(); ++i) {
                 int stride = i * 6;
@@ -917,7 +1009,6 @@ void ChElementBeamTaperedTimoshenko::ComputeKRMmatricesGlobal(ChMatrixRef H,
             H.block(0, 0, 12, 12) += Mloc;
 
         } else {
-
             Mloc = this->M * Mfactor;
 
             // The following would be needed if consistent mass matrix is used, but...
@@ -936,7 +1027,6 @@ void ChElementBeamTaperedTimoshenko::ComputeKRMmatricesGlobal(ChMatrixRef H,
             ChMatrixCorotation::ComputeKCt(CK, R, 4, CKCt);
 
             H.block(0, 0, 12, 12) += CKCt;
-
         }
 
         //// TODO better per-node lumping, or 4x4 consistent mass matrices, maybe with integration if not uniform
@@ -946,7 +1036,7 @@ void ChElementBeamTaperedTimoshenko::ComputeKRMmatricesGlobal(ChMatrixRef H,
 
 void ChElementBeamTaperedTimoshenko::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     assert(Fi.size() == 12);
-    assert(taperedSection);
+    assert(tapered_section);
 
     // set up vector of nodal displacements and small rotations (in local element system)
     ChVectorDynamic<> displ(12);
@@ -959,7 +1049,7 @@ void ChElementBeamTaperedTimoshenko::ComputeInternalForces(ChVectorDynamic<>& Fi
     ChVectorDynamic<> displ_dt(12);
     this->GetField_dt(displ_dt);
 
-    //ChMatrixDynamic<> FiR_local = this->taperedSection->GetBeamRaleyghDamping() * this->Km * displ_dt;
+    // ChMatrixDynamic<> FiR_local = this->tapered_section->GetBeamRaleyghDamping() * this->Km * displ_dt;
     ChMatrixDynamic<> FiR_local = this->Rm * displ_dt;
 
     FiK_local += FiR_local;
@@ -989,9 +1079,9 @@ void ChElementBeamTaperedTimoshenko::ComputeInternalForces(ChVectorDynamic<>& Fi
     for (int i = 0; i < nodes.size(); ++i) {
         int stride = i * 6;
         if (i == 0) {
-            this->taperedSection->GetSectionA()->ComputeQuadraticTerms(mFcent_i, mTgyro_i, nodes[i]->GetWvel_loc());
+            this->tapered_section->GetSectionA()->ComputeQuadraticTerms(mFcent_i, mTgyro_i, nodes[i]->GetWvel_loc());
         } else {  // i==1
-            this->taperedSection->GetSectionB()->ComputeQuadraticTerms(mFcent_i, mTgyro_i, nodes[i]->GetWvel_loc());
+            this->tapered_section->GetSectionB()->ComputeQuadraticTerms(mFcent_i, mTgyro_i, nodes[i]->GetWvel_loc());
         }
         ChQuaternion<> q_i(nodes[i]->GetRot());
         Fi.segment(i * 6, 3) -= node_multiplier * (nodes[i]->GetA() * mFcent_i).eigen();
@@ -1021,12 +1111,12 @@ void ChElementBeamTaperedTimoshenko::ComputeInternalForces(ChVectorDynamic<>& Fi
                                                            bool Rfactor,
                                                            bool Gfactor) {
     assert(Fi.size() == 12);
-    assert(taperedSection);
+    assert(tapered_section);
 
     ChVectorDynamic<> FiMKR_local(12);
     FiMKR_local.setZero();
-    
-    if (Mfactor && true) { // Is this correct? Or the code in lines 1072~1090
+
+    if (Mfactor && true) {  // Is this correct? Or the code in lines 1072~1090
         // set up vector of nodal accelerations (in local element system)
         ChVectorDynamic<> displ_dtdt(12);
         this->GetField_dtdt(displ_dtdt);
@@ -1049,7 +1139,7 @@ void ChElementBeamTaperedTimoshenko::ComputeInternalForces(ChVectorDynamic<>& Fi
         ChVectorDynamic<> displ_dt(12);
         this->GetField_dt(displ_dt);
 
-        // ChMatrixDynamic<> FiR_local = this->taperedSection->GetBeamRaleyghDamping() * this->Km * displ_dt;
+        // ChMatrixDynamic<> FiR_local = this->tapered_section->GetBeamRaleyghDamping() * this->Km * displ_dt;
         ChMatrixDynamic<> FiR_local = this->Rm * displ_dt;
         FiMKR_local -= FiR_local;
     }
@@ -1073,22 +1163,22 @@ void ChElementBeamTaperedTimoshenko::ComputeInternalForces(ChVectorDynamic<>& Fi
         // set up vector of nodal accelarations (in absolute element system)
         ChVectorDynamic<> displ_dtdt(12);
         displ_dtdt.segment(0, 3) = nodes[0]->Frame().GetPos_dtdt().eigen();
-        //displ_dtdt.segment(3, 3) = nodes[0]->Frame().GetWacc_par().eigen();        //但是之后dynamics求解发散
-        displ_dtdt.segment(3, 3) = nodes[0]->Frame().GetWacc_loc().eigen();      //但是之后dynamics求解发散
+        // displ_dtdt.segment(3, 3) = nodes[0]->Frame().GetWacc_par().eigen();        //但是之后dynamics求解发散
+        displ_dtdt.segment(3, 3) = nodes[0]->Frame().GetWacc_loc().eigen();  //但是之后dynamics求解发散
 
         displ_dtdt.segment(6, 3) = nodes[1]->Frame().GetPos_dtdt().eigen();
-        //displ_dtdt.segment(9, 3) = nodes[1]->Frame().GetWacc_par().eigen();
-         displ_dtdt.segment(9, 3) = nodes[1]->Frame().GetWacc_loc().eigen();
-        //this->GetField_dtdt(displ_dtdt);
+        // displ_dtdt.segment(9, 3) = nodes[1]->Frame().GetWacc_par().eigen();
+        displ_dtdt.segment(9, 3) = nodes[1]->Frame().GetWacc_loc().eigen();
+        // this->GetField_dtdt(displ_dtdt);
 
         ChMatrixDynamic<> Mabs(12, 12);
         Mabs.setZero();
-        this->ComputeKRMmatricesGlobal(Mabs,false,false,true); // Mabs is the mass matrix in absolute coordinate for this element
+        this->ComputeKRMmatricesGlobal(Mabs, false, false,
+                                       true);  // Mabs is the mass matrix in absolute coordinate for this element
 
         ChVectorDynamic<> FiM_abs = Mabs * displ_dtdt;
         Fi -= FiM_abs;
     }
-
 
     if (Gfactor) {
         // Add also inertial quadratic terms: gyroscopic and centrifugal
@@ -1100,9 +1190,9 @@ void ChElementBeamTaperedTimoshenko::ComputeInternalForces(ChVectorDynamic<>& Fi
         for (int i = 0; i < nodes.size(); ++i) {
             int stride = i * 6;
             if (i == 0) {
-                this->taperedSection->GetSectionA()->ComputeQuadraticTerms(mFcent_i, mTgyro_i, nodes[i]->GetWvel_loc());
+                this->tapered_section->GetSectionA()->ComputeQuadraticTerms(mFcent_i, mTgyro_i, nodes[i]->GetWvel_loc());
             } else {  // i==1
-                this->taperedSection->GetSectionB()->ComputeQuadraticTerms(mFcent_i, mTgyro_i, nodes[i]->GetWvel_loc());
+                this->tapered_section->GetSectionB()->ComputeQuadraticTerms(mFcent_i, mTgyro_i, nodes[i]->GetWvel_loc());
             }
             ChQuaternion<> q_i(nodes[i]->GetRot());
             Fi.segment(i * 6, 3) -= node_multiplier * (nodes[i]->GetA() * mFcent_i).eigen();
@@ -1127,7 +1217,6 @@ void ChElementBeamTaperedTimoshenko::ComputeInternalForces(ChVectorDynamic<>& Fi
 #endif
 }
 
-
 void ChElementBeamTaperedTimoshenko::ComputeGravityForces(ChVectorDynamic<>& Fg, const ChVector<>& G_acc) {
     // no so efficient... a temporary mass matrix here:
     ChMatrixDynamic<> mM(12, 12);
@@ -1144,8 +1233,8 @@ void ChElementBeamTaperedTimoshenko::ComputeGravityForces(ChVectorDynamic<>& Fg,
     // [Maybe one can replace this function with a faster ad-hoc implementation in case of lumped masses.]
     Fg = mM * mG;
 
-    //// TODO for the lumped mass matrix case, the mM * mG product can be unrolled into few multiplications as mM mostly
-    ///zero, and same for mG
+    //// TODO for the lumped mass matrix case, the mM * mG product can be unrolled into few multiplications as mM
+    /// mostly zero, and same for mG
 }
 
 void ChElementBeamTaperedTimoshenko::EvaluateSectionDisplacement(const double eta,
@@ -1153,7 +1242,7 @@ void ChElementBeamTaperedTimoshenko::EvaluateSectionDisplacement(const double et
                                                                  ChVector<>& u_rotaz) {
     ChVectorDynamic<> displ(this->GetNdofs());
     this->GetStateBlock(displ);
-    // No transformation for the displacement of two nodes, 
+    // No transformation for the displacement of two nodes,
     // so the section displacement is evaluated at the centerline of beam
 
     /* old code for Euler beam. Can be removed now.
@@ -1200,7 +1289,6 @@ void ChElementBeamTaperedTimoshenko::EvaluateSectionDisplacement(const double et
     u_rotaz.x() = kNx * qerx;
     u_rotaz.y() = -dkNbz * qez;
     u_rotaz.z() = dkNby * qey;
-
 }
 
 void ChElementBeamTaperedTimoshenko::EvaluateSectionFrame(const double eta, ChVector<>& point, ChQuaternion<>& rot) {
@@ -1226,20 +1314,20 @@ void ChElementBeamTaperedTimoshenko::EvaluateSectionFrame(const double eta, ChVe
 void ChElementBeamTaperedTimoshenko::EvaluateSectionForceTorque0(const double eta,
                                                                  ChVector<>& Fforce,
                                                                  ChVector<>& Mtorque) {
-    //This functionality is the old function for Euler beam, just for test. It can be removed now.
-    assert(taperedSection);
+    // This functionality is the old function for Euler beam, just for test. It can be removed now.
+    assert(tapered_section);
 
-    double EA = this->taperedSection->GetAverageSectionParameters()->EA;
-    double GJ = this->taperedSection->GetAverageSectionParameters()->GJ;
-    double GAyy = this->taperedSection->GetAverageSectionParameters()->GAyy;
-    double GAzz = this->taperedSection->GetAverageSectionParameters()->GAzz;
-    double EIyy = this->taperedSection->GetAverageSectionParameters()->EIyy;
-    double EIzz = this->taperedSection->GetAverageSectionParameters()->EIzz;
-    double alpha = this->taperedSection->GetAverageSectionParameters()->alpha;
-    double Cy = this->taperedSection->GetAverageSectionParameters()->Cy;
-    double Cz = this->taperedSection->GetAverageSectionParameters()->Cz;
-    double Sy = this->taperedSection->GetAverageSectionParameters()->Sy;
-    double Sz = this->taperedSection->GetAverageSectionParameters()->Sz;
+    double EA = this->tapered_section->GetAverageSectionParameters()->EA;
+    double GJ = this->tapered_section->GetAverageSectionParameters()->GJ;
+    double GAyy = this->tapered_section->GetAverageSectionParameters()->GAyy;
+    double GAzz = this->tapered_section->GetAverageSectionParameters()->GAzz;
+    double EIyy = this->tapered_section->GetAverageSectionParameters()->EIyy;
+    double EIzz = this->tapered_section->GetAverageSectionParameters()->EIzz;
+    double alpha = this->tapered_section->GetAverageSectionParameters()->alpha;
+    double Cy = this->tapered_section->GetAverageSectionParameters()->Cy;
+    double Cz = this->tapered_section->GetAverageSectionParameters()->Cz;
+    double Sy = this->tapered_section->GetAverageSectionParameters()->Sy;
+    double Sz = this->tapered_section->GetAverageSectionParameters()->Sz;
 
     // The shear center offset should be respect to elastic cetner.
     Sy = Sy - Cy;
@@ -1355,20 +1443,18 @@ void ChElementBeamTaperedTimoshenko::EvaluateSectionForceTorque0(const double et
         ChVectorN<double, 6> wrench = Klaw_r * sect_ek;
         Fforce = wrench.segment(0, 3);
         Mtorque = wrench.segment(3, 3);
-
     }
 }
 
 void ChElementBeamTaperedTimoshenko::EvaluateSectionForceTorque(const double eta,
                                                                 ChVector<>& Fforce,
                                                                 ChVector<>& Mtorque) {
-    assert(taperedSection);
+    assert(tapered_section);
 
     ChVectorDynamic<> displ(this->GetNdofs());
     this->GetStateBlock(displ);
 
     ChVectorDynamic<> displ_ec = this->T * displ;  // transform the displacement of two nodes to elastic axis
-
 
     ChVectorN<double, 4> qey;
     qey << displ_ec(1), displ_ec(5), displ_ec(7), displ_ec(11);
@@ -1392,16 +1478,17 @@ void ChElementBeamTaperedTimoshenko::EvaluateSectionForceTorque(const double eta
     auto dddkNby = std::get<0>(sfblk3d);
     auto dddkNbz = std::get<1>(sfblk3d);
 
-    double EA = this->taperedSection->GetAverageSectionParameters()->EA;
-    double GJ = this->taperedSection->GetAverageSectionParameters()->GJ;
-    double GAyy = this->taperedSection->GetAverageSectionParameters()->GAyy;
-    double GAzz = this->taperedSection->GetAverageSectionParameters()->GAzz;
-    double EIyy = this->taperedSection->GetAverageSectionParameters()->EIyy;
-    double EIzz = this->taperedSection->GetAverageSectionParameters()->EIzz;
+    double EA = this->tapered_section->GetAverageSectionParameters()->EA;
+    double GJ = this->tapered_section->GetAverageSectionParameters()->GJ;
+    double GAyy = this->tapered_section->GetAverageSectionParameters()->GAyy;
+    double GAzz = this->tapered_section->GetAverageSectionParameters()->GAzz;
+    double EIyy = this->tapered_section->GetAverageSectionParameters()->EIyy;
+    double EIzz = this->tapered_section->GetAverageSectionParameters()->EIzz;
 
     double eps = 1.0e-3;
     bool use_shear_stain = true;  // As default, use shear strain to evaluate the shear forces
-    if (abs(GAyy) < eps || abs(GAzz) < eps) {  // Sometimes, the user will not input GAyy, GAzz, so GAyy, GAzz may be zero.
+    if (abs(GAyy) < eps ||
+        abs(GAzz) < eps) {  // Sometimes, the user will not input GAyy, GAzz, so GAyy, GAzz may be zero.
         use_shear_stain = false;
     }
 
@@ -1422,17 +1509,16 @@ void ChElementBeamTaperedTimoshenko::EvaluateSectionForceTorque(const double eta
         sect_ek(2) = -dddkNbz * qez;  // Fz == -EIyy *  dddkNbz * qez == GAzz * dkNsz * qez;
     }
 
-
-    /* 
+    /*
     // e_x
     sect_ek(0) = (dN_xa * displ(0) + dN_xb * displ(6));  // x_a   x_b
     // e_y
     sect_ek(1) = (dddN_ua * displ(1) + dddN_ub * displ(7) +   // y_a   y_b
                   dddN_ra * displ(5) + dddN_rb * displ(11));  // Rz_a  Rz_b
     // e_z
-    sect_ek(2) = (-dddN_ua * displ(2) - dddN_ub * displ(8) +  // z_a   z_b   note - sign  TODO: need to check the sign
-                  dddN_ra * displ(4) + dddN_rb * displ(10));  // Ry_a  Ry_b
-    sect_ek(2) *= -1;  // TODO: need to check the sign of curvature, it depends on your definition
+    sect_ek(2) = (-dddN_ua * displ(2) - dddN_ub * displ(8) +  // z_a   z_b   note - sign  TODO: need to check the
+    sign dddN_ra * displ(4) + dddN_rb * displ(10));  // Ry_a  Ry_b sect_ek(2) *= -1;  // TODO: need to check the
+    sign of curvature, it depends on your definition
 
     // k_x
     sect_ek(3) = (dN_xa * displ(3) + dN_xb * displ(9));  // Rx_a  Rx_b
@@ -1460,19 +1546,18 @@ void ChElementBeamTaperedTimoshenko::EvaluateSectionForceTorque(const double eta
         Mtorque.y() = EIyy * sect_ek(4);
         Mtorque.z() = EIzz * sect_ek(5);
     } else {
-        
         // Constitutive matrix of the beam:
         ChMatrixNM<double, 6, 6> Klaw_d;
         Klaw_d.setZero();
-        Klaw_d(0,0) = EA;
-        Klaw_d(3,3) = GJ;
-        Klaw_d(4,4)=  EIyy;
-        Klaw_d(5,5) = EIzz;
+        Klaw_d(0, 0) = EA;
+        Klaw_d(3, 3) = GJ;
+        Klaw_d(4, 4) = EIyy;
+        Klaw_d(5, 5) = EIzz;
 
         if (use_shear_stain) {
             Klaw_d(1, 1) = GAyy;
             Klaw_d(2, 2) = GAzz;
-        }else{
+        } else {
             Klaw_d(1, 1) = EIzz;
             Klaw_d(2, 2) = EIyy;
         }
@@ -1489,7 +1574,6 @@ void ChElementBeamTaperedTimoshenko::EvaluateSectionForceTorque(const double eta
         ChVectorN<double, 6> wrench = Klaw_r * sect_ek;
         Fforce = wrench.segment(0, 3);
         Mtorque = wrench.segment(3, 3);
-
     }
 }
 
@@ -1570,8 +1654,8 @@ void ChElementBeamTaperedTimoshenko::ComputeNF(const double U,
 }
 
 double ChElementBeamTaperedTimoshenko::GetDensity() {
-    double mu1 = this->taperedSection->GetSectionA()->GetMassPerUnitLength();
-    double mu2 = this->taperedSection->GetSectionB()->GetMassPerUnitLength();
+    double mu1 = this->tapered_section->GetSectionA()->GetMassPerUnitLength();
+    double mu2 = this->tapered_section->GetSectionB()->GetMassPerUnitLength();
     double mu = (mu1 + mu2) / 2.0;
 
     return mu;

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenko.h
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenko.h
@@ -40,18 +40,22 @@ class ChApi ChElementBeamTaperedTimoshenko : public ChElementBeam,
                                  public ChLoadableU,
                                  public ChLoadableUVW,
                                  public ChElementCorotational {
-  public:
+  private:
+    // only used inside this Class
+    // to store the shape functions
     using ShapeVector = ChMatrixNM<double, 1, 10>;
 
     using ShapeFunctionN = ChMatrixNM<double, 6, 12>;
     using SFBlock = ChMatrixNM<double, 1, 4>;
-    using ShapeFunction5Blocks = std::tuple<SFBlock,SFBlock,SFBlock,SFBlock,ChMatrixNM<double, 1, 2>>;
-    using ShapeFunction2Blocks = std::tuple<SFBlock,SFBlock>;
-    using ShapeFunctionGroup = std::tuple<ShapeFunctionN,  //  restore shape function
-        ShapeFunction5Blocks, // restore blocks of shape function
-        ShapeFunction5Blocks, // restore blocks of first derivatives
-        ShapeFunction2Blocks, // restore blocks of second derivatives
-        ShapeFunction2Blocks>; // restore blocks of thrid derivatives
+    using ShapeFunction5Blocks = std::tuple<SFBlock, SFBlock, SFBlock, SFBlock, ChMatrixNM<double, 1, 2>>;
+    using ShapeFunction2Blocks = std::tuple<SFBlock, SFBlock>;
+    using ShapeFunctionGroup = std::tuple<ShapeFunctionN,         // restore shape function
+                                          ShapeFunction5Blocks,   // restore blocks of shape function
+                                          ShapeFunction5Blocks,   // restore blocks of first derivatives
+                                          ShapeFunction2Blocks,   // restore blocks of second derivatives
+                                          ShapeFunction2Blocks>;  // restore blocks of thrid derivatives
+
+  public:
 
     ChElementBeamTaperedTimoshenko();
 
@@ -129,7 +133,7 @@ class ChApi ChElementBeamTaperedTimoshenko : public ChElementBeam,
     ///      | .    .   -6  .   8   .   .   .   -7  .   9   .   |
     ///      | .    6   .   .   .   8   .   7   .   .   .   9   |
     /// // Old shape functions here, just for test
-    void ShapeFunctions(ShapeVector& N, double eta);
+    void ShapeFunctionsEuler(ShapeVector& N, double eta);
 
     // New shape functions for Timoshenko beam
     void ShapeFunctionsTimoshenko(ShapeFunctionGroup& NN, double eta);

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenko.h
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenko.h
@@ -72,10 +72,10 @@ class ChApi ChElementBeamTaperedTimoshenko : public ChElementBeam,
     /// Set the section & material of beam element .
     /// It is a shared property, so it can be shared between other beams.
     void SetTaperedSection(std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGeneric> my_material) {
-        taperedSection = my_material;
+        tapered_section = my_material;
     }
     /// Get the section & material of the element
-    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGeneric> GetTaperedSection() { return taperedSection; }
+    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGeneric> GetTaperedSection() { return tapered_section; }
 
     /// Get the first node (beginning)
     std::shared_ptr<ChNodeFEAxyzrot> GetNodeA() { return nodes[0]; }
@@ -115,7 +115,6 @@ class ChApi ChElementBeamTaperedTimoshenko : public ChElementBeam,
 
     void SetUseRc(bool md) { this->use_Rc = md; }
     void SetUseRs(bool md) { this->use_Rs = md; }
-
 
     /// Fills the N matrix (compressed! single row, 12 columns) with the
     /// values of shape functions at abscissa 'eta'.
@@ -173,6 +172,9 @@ class ChApi ChElementBeamTaperedTimoshenko : public ChElementBeam,
     /// is computed only at the beginning, and later it is multiplied by P all times the real Kg is needed.
     /// If you later change some material property, call this or InitialSetup().
     void ComputeGeometricStiffnessMatrix();
+
+    void ComputeKiRimatricesLocal(bool inertial_damping, bool inertial_stiffness);
+
 
     /// Sets H as the global stiffness matrix K, scaled  by Kfactor. Optionally, also
     /// superimposes global damping matrix R, scaled by Rfactor, and global mass matrix M multiplied by Mfactor.
@@ -305,13 +307,14 @@ class ChApi ChElementBeamTaperedTimoshenko : public ChElementBeam,
 
     std::vector<std::shared_ptr<ChNodeFEAxyzrot> > nodes;
 
-    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGeneric> taperedSection;
+    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGeneric> tapered_section;
 
     ChMatrixDynamic<> Km;  ///< local material  stiffness matrix
     ChMatrixDynamic<> Kg;  ///< local geometric stiffness matrix NORMALIZED by P
     ChMatrixDynamic<> M;   ///< local material mass matrix, it could be lumped or consistent mass matrix, depends on SetLumpedMassMatrix(true/false)
     ChMatrixDynamic<> Rm;   ///< local material damping matrix
-
+    ChMatrixDynamic<> Ri;   ///< local inertial-damping (gyroscopic damping) matrix
+    ChMatrixDynamic<> Ki;   ///< local inertial-stiffness matrix
 
     ChQuaternion<> q_refrotA;
     ChQuaternion<> q_refrotB;
@@ -325,6 +328,15 @@ class ChApi ChElementBeamTaperedTimoshenko : public ChElementBeam,
     bool use_geometric_stiffness;
     bool use_Rc;
     bool use_Rs;
+     
+    /// Flag that turns on/off the computation of the [Ri] 'gyroscopic' inertial damping matrix.
+    /// If false, Ri=0. Can be used for cpu speedup, profiling, tests. Default: true.
+    //bool compute_inertia_damping_matrix = true;
+
+    /// Flag that turns on/off the computation of the [Ki] inertial stiffness matrix.
+    /// If false, Ki=0. Can be used for cpu speedup, profiling, tests. Default: true.
+    //bool compute_inertia_stiffness_matrix = true;
+
 
     ChMatrixDynamic<> T; ///< transformation matrix for two nodes, from centerline to elastic axis
     ChMatrixDynamic<> Rc;

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.cpp
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.cpp
@@ -13,14 +13,134 @@
 // =============================================================================
 
 //#define BEAM_VERBOSE
-
+#include "chrono/core/ChQuadrature.h"
 #include "chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h"
 
 namespace chrono {
 namespace fea {
+void ChElementBeamTaperedTimoshenkoFPM::ShapeFunctionsTimoshenkoFPM(ShapeFunctionGroupFPM& NB, double eta) {
+    // The shape functions have referenced two papers below, especially the first one:
+    // Alexander R.Stäblein,and Morten H.Hansen.
+    // "Timoshenko beam element with anisotropic cross-sectional properties." %
+    // ECCOMAS Congress 2016, VII European Congress on Computational Methods in Applied Sciences and Engineering.
+    // Crete Island, Greece, 5 - 10 June 2016
+    // 
+    // Taeseong Kim, Anders M.Hansen,and Kim Branner.
+    // "Development of an anisotropic beam finite element for composite wind turbine blades in multibody system." 
+    // Renewable Energy 59(2013) : 172 - 183.
+    
+    // eta = 2 * x/L;
+    // x = (-L/2, L/2),  hence eta = (-1, 1)
+    double L = this->length;
+    double LL = L * L;
+    double LLL = LL * L;
+    double eta1 = (eta + 1) / 2.0;
+    double eta2 = eta1 * eta1;
+    double eta3 = eta2 * eta1;
+
+    ChMatrixNM<double, 6, 14> Ax;    
+    Ax.setZero();
+    ChMatrixNM<double, 6, 14> dAx;
+    dAx.setZero();
+    ChMatrixNM<double, 14, 14> Ex;
+    Ex.setZero();
+    ChMatrixNM<double, 14, 14> Ex_inv;
+    Ex_inv.setZero();
+    ChMatrixNM<double, 6, 12> Nx;
+    Nx.setZero();
+    ChMatrixNM<double, 6, 12> dNx;
+    dNx.setZero();
+
+    // The coefficient matrix of the displacements and rotations with respect to the shape function coefficient vector c_v
+    // note: the shape function coefficient vector is as below:
+    // c_v = [c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c13 c14 c11 c12].';  // notice the order of c11 c12 c13 c14
+    Ax.row(0) << L * eta1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    Ax.row(1) << 0, 0, LLL * eta3, LL * eta2, L * eta1, 1, 0, 0, 0, 0, 0, 0, 0, 0;
+    Ax.row(2) << 0, 0, 0, 0, 0, 0, LLL * eta3, LL * eta2, L * eta1, 1, 0, 0, 0, 0;
+    Ax.row(3) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, L * eta1, 1;
+    Ax.row(4) << 0, 0, 0, 0, 0, 0, -3 * LL * eta2, -2 * L * eta1, -1, 0, 1, 0, 0, 0;
+    Ax.row(5) << 0, 0, 3 * LL * eta2, 2 * L * eta1, 1, 0, 0, 0, 0, 0, 0, -1, 0, 0;
+
+    // The derivative of Ax
+    dAx.row(0) << 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,0 ;
+    dAx.row(1) << 0, 0, 3 * LL * eta2, 2 * L * eta1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    dAx.row(2) << 0, 0, 0, 0, 0, 0, 3 * LL * eta2, 2 * L * eta1, 1, 0, 0, 0, 0, 0;
+    dAx.row(3) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0;
+    dAx.row(4) << 0, 0, 0, 0, 0, 0, -6 * L * eta1, -2, 0, 0, 0, 0, 0, 0;
+    dAx.row(5) << 0, 0, 6 * L * eta1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+
+    // A temporary transformation matrix
+    ChMatrixNM<double, 14, 12> Ttemp;
+    Ttemp.setZero();
+    Ttemp.block<12, 12>(2, 0).setIdentity();
+
+    // the cross-sectional material stiffness matrix Klaw along beam element may be variant
+    // due to different Klaw at two ends of tapered-sectional beam
+    ChMatrixNM<double, 6, 6> Klaw_point = this->tapered_section_fpm->GetKlawAtPoint(eta);
+    //double k11 = Klaw_point(0, 0);
+    double k12 = Klaw_point(0, 1);
+    double k13 = Klaw_point(0, 2);
+    //double k14 = Klaw_point(0, 3);
+    //double k15 = Klaw_point(0, 4);
+    //double k16 = Klaw_point(0, 5);
+    double k22 = Klaw_point(1, 1);
+    double k23 = Klaw_point(1, 2);
+    double k24 = Klaw_point(1, 3);
+    double k25 = Klaw_point(1, 4);
+    double k26 = Klaw_point(1, 5);
+    double k33 = Klaw_point(2, 2);
+    double k34 = Klaw_point(2, 3);
+    double k35 = Klaw_point(2, 4);
+    double k36 = Klaw_point(2, 5);
+    //double k44 = Klaw_point(3, 3);
+    //double k45 = Klaw_point(3, 4);
+    //double k46 = Klaw_point(3, 5);
+    double k55 = Klaw_point(4, 4);
+    double k56 = Klaw_point(4, 5);
+    double k66 = Klaw_point(5, 5);
+    
+    // The coefficient matrix of the equilibrium and compatibility equations
+    // with respect to the shape function coefficient vector c_v
+    Ex.row(0) << -k13, 0, 6 * k56 - 3 * L * k36 - 3 * L * eta * k36, -2 * k36, 0, 0,
+        3 * L * k35 - 6 * k55 + 3 * L * eta * k35, 2 * k35, 0, 0, -k33, -k23, -k34, 0;
+    Ex.row(1) << k12, 0, 6 * k66 + 3 * L * k26 + 3 * L * eta * k26, 2 * k26, 0, 0, 
+        -6 * k56 - 3 * L * k25 - 3 * L * eta * k25, -2 * k25, 0, 0, k23, k22, k24, 0;
+    Ex.row(2) << 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    Ex.row(3) << 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0;
+    Ex.row(4) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0;
+    Ex.row(5) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1;
+    Ex.row(6) << 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 1, 0, 0, 0;
+    Ex.row(7) << 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, -1, 0, 0;
+    Ex.row(8) << L, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+    Ex.row(9) << 0, 0, LLL, LL, L, 1, 0, 0, 0, 0, 0, 0, 0, 0;
+    Ex.row(10) << 0, 0, 0, 0, 0, 0, LLL, LL, L, 1, 0, 0, 0, 0;
+    Ex.row(11) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, L, 1;
+    Ex.row(12) << 0, 0, 0, 0, 0, 0, -3 * LL, -2 * L, -1, 0, 1, 0, 0, 0;
+    Ex.row(13) << 0, 0, 3 * LL, 2 * L, 1, 0, 0, 0, 0, 0, 0, -1, 0, 0;
+
+    // The inverse of Ex
+    Ex_inv = Ex.inverse();
+
+    // The shape function matrix at dimensionless position eta
+    Nx = Ax * Ex_inv * Ttemp;
+    // and its derivative
+    dNx = dAx * Ex_inv * Ttemp;  // DO NOT add Ax * dEx_inv * Ttemp, see the first paper please.
+
+    // A temporary matrix
+    ChMatrixNM<double, 6, 6> TNtemp;
+    TNtemp.setZero();
+    TNtemp(1, 5) = -1.0;
+    TNtemp(2, 4) = 1.0;
+
+    // The strain displacement matrix at dimensionless position eta
+    ChMatrixNM<double, 6, 12> Bx = dNx + TNtemp * Nx;
+
+    // return result
+    NB = std::make_tuple(Nx, Bx);
+}
 
 
-void ChElementBeamTaperedTimoshenkoFPM::ComputeStiffnessMatrix() {
+void ChElementBeamTaperedTimoshenkoFPM::ComputeStiffnessMatrix0() {
     assert(tapered_section_fpm);
 
     double L = this->length;
@@ -148,7 +268,7 @@ void ChElementBeamTaperedTimoshenkoFPM::ComputeStiffnessMatrix() {
     Km = this->T.transpose() * Km * this->T;
 }
 
-void ChElementBeamTaperedTimoshenkoFPM::ComputeDampingMatrix() {
+void ChElementBeamTaperedTimoshenkoFPM::ComputeDampingMatrix0() {
     assert(tapered_section_fpm);
 
     double L = this->length;
@@ -290,6 +410,117 @@ void ChElementBeamTaperedTimoshenkoFPM::ComputeDampingMatrix() {
     Rm = this->T.transpose() * Rm * this->T;
 }
 
+/// This class defines the calculations for the integrand of 
+/// the cross-sectional stiffness/damping/mass matrices
+class BeamTaperedTimoshenkoFPM : public ChIntegrable1D<ChMatrixNM<double, 12, 12>> {
+  public:
+    BeamTaperedTimoshenkoFPM(ChElementBeamTaperedTimoshenkoFPM* element, const int option)
+        : m_element(element), m_choice_KiRiMi(option) {}
+    ~BeamTaperedTimoshenkoFPM() {}
+
+    void SetChoiceKiRiMi(int mv) { m_choice_KiRiMi = mv; }
+    int GetChoiceKiRiMi() { return m_choice_KiRiMi; }
+
+  private:
+    ChElementBeamTaperedTimoshenkoFPM* m_element;
+    // 0: stiffness matrix
+    // 1: damping matrix
+    // 2: mass matix
+    int m_choice_KiRiMi = 0;
+
+    virtual void Evaluate(ChMatrixNM<double, 12, 12>& result, const double x) override;
+};
+
+void BeamTaperedTimoshenkoFPM::Evaluate(ChMatrixNM<double, 12, 12>& result,const double x) {
+    ChElementBeamTaperedTimoshenkoFPM::ShapeFunctionGroupFPM NxBx;
+    double eta = x;
+    m_element->ShapeFunctionsTimoshenkoFPM(NxBx,eta);
+    auto tapered_section_fpm = m_element->GetTaperedSection();
+    auto Klaw_point = tapered_section_fpm->GetKlawAtPoint(eta);
+    auto Rlaw_point = tapered_section_fpm->GetRlawAtPoint(eta);
+    auto Mlaw_point = tapered_section_fpm->GetMlawAtPoint(eta);
+
+    // shape function matrix
+    ChMatrixNM<double, 6, 12> Nx = std::get<0>(NxBx);
+    // strain-displacement relation matrix
+    ChMatrixNM<double, 6, 12> Bx = std::get<1>(NxBx);
+
+    switch (m_choice_KiRiMi) {
+        case 0:
+            result = Bx.transpose() * Klaw_point * Bx;
+            break;
+        case 1:
+            result = Bx.transpose() * Rlaw_point * Bx; // modified Rayleigh damping model
+            break;
+        case 2:
+            result = Nx.transpose() * Mlaw_point * Nx;
+            break;
+        default:
+            std::cout << "Please input the correct option: 0,1,2" <<std::endl;
+            return;
+    }
+};
+
+void ChElementBeamTaperedTimoshenkoFPM::ComputeStiffnessMatrix() {
+    // Calculate the local element stiffness matrix via Guass integration
+    this->Km.setZero();
+    BeamTaperedTimoshenkoFPM myformula(this,0);  // 0: stiffness matrix
+    ChMatrixNM<double, 12, 12> TempStiffnessMatrix;
+    TempStiffnessMatrix.setZero();
+    ChQuadrature::Integrate1D<ChMatrixNM<double, 12, 12>>(TempStiffnessMatrix,  // result of integration will go there
+                                                          myformula,       // formula to integrate
+                                                          -1, 1,           // x limits
+                                                          guass_order      // order of integration
+    );
+
+    this->Km = this->T.transpose() * TempStiffnessMatrix * this->T;
+}
+
+
+void ChElementBeamTaperedTimoshenkoFPM::ComputeDampingMatrix() {
+    // Calculate the local element damping matrix via Guass integration
+    this->Rm.setZero();
+    BeamTaperedTimoshenkoFPM myformula(this, 1);  // 1: damping matrix
+    ChMatrixNM<double, 12, 12> TempDampingMatrix;
+    TempDampingMatrix.setZero();
+    ChQuadrature::Integrate1D<ChMatrixNM<double, 12, 12>>(TempDampingMatrix,  // result of integration will go there
+                                                          myformula,            // formula to integrate
+                                                          -1, 1,                // x limits
+                                                          guass_order           // order of integration
+    );
+
+    this->Rm = this->T.transpose() * TempDampingMatrix * this->T;
+}
+
+void ChElementBeamTaperedTimoshenkoFPM::ComputeConsistentMassMatrix() {
+    // Calculate the local element mass matrix via Guass integration
+    this->M.setZero();
+    BeamTaperedTimoshenkoFPM myformula(this, 2);  // 2: mass matrix
+    ChMatrixNM<double, 12, 12> TempMassMatrix;
+    TempMassMatrix.setZero();
+    ChQuadrature::Integrate1D<ChMatrixNM<double, 12, 12>>(TempMassMatrix,  // result of integration will go there
+                                                          myformula,          // formula to integrate
+                                                          -1, 1,              // x limits
+                                                          guass_order         // order of integration
+    );
+    this->M = TempMassMatrix;
+    // If the cross-sectional mass properties are gives at the mass center, 
+    // then it should be transformed to the centerline firstly, 
+    // this is handled in the Class ChBeamSectionTimoshenkoAdvancedGenericFPM. NOT HERE.
+}
+
+void ChElementBeamTaperedTimoshenkoFPM::ComputeMassMatrix() {
+    // Compute mass matrix of local element
+    // It could be lumped or consistent mass matrix, depends on SetLumpedMassMatrix(true/false)
+    if (this->tapered_section_fpm->GetLumpedMassMatrixType()) {
+        // If it is lumped mass matrix, you need to multiple 0.5 * length to obtain the final mass matrix
+        // For consistent mass matrix, don't need to multiple anything.
+        this->tapered_section_fpm->ComputeInertiaMatrix(this->M);
+    } else {
+        ComputeConsistentMassMatrix();
+    }
+}
+
 
 void ChElementBeamTaperedTimoshenkoFPM::SetupInitial(ChSystem* system) {
     assert(tapered_section_fpm);
@@ -306,15 +537,11 @@ void ChElementBeamTaperedTimoshenkoFPM::SetupInitial(ChSystem* system) {
     A0.Set_A_Xdir(mXele, myele);
     q_element_ref_rot = A0.Get_A_quaternion();
 
-
-    // Compute local mass matrix
-    // It could be lumped or consistent mass matrix, depends on SetLumpedMassMatrix(true/false)
-    // If it is lumped mass matrix, you need to multiple 0.5 * length to obtain the final mass matrix
-    // For consistent mass matrix, don't need to multiple anything.
-    this->tapered_section_fpm->ComputeInertiaMatrix(this->M);
-
     // Compute transformation matrix
     ComputeTransformMatrix();
+
+    // Compute local mass matrix:
+    ComputeMassMatrix();
 
     // Compute local stiffness matrix:
     ComputeStiffnessMatrix();
@@ -326,6 +553,33 @@ void ChElementBeamTaperedTimoshenkoFPM::SetupInitial(ChSystem* system) {
     ComputeDampingMatrix();
 }
 
+
+void ChElementBeamTaperedTimoshenkoFPM::EvaluateSectionDisplacement(const double eta,
+                                                                    ChVector<>& u_displ,
+                                                                    ChVector<>& u_rotaz) {
+
+    ChVectorDynamic<> displ(this->GetNdofs());
+    this->GetStateBlock(displ);
+    // No transformation for the displacement of two nodes,
+    // so the section displacement is evaluated at the centerline of beam
+
+    ShapeFunctionGroupFPM NxBx;
+    ShapeFunctionsTimoshenkoFPM(NxBx, eta);
+    // the shape function matrix
+    ChMatrixNM<double, 6, 12> Nx = std::get<0>(NxBx);
+
+    // the displacements and rotations, as a vector
+    ChVectorDynamic<> u_vector = Nx * displ;
+
+    u_displ.x() = u_vector(0);
+    u_displ.y() = u_vector(1);
+    u_displ.z() = u_vector(2);
+    u_rotaz.x() = u_vector(3);
+    u_rotaz.y() = u_vector(4);
+    u_rotaz.z() = u_vector(5);
+
+}
+
 void ChElementBeamTaperedTimoshenkoFPM::EvaluateSectionForceTorque(const double eta,
                                                                 ChVector<>& Fforce,
                                                                 ChVector<>& Mtorque) {
@@ -334,97 +588,87 @@ void ChElementBeamTaperedTimoshenkoFPM::EvaluateSectionForceTorque(const double 
     ChVectorDynamic<> displ(this->GetNdofs());
     this->GetStateBlock(displ);
 
-    ChVectorDynamic<> displ_ec = this->T * displ;  // transform the displacement of two nodes to elastic axis
+    // transform the displacement of two nodes to elastic axis
+    ChVectorDynamic<> displ_ec = this->T * displ;  
 
-    ChVectorN<double, 4> qey;
-    qey << displ_ec(1), displ_ec(5), displ_ec(7), displ_ec(11);
-    ChVectorN<double, 4> qez;
-    qez << displ_ec(2), displ_ec(4), displ_ec(8), displ_ec(10);
-    ChVectorN<double, 2> qeux;
-    qeux << displ_ec(0), displ_ec(6);
-    ChVectorN<double, 2> qerx;
-    qerx << displ_ec(3), displ_ec(9);
-
-    ShapeFunctionGroup NN;
-    ShapeFunctionsTimoshenko(NN, eta);
-    ShapeFunction5Blocks sfblk1d = std::get<2>(NN);
-    ShapeFunction2Blocks sfblk2d = std::get<3>(NN);
-    ShapeFunction2Blocks sfblk3d = std::get<4>(NN);
-    auto dkNx1 = std::get<4>(sfblk1d);
-    auto dkNsy = std::get<1>(sfblk1d);
-    auto dkNsz = std::get<3>(sfblk1d);
-    auto ddkNby = std::get<0>(sfblk2d);
-    auto ddkNbz = std::get<1>(sfblk2d);
-    auto dddkNby = std::get<0>(sfblk3d);
-    auto dddkNbz = std::get<1>(sfblk3d);
-
-    double EA = this->tapered_section_fpm->GetAverageSectionParameters()->EA;
-    double GJ = this->tapered_section_fpm->GetAverageSectionParameters()->GJ;
-    double GAyy = this->tapered_section_fpm->GetAverageSectionParameters()->GAyy;
-    double GAzz = this->tapered_section_fpm->GetAverageSectionParameters()->GAzz;
-    double EIyy = this->tapered_section_fpm->GetAverageSectionParameters()->EIyy;
-    double EIzz = this->tapered_section_fpm->GetAverageSectionParameters()->EIzz;
-    
-    double eps = 1.0e-3;
-    bool use_shear_stain = true;  // As default, use shear strain to evaluate the shear forces
-    if (abs(GAyy) < eps ||
-        abs(GAzz) < eps) {  // Sometimes, the user will not input GAyy, GAzz, so GAyy, GAzz may be zero.
-        use_shear_stain = false;
-    }
+    ShapeFunctionGroupFPM NxBx;
+    ShapeFunctionsTimoshenkoFPM(NxBx, eta);
+    // the strain displacement matrix B:
+    ChMatrixNM<double, 6, 12> Bx = std::get<1>(NxBx);
 
     // generalized strains/curvatures;
-    ChVectorN<double, 6> sect_ek;
-    sect_ek(0) = dkNx1 * qeux;   // ux
-    sect_ek(3) = dkNx1 * qerx;   // rotx
-    sect_ek(4) = -ddkNbz * qez;  // roty
-    sect_ek(5) = ddkNby * qey;   // rotz
+    ChVectorN<double, 6> sect_ek = Bx * displ_ec;
 
-    if (use_shear_stain) {
-        // Strictly speaking, dkNsy * qey,dkNsz * qez are the real shear strains.
-        sect_ek(1) = dkNsy * qey;  // gamma_y = dkNsy * qey; Fy = GAyy * gamma_y;
-        sect_ek(2) = dkNsz * qez;  // gamma_z = dkNsz * qez; Fz = GAzz * gamma_z;
-    } else {
-        // Calculate the shear strain through third-differentian of bending displacement
-        sect_ek(1) = -dddkNby * qey;  // Fy == -EIzz * dddkNby * qey == GAyy * dkNsy * qey;
-        sect_ek(2) = -dddkNbz * qez;  // Fz == -EIyy *  dddkNbz * qez == GAzz * dkNsz * qez;
-    }
+    // 6*6 fully populated constitutive matrix of the beam:
+    ChMatrixNM<double, 6, 6> Klaw_d = this->tapered_section_fpm->GetKlawAtPoint(eta);
 
-    if (false)  // section->alpha ==0 && section->Cy ==0 && section->Cz==0 && section->Sy==0 && section->Sz==0)
-    {
-        // Fast computation:
-        Fforce.x() = EA * sect_ek(0);
-        if (use_shear_stain) {
-            Fforce.y() = GAyy * sect_ek(1);
-            Fforce.z() = GAzz * sect_ek(2);
-        } else {
-            Fforce.y() = EIzz * sect_ek(1);
-            Fforce.z() = EIyy * sect_ek(2);
-        }
+    ChMatrixDynamic<> Teta;
+    ComputeTransformMatrixAtPoint(Teta, eta);
 
-        Mtorque.x() = GJ * sect_ek(3);
-        Mtorque.y() = EIyy * sect_ek(4);
-        Mtorque.z() = EIzz * sect_ek(5);
-    } else {
-        // 6*6 fully populated constitutive matrix of the beam:
-        ChMatrixNM<double, 6, 6> Klaw_d = this->tapered_section_fpm->GetAverageFPM();
-        if (use_shear_stain == false) {
-            Klaw_d(1, 1) = EIzz;
-            Klaw_d(2, 2) = EIyy;
-        }
+    // ..unrolled rotated constitutive matrix..
+    ChMatrixNM<double, 6, 6> Klaw_r;
+    Klaw_r.setZero();
+    Klaw_r = Teta.transpose() * Klaw_d;
 
-        ChMatrixDynamic<> Teta;
-        ComputeTransformMatrixAtPoint(Teta, eta);
+    // .. compute wrench = Klaw_r * sect_ek
+    ChVectorN<double, 6> wrench = Klaw_r * sect_ek;
+    Fforce = wrench.segment(0, 3);
+    Mtorque = wrench.segment(3, 3);
 
-        // ..unrolled rotated constitutive matrix..
-        ChMatrixNM<double, 6, 6> Klaw_r;
-        Klaw_r.setZero();
-        Klaw_r = Teta.transpose() * Klaw_d;
+}
 
-        // .. compute wrench = Klaw_r * sect_ek
-        ChVectorN<double, 6> wrench = Klaw_r * sect_ek;
-        Fforce = wrench.segment(0, 3);
-        Mtorque = wrench.segment(3, 3);
-    }
+void ChElementBeamTaperedTimoshenkoFPM::ComputeNF(const double U,
+                                               ChVectorDynamic<>& Qi,
+                                               double& detJ,
+                                               const ChVectorDynamic<>& F,
+                                               ChVectorDynamic<>* state_x,
+                                               ChVectorDynamic<>* state_w) {
+    ShapeFunctionGroupFPM NxBx;
+    // the shape function matrix
+    ChMatrixNM<double, 6, 12> Nx;
+
+    double eta = -1;
+    ShapeFunctionsTimoshenkoFPM(NxBx, eta);
+    Nx = std::get<0>(NxBx);
+    Qi.head(6) = Nx.transpose() * F;
+
+    eta = 1;
+    ShapeFunctionsTimoshenkoFPM(NxBx, eta);
+    Nx = std::get<0>(NxBx);
+    Qi.tail(6) = Nx.transpose() * F;
+
+    // eta = 2*x/L;
+    // ---> Deta/dx = 2./L;
+    // ---> detJ = dx/Deta = L/2.;
+    detJ = this->GetRestLength() / 2.0;
+
+    /* old code for Euler beam
+    Qi(0) = N(0) * F(0);  // Nx1 * Fx
+    Qi(1) = N(1) * F(1) + N(6) * F(5);  // Ny1 * Fy + dN_ua * Mz
+    Qi(2) = N(1) * F(2) - N(6) * F(4);  // Ny1 * Fz - dN_ua * My
+    Qi(3) = N(0) * F(3);                // Nx1 * Mx
+    Qi(4) = -N(2) * F(2) + N(8) * F(4);  // - Nr1 * Fz + dN_ra * My
+    Qi(5) = N(2) * F(1) + N(8) * F(5);   // Nr1 * Fy +  dN_ra * Mz
+
+    Qi(6) = N(3) * F(0);  // Nx2 * Fx
+    Qi(7) = N(4) * F(1) + N(7) * F(5);  // Ny2 * Fy + dN_ub * Mz
+    Qi(8) = N(4) * F(2) - N(7) * F(4);  // Ny2 * Fz - dN_ub * My
+    Qi(9) = N(3) * F(3);                // Nx2 * Mx
+    Qi(10) = -N(5) * F(2) + N(9) * F(4);  // - Nr2 * Fz + dN_rb * My
+    Qi(11) = N(5) * F(1) + N(9) * F(5);   // Nr2 * Fy + dN_rb * Mz
+    */
+}
+
+void ChElementBeamTaperedTimoshenkoFPM::ComputeNF(const double U,
+                                               const double V,
+                                               const double W,
+                                               ChVectorDynamic<>& Qi,
+                                               double& detJ,
+                                               const ChVectorDynamic<>& F,
+                                               ChVectorDynamic<>* state_x,
+                                               ChVectorDynamic<>* state_w) {
+    this->ComputeNF(U, Qi, detJ, F, state_x, state_w);
+    detJ /= 4.0;  // because volume
 }
 
 

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.cpp
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.cpp
@@ -21,22 +21,22 @@ namespace fea {
 
 
 void ChElementBeamTaperedTimoshenkoFPM::ComputeStiffnessMatrix() {
-    assert(taperedSectionFPM);
+    assert(tapered_section_fpm);
 
     double L = this->length;
     double LL = L * L;
     double LLL = LL * L;
 
-    ChMatrixNM<double,6,6> Klaw = this->taperedSectionFPM->GetAverageFPM();
-    double EA = this->taperedSectionFPM->GetAverageSectionParameters()->EA;
-    double GJ = this->taperedSectionFPM->GetAverageSectionParameters()->GJ;
-    double GAyy = this->taperedSectionFPM->GetAverageSectionParameters()->GAyy;
-    double GAzz = this->taperedSectionFPM->GetAverageSectionParameters()->GAzz;
-    double EIyy = this->taperedSectionFPM->GetAverageSectionParameters()->EIyy;
-    double EIzz = this->taperedSectionFPM->GetAverageSectionParameters()->EIzz;
+    ChMatrixNM<double,6,6> Klaw = this->tapered_section_fpm->GetAverageFPM();
+    double EA = this->tapered_section_fpm->GetAverageSectionParameters()->EA;
+    double GJ = this->tapered_section_fpm->GetAverageSectionParameters()->GJ;
+    double GAyy = this->tapered_section_fpm->GetAverageSectionParameters()->GAyy;
+    double GAzz = this->tapered_section_fpm->GetAverageSectionParameters()->GAzz;
+    double EIyy = this->tapered_section_fpm->GetAverageSectionParameters()->EIyy;
+    double EIzz = this->tapered_section_fpm->GetAverageSectionParameters()->EIzz;
 
-    double phiy = this->taperedSectionFPM->GetAverageSectionParameters()->phiy;
-    double phiz = this->taperedSectionFPM->GetAverageSectionParameters()->phiz;
+    double phiy = this->tapered_section_fpm->GetAverageSectionParameters()->phiy;
+    double phiz = this->tapered_section_fpm->GetAverageSectionParameters()->phiz;
 
     double ay = 1. / (1. + phiy);
     double by = phiy * ay;
@@ -149,16 +149,16 @@ void ChElementBeamTaperedTimoshenkoFPM::ComputeStiffnessMatrix() {
 }
 
 void ChElementBeamTaperedTimoshenkoFPM::ComputeDampingMatrix() {
-    assert(taperedSectionFPM);
+    assert(tapered_section_fpm);
 
     double L = this->length;
     double LL = L * L;
     double LLL = LL * L;
 
-    double mbx = this->taperedSectionFPM->GetAverageSectionParameters()->rdamping_coeff.bx;
-    double mby = this->taperedSectionFPM->GetAverageSectionParameters()->rdamping_coeff.by;
-    double mbz = this->taperedSectionFPM->GetAverageSectionParameters()->rdamping_coeff.bz;
-    double mbt = this->taperedSectionFPM->GetAverageSectionParameters()->rdamping_coeff.bt;
+    double mbx = this->tapered_section_fpm->GetAverageSectionParameters()->rdamping_coeff.bx;
+    double mby = this->tapered_section_fpm->GetAverageSectionParameters()->rdamping_coeff.by;
+    double mbz = this->tapered_section_fpm->GetAverageSectionParameters()->rdamping_coeff.bz;
+    double mbt = this->tapered_section_fpm->GetAverageSectionParameters()->rdamping_coeff.bt;
     ChMatrixNM<double, 6, 6> mb;
     mb.setIdentity();
     mb(0, 0) = mbx;
@@ -168,7 +168,7 @@ void ChElementBeamTaperedTimoshenkoFPM::ComputeDampingMatrix() {
     mb(4, 4) = mbz;
     mb(5, 5) = mby;
 
-    ChMatrixNM<double, 6, 6> Klaw = this->taperedSectionFPM->GetAverageFPM();
+    ChMatrixNM<double, 6, 6> Klaw = this->tapered_section_fpm->GetAverageFPM();
     ChMatrixNM<double, 6, 6> Rlaw = mb.transpose() * Klaw * mb;  // material damping matrix
 
     double rEA = Rlaw(0,0);
@@ -178,8 +178,8 @@ void ChElementBeamTaperedTimoshenkoFPM::ComputeDampingMatrix() {
     double rEIyy = Rlaw(4, 4);
     double rEIzz = Rlaw(5, 5);
 
-    double phiy = this->taperedSectionFPM->GetAverageSectionParameters()->phiy;
-    double phiz = this->taperedSectionFPM->GetAverageSectionParameters()->phiz;
+    double phiy = this->tapered_section_fpm->GetAverageSectionParameters()->phiy;
+    double phiz = this->tapered_section_fpm->GetAverageSectionParameters()->phiz;
 
     double ay = 1. / (1. + phiy);
     double by = phiy * ay;
@@ -292,12 +292,12 @@ void ChElementBeamTaperedTimoshenkoFPM::ComputeDampingMatrix() {
 
 
 void ChElementBeamTaperedTimoshenkoFPM::SetupInitial(ChSystem* system) {
-    assert(taperedSectionFPM);
+    assert(tapered_section_fpm);
 
     // Compute rest length, mass:
     this->length = (nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos()).Length();
-    this->mass = this->length / 2 * this->taperedSectionFPM->GetSectionA()->GetMassPerUnitLength() +
-                 this->length / 2 * this->taperedSectionFPM->GetSectionB()->GetMassPerUnitLength();
+    this->mass = this->length / 2 * this->tapered_section_fpm->GetSectionA()->GetMassPerUnitLength() +
+                 this->length / 2 * this->tapered_section_fpm->GetSectionB()->GetMassPerUnitLength();
 
     // Compute initial rotation
     ChMatrix33<> A0;
@@ -311,7 +311,7 @@ void ChElementBeamTaperedTimoshenkoFPM::SetupInitial(ChSystem* system) {
     // It could be lumped or consistent mass matrix, depends on SetLumpedMassMatrix(true/false)
     // If it is lumped mass matrix, you need to multiple 0.5 * length to obtain the final mass matrix
     // For consistent mass matrix, don't need to multiple anything.
-    this->taperedSectionFPM->ComputeInertiaMatrix(this->M);
+    this->tapered_section_fpm->ComputeInertiaMatrix(this->M);
 
     // Compute transformation matrix
     ComputeTransformMatrix();
@@ -329,7 +329,7 @@ void ChElementBeamTaperedTimoshenkoFPM::SetupInitial(ChSystem* system) {
 void ChElementBeamTaperedTimoshenkoFPM::EvaluateSectionForceTorque(const double eta,
                                                                 ChVector<>& Fforce,
                                                                 ChVector<>& Mtorque) {
-    assert(taperedSectionFPM);
+    assert(tapered_section_fpm);
 
     ChVectorDynamic<> displ(this->GetNdofs());
     this->GetStateBlock(displ);
@@ -358,12 +358,12 @@ void ChElementBeamTaperedTimoshenkoFPM::EvaluateSectionForceTorque(const double 
     auto dddkNby = std::get<0>(sfblk3d);
     auto dddkNbz = std::get<1>(sfblk3d);
 
-    double EA = this->taperedSectionFPM->GetAverageSectionParameters()->EA;
-    double GJ = this->taperedSectionFPM->GetAverageSectionParameters()->GJ;
-    double GAyy = this->taperedSectionFPM->GetAverageSectionParameters()->GAyy;
-    double GAzz = this->taperedSectionFPM->GetAverageSectionParameters()->GAzz;
-    double EIyy = this->taperedSectionFPM->GetAverageSectionParameters()->EIyy;
-    double EIzz = this->taperedSectionFPM->GetAverageSectionParameters()->EIzz;
+    double EA = this->tapered_section_fpm->GetAverageSectionParameters()->EA;
+    double GJ = this->tapered_section_fpm->GetAverageSectionParameters()->GJ;
+    double GAyy = this->tapered_section_fpm->GetAverageSectionParameters()->GAyy;
+    double GAzz = this->tapered_section_fpm->GetAverageSectionParameters()->GAzz;
+    double EIyy = this->tapered_section_fpm->GetAverageSectionParameters()->EIyy;
+    double EIzz = this->tapered_section_fpm->GetAverageSectionParameters()->EIzz;
     
     double eps = 1.0e-3;
     bool use_shear_stain = true;  // As default, use shear strain to evaluate the shear forces
@@ -406,7 +406,7 @@ void ChElementBeamTaperedTimoshenkoFPM::EvaluateSectionForceTorque(const double 
         Mtorque.z() = EIzz * sect_ek(5);
     } else {
         // 6*6 fully populated constitutive matrix of the beam:
-        ChMatrixNM<double, 6, 6> Klaw_d = this->taperedSectionFPM->GetAverageFPM();
+        ChMatrixNM<double, 6, 6> Klaw_d = this->tapered_section_fpm->GetAverageFPM();
         if (use_shear_stain == false) {
             Klaw_d(1, 1) = EIzz;
             Klaw_d(2, 2) = EIyy;

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h
@@ -38,12 +38,16 @@ namespace fea {
 /// are needed, as in cables.
 
 class ChApi ChElementBeamTaperedTimoshenkoFPM : public ChElementBeamTaperedTimoshenko {
-  public:
+  
+public:
 
-    //ChElementBeamTaperedTimoshenkoFPM();
+    // To store the shape function matrix 'Nx' and strain-displacement relation matrix 'Bx'
+    using ShapeFunctionGroupFPM = std::tuple<ChMatrixNM<double, 6, 12>,ChMatrixNM<double, 6, 12>>;
+
+    //ChElementBeamTaperedTimoshenkoFPM();  // use the construction function of base class directly
 
     ~ChElementBeamTaperedTimoshenkoFPM() {}
-
+  
     //
     // FEM functions
     // 
@@ -59,16 +63,49 @@ class ChApi ChElementBeamTaperedTimoshenkoFPM : public ChElementBeamTaperedTimos
         return this->tapered_section_fpm;
     }
 
+    // Shape functions and strain-displacement matrix at position eta for FPM Timoshenko beam
+    void ShapeFunctionsTimoshenkoFPM(ShapeFunctionGroupFPM& NB, double eta);
+
+    void SetIntegrationPoints(int mv) { this->guass_order = mv; };
+    int GetIntegrationPoints() { return this->guass_order; };
+
     /// Computes the local (material) stiffness matrix of the element:
     /// K = integral( [B]' * [D] * [B] ),
     /// Note: in this 'basic' implementation, constant section and
     /// constant material are assumed, so the explicit result of quadrature is used.
     /// Also, this local material stiffness matrix is constant, computed only at the beginning
     /// for performance reasons; if you later change some material property, call this or InitialSetup().
+    void ComputeStiffnessMatrix0();  // discarded, it 's wrong
+
+    void ComputeDampingMatrix0();  // discarded, it 's wrong
+    
+    // compute the local element stiffness matrix via Guass Quadrature
     void ComputeStiffnessMatrix();
 
+    // Although the shape functions of this beam element have updated, 
+    // strictly speaking, we need to update the algorithm of geometric stiffness matrix correspondingly,
+    // but this geometric stiffness matrix is already a higher-order correction term,
+    // we can directly inherit the previous method for the sake of simplicity.
+    // The influence of different shape functions should be very limited.
+    // void ComputeGeometricStiffnessMatrix();
 
+    // compute the local element damping matrix via Guass Quadrature
     void ComputeDampingMatrix();
+
+    // compute the local element consistent mass matrix via Guass Quadrature
+    void ComputeConsistentMassMatrix();
+
+    // finally, choose the mass matrix of local element, 
+    // depending on 'use_lumped_mass_matrix' in its sectional settings
+    void ComputeMassMatrix();
+
+
+    /// Gets the xyz displacement of a point on the beam line,
+    /// and the rotation RxRyRz of section plane, at abscyssa 'eta'.
+    /// Note, eta=-1 at node1, eta=+1 at node2.
+    /// Results are not corotated.
+    virtual void EvaluateSectionDisplacement(const double eta, ChVector<>& u_displ, ChVector<>& u_rotaz) override;
+
 
     /// Gets the force (traction x, shear y, shear z) and the
     /// torque (torsion on x, bending on y, on bending on z) at a section along
@@ -79,15 +116,46 @@ class ChApi ChElementBeamTaperedTimoshenkoFPM : public ChElementBeamTaperedTimos
 
 
     /* To be completed: Created to be consistent with base class implementation*/
+    // strain_v = Bx * displ
     virtual void EvaluateSectionStrain(const double eta, ChVector<>& StrainV) override {}
 
 
+    /// Evaluate N'*F , where N is some type of shape function
+    /// evaluated at U coordinates of the line, each ranging in -1..+1
+    /// F is a load, N'*F is the resulting generalized load
+    /// Returns also det[J] with J=[dx/du,..], that might be useful in gauss quadrature.
+    virtual void ComputeNF(const double U,              ///< parametric coordinate in line
+                           ChVectorDynamic<>& Qi,       ///< Return result of Q = N'*F  here
+                           double& detJ,                ///< Return det[J] here
+                           const ChVectorDynamic<>& F,  ///< Input F vector, size is =n. field coords.
+                           ChVectorDynamic<>* state_x,  ///< if != 0, update state (pos. part) to this, then evaluate Q
+                           ChVectorDynamic<>* state_w   ///< if != 0, update state (speed part) to this, then evaluate Q
+                           ) override;
+
+    /// Evaluate N'*F , where N is some type of shape function
+    /// evaluated at U,V,W coordinates of the volume, each ranging in -1..+1
+    /// F is a load, N'*F is the resulting generalized load
+    /// Returns also det[J] with J=[dx/du,..], that might be useful in gauss quadrature.
+    virtual void ComputeNF(const double U,              ///< parametric coordinate in volume
+                           const double V,              ///< parametric coordinate in volume
+                           const double W,              ///< parametric coordinate in volume
+                           ChVectorDynamic<>& Qi,       ///< Return result of N'*F  here, maybe with offset block_offset
+                           double& detJ,                ///< Return det[J] here
+                           const ChVectorDynamic<>& F,  ///< Input F vector, size is = n.field coords.
+                           ChVectorDynamic<>* state_x,  ///< if != 0, update state (pos. part) to this, then evaluate Q
+                           ChVectorDynamic<>* state_w   ///< if != 0, update state (speed part) to this, then evaluate Q
+                           ) override;
+
   private:
+
     /// Initial setup. Precompute mass and matrices that do not change during the simulation, such as the local tangent
     /// stiffness Kl of each element, if needed, etc.
     virtual void SetupInitial(ChSystem* system) override;
 
     std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> tapered_section_fpm;
+    
+    // the order of Gauss-Legendre quadrature for local element stiffness/damping/mass matrices 
+    int guass_order = 4;  // be careful of shear locking effect
 
 };
 

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h
@@ -51,12 +51,12 @@ class ChApi ChElementBeamTaperedTimoshenkoFPM : public ChElementBeamTaperedTimos
     /// Set the section & material of beam element .
     /// It is a shared property, so it can be shared between other beams.
     void SetTaperedSection(std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> my_material) {
-        this->taperedSectionFPM = my_material;
-        this->taperedSection = std::dynamic_pointer_cast<ChBeamSectionTaperedTimoshenkoAdvancedGeneric>(my_material);
+        this->tapered_section_fpm = my_material;
+        this->tapered_section = std::dynamic_pointer_cast<ChBeamSectionTaperedTimoshenkoAdvancedGeneric>(my_material);
     }
     /// Get the section & material of the element
     std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> GetTaperedSection() {
-        return this->taperedSectionFPM;
+        return this->tapered_section_fpm;
     }
 
     /// Computes the local (material) stiffness matrix of the element:
@@ -87,7 +87,7 @@ class ChApi ChElementBeamTaperedTimoshenkoFPM : public ChElementBeamTaperedTimos
     /// stiffness Kl of each element, if needed, etc.
     virtual void SetupInitial(ChSystem* system) override;
 
-    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> taperedSectionFPM;
+    std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM> tapered_section_fpm;
 
 };
 

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h
@@ -44,7 +44,7 @@ public:
     // To store the shape function matrix 'Nx' and strain-displacement relation matrix 'Bx'
     using ShapeFunctionGroupFPM = std::tuple<ChMatrixNM<double, 6, 12>,ChMatrixNM<double, 6, 12>>;
 
-    //ChElementBeamTaperedTimoshenkoFPM();  // use the construction function of base class directly
+    ChElementBeamTaperedTimoshenkoFPM();  // use the construction function of base class directly
 
     ~ChElementBeamTaperedTimoshenkoFPM() {}
   

--- a/src/demos/fea/CMakeLists.txt
+++ b/src/demos/fea/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 if(ENABLE_MODULE_IRRLICHT AND ENABLE_MODULE_PARDISO_MKL)
 set(FEA_DEMOS ${FEA_DEMOS}
     demo_FEA_contacts_NSC
+    #demo_FEA_basic
     demo_FEA_beams
     demo_FEA_beams_static
     demo_FEA_beams_constr
@@ -106,7 +107,7 @@ endif()
 #--------------------------------------------------------------
 
 message(STATUS "Demo programs for FEA module...")
-
+add_compile_options(/bigobj)
 foreach(PROGRAM ${FEA_DEMOS})
     message(STATUS "...add ${PROGRAM}")
 

--- a/src/demos/fea/demo_FEA_basic.cpp
+++ b/src/demos/fea/demo_FEA_basic.cpp
@@ -27,6 +27,17 @@
 #include "chrono/fea/ChMesh.h"
 #include "chrono/fea/ChLinkPointFrame.h"
 
+#include "chrono_pardisomkl/ChSolverPardisoMKL.h"
+#include "chrono/fea/ChNodeFEAxyzrot.h"
+#include "chrono/fea/ChElementBeamEuler.h"
+#include "chrono/fea/ChElementBeamTaperedTimoshenko.h"
+#include "chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h"
+#include "chrono/fea/ChBuilderBeam.h"
+#include "chrono/physics/ChLinkMate.h"
+#include "E:/pengchao/Chrono/sourceCode/nlohmann/json.hpp"
+#include <chrono/physics/ChLinkMotorRotationSpeed.h>
+using Json = nlohmann::json;
+
 using namespace chrono;
 using namespace fea;
 
@@ -588,6 +599,2008 @@ void test_5() {
     GetLog() << "Element volume" << melement1->GetVolume() << "\n";
 }
 
+//////////////////////////////////////////////////////////////////
+// ============================================================ //
+// Test 6													    //
+// To test the new developed Tapered Timoshenko beam element    //
+// ============================================================ //
+void test_6() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko beam element  \n\n";
+
+    struct BladeSection {
+        double ref_twist;
+        double mass_twist;
+        double elastic_twist;
+        double aero_twist;
+        double twist_rotation;     // nodal section rotational angle, between elastic principal axis and reference axis
+        double area;               // A
+        double flap_inertia;       // Iyy
+        double edge_inertia;       // Izz
+        double polar_inertia;      // Ixx, Ip
+        double y_shear_coefficient;  // Ksy
+        double z_shear_coefficient;  // Ksz
+        double density;              // pho
+        double young_modulus;        // E
+        double shear_modulus;        // G
+        double rayleigh_damping_beta;  // beta
+        double EA;                     // axial stiffness
+        double GJ;                     // torsional stiffness
+        double EIyy;                   // flapwise stiffness, bending about y-axis
+        double EIzz;                   // edgewise stiffness, bending about z-axis
+        double GAyy;                   // shear stiffness along edgewise direction, along y-axis
+        double GAzz;                   // shear stiffness along flapwise direction, along z-axis
+        double mass_per_length;
+        double mass_inertia_Jxx_per_length;
+        double radii_of_gyration_ratio;
+        //double prebend_rotational_angle;
+        //double presweep_rotation_angle;
+
+        ChVector<double> position;
+        ChVector2<double> elastic_center;
+        ChVector2<double> mass_center;
+        ChVector2<double> shear_center;
+        ChVector2<double> aerodynamic_center;
+        ChFrame<double> section_frame_in_blade_root_frame;
+        ChQuaternion<double> q;
+    };
+
+    auto GetLocalFrameInBladeRootFrame = [&](const ChVector<double>& nodeA_position,
+                                                  const ChVector<double>& nodeB_position,
+                                                  const double local_twist) {
+        // 按照Bladed中的坐标变换顺序进行建模
+
+        // translation: 从叶根平移到截面处，不旋转
+        ChVector<double> section_position = 0.5 * (nodeA_position, nodeB_position);
+        ChFrame<double> translation(section_position, QUNIT);
+
+        ChVector<double> section_X_dir = (nodeB_position - nodeA_position).GetNormalized();
+
+        ChFrame<double> pretorsion_rotation({0, 0, 0}, Q_from_AngAxis(local_twist, VECT_X));
+        ChMatrix33<double> pretorsion_A = pretorsion_rotation.GetA();
+
+        double rx = nodeB_position.x() - nodeA_position.x();
+        double ry = nodeB_position.y() - nodeA_position.y();
+        double rz = nodeB_position.z() - nodeA_position.z();
+
+        double prebend_rot_angle = -atan2(rz, rx);
+        ChFrame<double> prebend_rotation({0, 0, 0}, Q_from_AngAxis(prebend_rot_angle, VECT_Y));
+        ChMatrix33<double> prebend_A = prebend_rotation.GetA();
+
+        double presweep_rot_angle = atan2(ry, rx);
+        ChFrame<double> presweep_rotation({0, 0, 0},
+                                                  Q_from_AngAxis(presweep_rot_angle, VECT_Z));
+        ChMatrix33<double> presweep_A = presweep_rotation.GetA();
+
+        ChFrame<double> section_frame_tmp = pretorsion_rotation >> prebend_rotation >> presweep_rotation;
+        ChMatrix33<double> section_A_tmp = presweep_A * prebend_A * pretorsion_A;
+
+        ChVector<double> section_Z_dir = (section_A_tmp * chrono::VECT_Z).GetNormalized();
+        ChVector<double> section_Y_dir = Vcross(section_Z_dir, section_X_dir);
+        ChMatrix33<double> section_A = ChMatrix33<double>(section_X_dir, section_Y_dir, section_Z_dir);
+        // chrono::GetLog() << "section_X_dir: \t" << section_X_dir << "\n";
+        // chrono::GetLog() << "section_Y_dir: \t" << section_Y_dir << "\n";
+        // chrono::GetLog() << "section_Z_dir: \t" << section_Z_dir << "\n";
+        // chrono::GetLog() << "section_A: \t" << section_A << "\n";
+        ChFrame<double> section_frame = ChFrame<double>(section_position, section_A);
+        return section_frame;
+    };
+
+    double PI = 3.1415926535897932384626;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    std::vector<std::shared_ptr<ChBeamSectionTimoshenkoAdvancedGeneric>> blade_sections_;
+    std::vector<std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGeneric>> blade_tapered_sections_;
+    std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenko>> blade_beams_;
+    auto blade_mesh_ = chrono_types::make_shared<ChMesh>();
+    auto blade_nodes_ = std::vector<std::shared_ptr<ChNodeFEAxyzrot>>();
+    auto foundation = chrono_types::make_shared<ChBody>();
+    auto mkl_solver_ = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper_ = chrono_types::make_shared<ChTimestepperHHT>();
+
+    foundation->SetCoord({0, 0, 0}, chrono::QUNIT);
+    foundation->SetMass(1.0);
+    foundation->SetNameString("foundation body of system");
+    foundation->SetBodyFixed(true);
+    my_system.AddBody(foundation);
+
+    Json json_info;
+    std::string JsonPath="C:/Users/31848/Desktop/goldflex_chrono20210126/goldflex-mb/resource/case.example.gf.json";
+    std::ifstream case_stream{JsonPath};
+    case_stream >> json_info;
+    case_stream.close();
+    Json blade_section_info = json_info["blade1"]["sections"];
+    int blade_node_counts = blade_section_info.size();
+    std::vector<std::shared_ptr<BladeSection>> blade_original_section_list_;
+
+    auto GetOriginalData = [&](const std::string& key, const Json& current) { 
+        return current[key].get<double>(); };
+
+    double switchOff = 0.0;
+    double switchOn = 1.0;
+
+
+    for (int iSec = 0; iSec < blade_node_counts; iSec++) {
+
+        auto blade_section = std::make_shared<BladeSection>();
+        auto curr_info = blade_section_info[iSec];
+        // 暂时关掉预弯，避免quatenion变换太复杂 ChQuaternion
+        blade_section->position = ChVector<double>(curr_info["ref_location_z"].get<double>(), 
+                                                    curr_info["ref_location_y"].get<double>() * switchOn,
+                                                   -curr_info["ref_location_x"].get<double>() * switchOn);
+        blade_section->ref_twist = GetOriginalData("ref_twist", curr_info) * switchOn;
+        blade_section->mass_twist = GetOriginalData("mass_twist", curr_info) * switchOn;
+        blade_section->elastic_twist = GetOriginalData("elastic_twist", curr_info) * switchOn;
+        blade_section->aero_twist = GetOriginalData("aerodynamic_twist", curr_info) * switchOn;
+        blade_section->twist_rotation = (blade_section->elastic_twist - blade_section->ref_twist) * switchOn;
+        blade_section->mass_center =
+            ChVector2<double>(GetOriginalData("mass_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("mass_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->aerodynamic_center =
+            ChVector2<double>(GetOriginalData("aerodynamic_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("aerodynamic_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->elastic_center =
+            ChVector2<double>(GetOriginalData("elastic_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("elastic_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->shear_center =
+            ChVector2<double>(GetOriginalData("shear_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("shear_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->mass_per_length = GetOriginalData("mass_per_unit_length", curr_info);
+        blade_section->mass_inertia_Jxx_per_length = GetOriginalData("mass_inertia_Jzz_per_unit_length", curr_info);
+        blade_section->radii_of_gyration_ratio = GetOriginalData("radii_of_gyration_ratio", curr_info);
+        blade_section->EA = GetOriginalData("axial_stiffness", curr_info);
+        blade_section->GJ = GetOriginalData("torsional_stiffness", curr_info);
+        blade_section->EIyy = GetOriginalData("flapwise_bending_stiffness", curr_info);
+        blade_section->EIzz = GetOriginalData("edgewise_bending_stiffness", curr_info);
+        blade_section->GAyy = GetOriginalData("edgewise_shear_stiffness", curr_info);
+        blade_section->GAzz = GetOriginalData("flapwise_shear_stiffness", curr_info);
+        blade_section->rayleigh_damping_beta = GetOriginalData("damping_beta_coefficient", curr_info);
+
+        blade_section->young_modulus = 1.4e10;
+        blade_section->area = blade_section->EA / blade_section->young_modulus;
+        blade_section->density = blade_section->mass_per_length / blade_section->area;
+        blade_section->polar_inertia = blade_section->mass_inertia_Jxx_per_length / blade_section->density;
+        //      blade_section->flap_inertia = blade_section->EIyy / blade_section->young_modulus;
+        //      blade_section->edge_inertia = blade_section->EIzz / blade_section->young_modulus;
+        blade_section->edge_inertia = blade_section->polar_inertia / (1 + blade_section->radii_of_gyration_ratio *
+                                                                              blade_section->radii_of_gyration_ratio);
+        blade_section->flap_inertia = blade_section->edge_inertia * blade_section->radii_of_gyration_ratio *
+                                      blade_section->radii_of_gyration_ratio;
+        blade_section->shear_modulus = blade_section->GJ / blade_section->polar_inertia;
+        blade_section->y_shear_coefficient = 1e2;  // IGA单元需要构造一个很大的剪切刚度，但似乎太大了也不行
+        blade_section->z_shear_coefficient = 1e2;
+        // Bladed文件中没有给定GAEDGE，则JSON文件中GAyy为0，这里需要构造一个GAyy，用于IGA单元
+        if (abs(blade_section->GAyy) < 0.001) {
+            blade_section->GAyy =
+                blade_section->shear_modulus * blade_section->area * blade_section->y_shear_coefficient;
+        }
+        // Bladed文件中没有给定GAFLAP，则JSON文件中GAzz为0，这里需要构造一个GAzz，用于IGA单元
+        if (abs(blade_section->GAzz) < 0.001) {
+            blade_section->GAzz =
+                blade_section->shear_modulus * blade_section->area * blade_section->z_shear_coefficient;
+        }
+
+        blade_original_section_list_.push_back(blade_section);
+    }
+
+    std::vector<ChFrame<double>> middle_section_frame;
+   for (int i = 0; i < blade_node_counts-1; i++) {
+        auto node_A = blade_original_section_list_[i];
+        auto node_B = blade_original_section_list_[i+1];
+        auto average_twist = (node_A->ref_twist + node_B->ref_twist) * 0.5;
+        auto tmp = GetLocalFrameInBladeRootFrame(node_A->position, node_B->position, average_twist);
+        middle_section_frame.push_back(tmp);
+   }
+
+    std::vector<ChFrame<double>> blade_node_frame;
+   blade_node_frame.resize(blade_node_counts);
+     // 【除了叶根、叶尖两个node外】
+   // node的quatenion，由相邻两个section的quatenion平均而来
+   for (int i = 1; i < blade_node_counts - 1; i++) {
+      auto q = (middle_section_frame.at(i - 1).GetRot() + middle_section_frame.at(i).GetRot()).GetNormalized();
+      blade_node_frame.at(i) = chrono::ChFrame<double>(blade_original_section_list_[i]->position,q);
+   }
+   blade_node_frame.at(0) = chrono::ChFrame<double>(blade_original_section_list_.at(0)->position, chrono::QUNIT);
+   blade_node_frame.at(blade_node_counts - 1) = chrono::ChFrame<double>(
+       blade_original_section_list_.at(blade_node_counts - 1)->position, middle_section_frame.back().GetRot());
+
+
+   auto blade_root_coord_ = ChCoordsys<double>(foundation->GetCoord());
+   for (int i = 0; i < blade_node_counts; i++) {
+        //节点的坐标转换
+        auto node_temp = chrono_types::make_shared<ChNodeFEAxyzrot>(blade_node_frame[i]);
+        blade_nodes_.push_back(node_temp);
+        blade_mesh_->AddNode(blade_nodes_.back());  //节点一个个加入到mesh中
+    }
+
+
+   for (int i = 0; i < blade_node_counts; i++) {
+        //建立截面的数据
+        auto section = chrono_types::make_shared<ChBeamSectionTimoshenkoAdvancedGeneric>();
+
+        //截面属性设置
+        section->SetSectionRotation(blade_original_section_list_[i]->twist_rotation);
+        section->SetCenterOfMass(blade_original_section_list_[i]->mass_center.x(),
+                                 blade_original_section_list_[i]->mass_center.y());
+        section->SetCentroidY(blade_original_section_list_[i]->elastic_center.x());
+        section->SetCentroidZ(blade_original_section_list_[i]->elastic_center.y());
+        section->SetShearCenterY(blade_original_section_list_[i]->shear_center.x());
+        section->SetShearCenterZ(blade_original_section_list_[i]->shear_center.y());
+        section->SetMassPerUnitLength(blade_original_section_list_[i]->mass_per_length);
+        double Jmyy = blade_original_section_list_[i]->flap_inertia * blade_original_section_list_[i]->density;
+        double Jmzz = blade_original_section_list_[i]->edge_inertia * blade_original_section_list_[i]->density;
+        double Jmyz = 0.;
+        double mass_phi = blade_original_section_list_[i]->mass_twist - blade_original_section_list_[i]->ref_twist;
+        double Qmy = 0.;
+        double Qmz = 0.;
+        section->SetMainInertiasInMassReference(Jmyy,Jmzz,Jmyz,mass_phi,Qmy,Qmz);
+        section->SetArtificialJyyJzzFactor(1.0 / 500);
+        section->SetAxialRigidity(blade_original_section_list_[i]->EA);
+        section->SetXtorsionRigidity(blade_original_section_list_[i]->GJ);
+        section->SetYbendingRigidity(blade_original_section_list_[i]->EIyy);
+        section->SetZbendingRigidity(blade_original_section_list_[i]->EIzz);
+        DampingCoefficients mdamping_coeff;
+        mdamping_coeff.bx = pow(blade_original_section_list_[i]->rayleigh_damping_beta, 0.5);
+        mdamping_coeff.by = mdamping_coeff.bx;
+        mdamping_coeff.bz = mdamping_coeff.bx;
+        mdamping_coeff.bt = mdamping_coeff.bx;
+        section->SetBeamRaleyghDamping(mdamping_coeff);
+        section->SetYshearRigidity(blade_original_section_list_[i]->GAyy);
+        section->SetZshearRigidity(blade_original_section_list_[i]->GAyy);
+
+        blade_sections_.push_back(section);
+    }
+
+   for (int i = 0; i < blade_node_counts - 1; i++) {
+        // 建立变截面属性
+       auto tapered_section = chrono_types::make_shared<chrono::fea::ChBeamSectionTaperedTimoshenkoAdvancedGeneric>();
+        tapered_section->SetLumpedMassMatrixType(false);
+        tapered_section->SetSectionA(blade_sections_.at(i));
+        tapered_section->SetSectionB(blade_sections_.at(i + 1));
+        tapered_section->SetLength(
+            (blade_original_section_list_.at(i + 1)->position - blade_original_section_list_.at(i)->position).Length());
+
+        blade_tapered_sections_.push_back(tapered_section);
+
+        blade_beams_.push_back(chrono_types::make_shared<chrono::fea::ChElementBeamTaperedTimoshenko>());
+        blade_beams_.back()->SetTaperedSection(tapered_section);
+
+        auto section_frame_g = middle_section_frame[i] >> blade_root_coord_;
+        auto node_a_frame_g = blade_nodes_[i]->Frame() >> blade_root_coord_;
+        auto node_b_frame_g = blade_nodes_[i+1]->Frame() >> blade_root_coord_;
+
+        blade_beams_.back()->SetNodeAreferenceRot(section_frame_g.GetRot().GetConjugate() % node_a_frame_g.GetRot());
+        blade_beams_.back()->SetNodeBreferenceRot(section_frame_g.GetRot().GetConjugate() % node_b_frame_g.GetRot());
+        blade_beams_.back()->SetNodes(blade_nodes_.at(i), blade_nodes_.at(i + 1));
+        //        blade_beams_.back()->SetDisableCorotate(true);
+        blade_mesh_->AddElement(blade_beams_.back());  //单元一个个加入到mesh中
+    }
+
+    blade_mesh_->SetNameString("blade_mesh");
+    my_system.Add(blade_mesh_);
+
+    auto link_blade_root = chrono_types::make_shared<ChLinkMateFix>();
+    // 这里似乎node一定要在前面，否则数值计算稳定性不佳，可能崩溃
+    link_blade_root->Initialize(blade_nodes_[0], foundation);
+    my_system.Add(link_blade_root);
+    //my_system.Set_G_acc({9.81, 9.81, -2.*9.81});
+    my_system.Set_G_acc({0,0,0});
+    blade_nodes_.at(3)->SetForce({100.,200.,300.});
+    blade_nodes_.at(3)->SetTorque({400., 500., 600.});
+
+    mkl_solver_->UseSparsityPatternLearner(true);
+    mkl_solver_->LockSparsityPattern(true);
+    mkl_solver_->SetVerbose(false);
+    my_system.SetSolver(mkl_solver_);  //矩阵求解
+
+    my_system.SetTimestepperType(ChTimestepper::Type::HHT);
+    hht_time_stepper_ = std::dynamic_pointer_cast<ChTimestepperHHT>(my_system.GetTimestepper());
+    hht_time_stepper_->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+    hht_time_stepper_->SetMinStepSize(1e-9);
+    hht_time_stepper_->SetAbsTolerances(1e-6);
+    hht_time_stepper_->SetMaxiters(100);
+    hht_time_stepper_->SetStepControl(true);     // 提高数值计算的收敛性
+    hht_time_stepper_->SetModifiedNewton(true);  // 提高数值计算的收敛性
+    
+    my_system.Setup();
+
+    // Output some results
+    GetLog() << "test_6: \n";
+    GetLog() << "Simulation starting..............\n";
+    GetLog() << "Blade tip coordinate X: " << blade_nodes_.back()->GetPos().x() << "\n";
+    GetLog() << "Blade tip coordinate Y: " << blade_nodes_.back()->GetPos().y() << "\n";
+    GetLog() << "Blade tip coordinate Z: " << blade_nodes_.back()->GetPos().z() << "\n";
+    my_system.DoStaticNonlinear(100, false);
+
+    GetLog() << "\n\n\n";
+    GetLog() << "Simulation finished..............\n";
+    GetLog() << "Blade tip coordinate X: " << blade_nodes_.back()->GetPos().x() << "\n";
+    GetLog() << "Blade tip coordinate Y: " << blade_nodes_.back()->GetPos().y() << "\n";
+    GetLog() << "Blade tip coordinate Z: " << blade_nodes_.back()->GetPos().z() << "\n";
+    GetLog() << "\n\n\n";
+
+    int node_ct = 5;
+    int start_node = 0;
+    ChMatrixDynamic<> Fout;
+    Fout.resize(12, node_ct * 2);
+    ChMatrixDynamic<> Fout1;
+    Fout1.resize(12, node_ct);
+    ChMatrixDynamic<> Fout2;
+    Fout2.resize(12, node_ct);
+    for (int i = 0; i < node_ct; i++) {
+        int j = i + start_node;
+
+        ChVectorDynamic<> Fi1;
+        Fi1.resize(12);
+        blade_beams_.at(j)->ComputeInternalForces(Fi1);
+
+        ChVectorN<double, 12> Fi2;
+        ChVector<> Fforce;
+        ChVector<> Mtorque;
+        blade_beams_.at(j)->EvaluateSectionForceTorque(-1, Fforce, Mtorque);
+        //blade_beams_.at(j)->EvaluateSectionForceTorque0(-1, Fforce, Mtorque);
+        Fi2.segment(0, 3) = Fforce.eigen()*(-1.0);
+        Fi2.segment(3, 3) = Mtorque.eigen() * (-1.0);
+        blade_beams_.at(j)->EvaluateSectionForceTorque(1, Fforce, Mtorque);
+        //blade_beams_.at(j)->EvaluateSectionForceTorque0(1, Fforce, Mtorque);
+        Fi2.segment(6, 3) = Fforce.eigen();
+        Fi2.segment(9, 3) = Mtorque.eigen();
+
+        auto q_element_abs_rot = blade_beams_.at(j)->GetAbsoluteRotation();
+        ChMatrix33<> Atoabs(q_element_abs_rot);
+        ChMatrix33<> AtolocwelA(blade_beams_.at(j)->GetNodeA()->Frame().GetRot().GetConjugate() %
+                                q_element_abs_rot);
+        ChMatrix33<> AtolocwelB(blade_beams_.at(j)->GetNodeB()->Frame().GetRot().GetConjugate() %
+                                q_element_abs_rot);
+        std::vector<ChMatrix33<>*> R;
+        R.push_back(&Atoabs);
+        R.push_back(&AtolocwelA);
+        R.push_back(&Atoabs);
+        R.push_back(&AtolocwelB);
+        ChVectorN<double, 12> Fi2abs;
+        ChMatrixCorotation::ComputeCK(Fi2, R, 4, Fi2abs);
+
+        Fout1.col(i) = Fi1;
+        Fout2.col(i) = Fi2abs;
+        Fout.col(2 * i) = Fi1;
+        Fout.col(2 * i + 1) = Fi2abs;
+    }
+
+    ChVectorDynamic<> Fi0;
+    Fi0.resize(6);
+    Fi0.segment(0, 3) = link_blade_root->Get_react_force().eigen();
+    Fi0.segment(3, 3) = link_blade_root->Get_react_torque().eigen();
+
+
+    GetLog() << "\n\n check Fout: \n";
+    GetLog() << (Fout1 + Fout2);  // (Fout1 + Fout2).eigen()
+    GetLog() << "\n\n\n";
+
+    std::string asciifile_static = R"(E:\pengchao\matlab_work\blade\Fout_static.dat)";
+    chrono::ChStreamOutAsciiFile mfileo(asciifile_static.c_str());
+    mfileo.SetNumFormat("%.12g");
+    mfileo << "Fout0:\n" << Fi0 << "\n";
+    mfileo << "Fout1:\n" << Fout1 << "\n";
+    mfileo << "Fout2:\n" << Fout2 << "\n";
+    mfileo << "Fout:\n" << Fout << "\n";
+
+    bool bSolveMode = true;
+    if (bSolveMode) {  // start of modal solving
+        bool save_M = true;
+        bool save_K = true;
+        bool save_R = true;
+        bool save_Cq = true;
+        auto sysMat_name_temp = R"(E:\pengchao\matlab_work\blade\blade)";
+        const char* path_sysMatMKR = R"(E:\pengchao\matlab_work\blade\blade)";
+        //输出 M K R 矩阵到文本文件，方便matlab处理
+        my_system.DumpSystemMatrices(save_M, save_K, save_R, save_Cq, path_sysMatMKR);
+        //直接提取 M K R 矩阵，并计算特征值和特征向量
+        chrono::ChSparseMatrix sysMat_M;
+        my_system.GetMassMatrix(&sysMat_M);
+        chrono::ChSparseMatrix sysMat_K;
+        my_system.GetStiffnessMatrix(&sysMat_K);
+        chrono::ChSparseMatrix sysMat_R;
+        my_system.GetDampingMatrix(&sysMat_R);
+        chrono::ChSparseMatrix sysMat_Cq;
+        my_system.GetConstraintJacobianMatrix(&sysMat_Cq);
+        // 调用EIGEN3求解dense matrix的特征值和特征向量
+        Eigen::MatrixXd dense_sysMat_M = sysMat_M.toDense();
+        Eigen::MatrixXd dense_sysMat_K = sysMat_K.toDense();
+        Eigen::MatrixXd dense_sysMat_R = sysMat_R.toDense();
+        Eigen::MatrixXd dense_sysMat_Cq = sysMat_Cq.toDense();
+        // 计算Cq矩阵的null space（零空间）
+        Eigen::MatrixXd Cq_null_space = dense_sysMat_Cq.fullPivLu().kernel();
+        Eigen::MatrixXd M_hat = Cq_null_space.transpose() * dense_sysMat_M * Cq_null_space;
+        Eigen::MatrixXd K_hat = Cq_null_space.transpose() * dense_sysMat_K * Cq_null_space;
+        Eigen::MatrixXd R_hat = Cq_null_space.transpose() * dense_sysMat_R * Cq_null_space;
+        // frequency-shift，解决矩阵奇异问题，现在还用不着，可以置0
+        double freq_shift = 0.0;  //偏移值，可取1~10等任意数值
+        Eigen::MatrixXd M_bar = M_hat;
+        Eigen::MatrixXd K_bar = pow(freq_shift, 2) * M_hat + freq_shift * R_hat + K_hat;
+        Eigen::MatrixXd R_bar = 2 * freq_shift * M_hat + R_hat;
+        Eigen::MatrixXd M_bar_inv = M_bar.inverse();  //直接用dense matrix求逆也不慢
+        // 生成状态方程的 A 矩阵，其特征值就是模态频率
+        int dim = M_bar.rows();
+        Eigen::MatrixXd A_tilde(2 * dim, 2 * dim);  // 拼成系统矩阵 A 矩阵，dense matrix。
+        A_tilde << Eigen::MatrixXd::Zero(dim, dim), Eigen::MatrixXd::Identity(dim, dim), -M_bar_inv * K_bar,
+            -M_bar_inv * R_bar;
+        // 调用EIGEN3，dense matrix直接求解特征值和特征向量
+        // NOTE：EIGEN3在release模式下计算速度非常快[~1s]，在debug模式下计算速度非常慢[>100s]
+        Eigen::EigenSolver<Eigen::MatrixXd> eigenSolver(A_tilde);
+        Eigen::VectorXcd sys_eValues = eigenSolver.eigenvalues() + freq_shift;
+        Eigen::MatrixXcd sys_eVectors = eigenSolver.eigenvectors();
+
+        typedef std::tuple<double, double, double, std::complex<double>, Eigen::VectorXcd> myEigenRes;
+        std::vector<myEigenRes> eigen_vectors_and_values;
+        for (int i = 0; i < sys_eValues.size(); i++) {
+            myEigenRes vec_and_val(
+                std::abs(sys_eValues(i)) / (2 * PI),  // index：0     特征值的绝对值, 无阻尼模态频率
+                sys_eValues(i).imag() / (2 * PI),     // index：1     特征值的虚部,有阻尼模态频率
+                -sys_eValues(i).real() / std::abs(sys_eValues(i)),  // index：2     特征值的实部代表了阻尼比
+                sys_eValues(i),                                     // index：3     复数形式的特征值
+                sys_eVectors.col(i)                                 // index：4     振型
+            );
+            if (std::abs(sys_eValues(i).imag()) > 1.0e-6) {  // 只有虚部不为零的特征值会放入结果中
+                eigen_vectors_and_values.push_back(vec_and_val);
+            }
+        }
+        std::sort(eigen_vectors_and_values.begin(), eigen_vectors_and_values.end(),
+                  [&](const myEigenRes& a, const myEigenRes& b) -> bool {
+                      return std::get<1>(a) < std::get<1>(b);
+                  });  // index：1，表示按照特征值的虚部进行排序，‘ < ’为升序
+
+        int midN = (int)(eigen_vectors_and_values.size() / 2);
+        int nModes = 20;  // 提取20阶模态频率，不要修改这个数值，因为与之对比的Bladed的模态结果只给了20阶
+        std::vector<Eigen::VectorXcd> res_Modeshapes;
+        Eigen::MatrixXd res_Modes(nModes, 3);
+        int jj = 0;
+        int i = 0;
+        while ( i < nModes) {  
+            // 前面一半的特征值的虚部为负数，没有意义，需要丢掉【QUESTION：这部分的特征值到底是什么物理意义？】
+            double damping_ratio = std::get<2>(eigen_vectors_and_values.at(jj + midN));
+            if (damping_ratio < 0.5) {  // 只提取模态阻尼比小于0.5的模态
+                res_Modes(i, 0) = std::get<0>(eigen_vectors_and_values.at(jj + midN));  // 无阻尼模态频率
+                res_Modes(i, 1) = std::get<1>(eigen_vectors_and_values.at(jj + midN));  // 有阻尼模态频率
+                res_Modes(i, 2) = std::get<2>(eigen_vectors_and_values.at(jj + midN));  // 阻尼比
+                // Eigen::VectorXcd tempVector = std::get<4>(eigen_vectors_and_values.at(jj + midN));
+                // res_Modeshapes.push_back(Cq_null_space * tempVector.head(midN));
+                i++;
+            }  // TODO：阵型提取，参考单叶片稳定性分析python代码中的算法
+            jj++;
+        }
+
+        // 与Bladed计算的单叶片模态频率对比，计算误差，%
+        Eigen::MatrixXd res_Bladed;
+        res_Bladed.resize(nModes, 1);
+        res_Bladed << 2.866, 4.5783, 8.0878, 14.44, 17.243, 29.435, 32.57, 43.261, 45.452, 60.195, 65.468, 71.914,
+            84.706, 97.478, 104.66, 109.45, 126.07, 130.82, 136.21, 146.88;
+        res_Bladed /= (2 * PI);  // 转换为Hz
+        Eigen::MatrixXd error_to_Bladed = (res_Modes.col(0).array() - res_Bladed.array()) / res_Bladed.array() * 100.0;
+
+
+        // 模态计算结果输出到屏幕
+        Eigen::MatrixXd res_output(nModes, 4);
+        res_output << res_Modes, error_to_Bladed;
+        std::cout << "The eigenvalues of single blade are:\t\n"
+                  << "01 undamped frequency/Hz\t"
+                  << "02 damped frequency/Hz\t"
+                  << "03 damping ratio\t"
+                  << "04 dfferences[%]\n"
+                  << res_output << std::endl;
+    }  // end of modal solving
+
+}
+
+
+void test_7() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko FPM beam element  \n\n";
+
+    struct BladeSection {
+        double ref_twist;
+        double mass_twist;
+        double elastic_twist;
+        double aero_twist;
+        double twist_rotation;  // nodal section rotational angle, between elastic principal axis and reference axis
+        double area;            // A
+        double flap_inertia;    // Iyy
+        double edge_inertia;    // Izz
+        double polar_inertia;   // Ixx, Ip
+        double y_shear_coefficient;    // Ksy
+        double z_shear_coefficient;    // Ksz
+        double density;                // pho
+        double young_modulus;          // E
+        double shear_modulus;          // G
+        double rayleigh_damping_beta;  // beta
+        double EA;                     // axial stiffness
+        double GJ;                     // torsional stiffness
+        double EIyy;                   // flapwise stiffness, bending about y-axis
+        double EIzz;                   // edgewise stiffness, bending about z-axis
+        double GAyy;                   // shear stiffness along edgewise direction, along y-axis
+        double GAzz;                   // shear stiffness along flapwise direction, along z-axis
+        double mass_per_length;
+        double mass_inertia_Jxx_per_length;
+        double radii_of_gyration_ratio;
+        // double prebend_rotational_angle;
+        // double presweep_rotation_angle;
+
+        ChVector<double> position;
+        ChVector2<double> elastic_center;
+        ChVector2<double> mass_center;
+        ChVector2<double> shear_center;
+        ChVector2<double> aerodynamic_center;
+        ChFrame<double> section_frame_in_blade_root_frame;
+        ChQuaternion<double> q;
+
+        ChMatrixNM<double, 6, 6> Klaw;  // fully populated material stiffness matrix
+    };
+
+    auto GetLocalFrameInBladeRootFrame = [&](const ChVector<double>& nodeA_position,
+                                             const ChVector<double>& nodeB_position, const double local_twist) {
+        // 按照Bladed中的坐标变换顺序进行建模
+
+        // translation: 从叶根平移到截面处，不旋转
+        ChVector<double> section_position = 0.5 * (nodeA_position, nodeB_position);
+        ChFrame<double> translation(section_position, QUNIT);
+
+        ChVector<double> section_X_dir = (nodeB_position - nodeA_position).GetNormalized();
+
+        ChFrame<double> pretorsion_rotation({0, 0, 0}, Q_from_AngAxis(local_twist, VECT_X));
+        ChMatrix33<double> pretorsion_A = pretorsion_rotation.GetA();
+
+        double rx = nodeB_position.x() - nodeA_position.x();
+        double ry = nodeB_position.y() - nodeA_position.y();
+        double rz = nodeB_position.z() - nodeA_position.z();
+
+        double prebend_rot_angle = -atan2(rz, rx);
+        ChFrame<double> prebend_rotation({0, 0, 0}, Q_from_AngAxis(prebend_rot_angle, VECT_Y));
+        ChMatrix33<double> prebend_A = prebend_rotation.GetA();
+
+        double presweep_rot_angle = atan2(ry, rx);
+        ChFrame<double> presweep_rotation({0, 0, 0}, Q_from_AngAxis(presweep_rot_angle, VECT_Z));
+        ChMatrix33<double> presweep_A = presweep_rotation.GetA();
+
+        ChFrame<double> section_frame_tmp = pretorsion_rotation >> prebend_rotation >> presweep_rotation;
+        ChMatrix33<double> section_A_tmp = presweep_A * prebend_A * pretorsion_A;
+
+        ChVector<double> section_Z_dir = (section_A_tmp * chrono::VECT_Z).GetNormalized();
+        ChVector<double> section_Y_dir = Vcross(section_Z_dir, section_X_dir);
+        ChMatrix33<double> section_A = ChMatrix33<double>(section_X_dir, section_Y_dir, section_Z_dir);
+        // chrono::GetLog() << "section_X_dir: \t" << section_X_dir << "\n";
+        // chrono::GetLog() << "section_Y_dir: \t" << section_Y_dir << "\n";
+        // chrono::GetLog() << "section_Z_dir: \t" << section_Z_dir << "\n";
+        // chrono::GetLog() << "section_A: \t" << section_A << "\n";
+        ChFrame<double> section_frame = ChFrame<double>(section_position, section_A);
+        return section_frame;
+    };
+
+    double PI = 3.1415926535897932384626;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    std::vector<std::shared_ptr<ChBeamSectionTimoshenkoAdvancedGenericFPM>> blade_sections_;
+    std::vector<std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM>> blade_tapered_sections_;
+    std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenkoFPM>> blade_beams_;
+    auto blade_mesh_ = chrono_types::make_shared<ChMesh>();
+    auto blade_nodes_ = std::vector<std::shared_ptr<ChNodeFEAxyzrot>>();
+    auto foundation = chrono_types::make_shared<ChBody>();
+    auto mkl_solver_ = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper_ = chrono_types::make_shared<ChTimestepperHHT>();
+
+    foundation->SetCoord({0, 0, 0}, chrono::QUNIT);
+    foundation->SetMass(1.0);
+    foundation->SetNameString("foundation body of system");
+    foundation->SetBodyFixed(true);
+    my_system.AddBody(foundation);
+
+    Json json_info;
+    std::string JsonPath = "C:/Users/31848/Desktop/goldflex_chrono20210126/goldflex-mb/resource/case.example.gf.json";
+    std::ifstream case_stream{JsonPath};
+    case_stream >> json_info;
+    case_stream.close();
+    Json blade_section_info = json_info["blade1"]["sections"];
+    int blade_node_counts = blade_section_info.size();
+    std::vector<std::shared_ptr<BladeSection>> blade_original_section_list_;
+
+    auto GetOriginalData = [&](const std::string& key, const Json& current) { return current[key].get<double>(); };
+
+    double switchOff = 0.0;
+    double switchOn = 1.0;
+
+    for (int iSec = 0; iSec < blade_node_counts; iSec++) {
+        auto blade_section = std::make_shared<BladeSection>();
+        auto curr_info = blade_section_info[iSec];
+        // 暂时关掉预弯，避免quatenion变换太复杂 ChQuaternion
+        blade_section->position = ChVector<double>(curr_info["ref_location_z"].get<double>(),
+                                                   curr_info["ref_location_y"].get<double>() * switchOn,
+                                                   -curr_info["ref_location_x"].get<double>() * switchOn);
+        blade_section->ref_twist = GetOriginalData("ref_twist", curr_info) * switchOn;
+        blade_section->mass_twist = GetOriginalData("mass_twist", curr_info) * switchOn;
+        blade_section->elastic_twist = GetOriginalData("elastic_twist", curr_info) * switchOn;
+        blade_section->aero_twist = GetOriginalData("aerodynamic_twist", curr_info) * switchOn;
+        blade_section->twist_rotation = (blade_section->elastic_twist - blade_section->ref_twist) * switchOn;
+        blade_section->mass_center =
+            ChVector2<double>(GetOriginalData("mass_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("mass_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->aerodynamic_center =
+            ChVector2<double>(GetOriginalData("aerodynamic_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("aerodynamic_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->elastic_center =
+            ChVector2<double>(GetOriginalData("elastic_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("elastic_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->shear_center =
+            ChVector2<double>(GetOriginalData("shear_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("shear_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->mass_per_length = GetOriginalData("mass_per_unit_length", curr_info);
+        blade_section->mass_inertia_Jxx_per_length = GetOriginalData("mass_inertia_Jzz_per_unit_length", curr_info);
+        blade_section->radii_of_gyration_ratio = GetOriginalData("radii_of_gyration_ratio", curr_info);
+        blade_section->EA = GetOriginalData("axial_stiffness", curr_info);
+        blade_section->GJ = GetOriginalData("torsional_stiffness", curr_info);
+        blade_section->EIyy = GetOriginalData("flapwise_bending_stiffness", curr_info);
+        blade_section->EIzz = GetOriginalData("edgewise_bending_stiffness", curr_info);
+        blade_section->GAyy = GetOriginalData("edgewise_shear_stiffness", curr_info);
+        blade_section->GAzz = GetOriginalData("flapwise_shear_stiffness", curr_info);
+        blade_section->rayleigh_damping_beta = GetOriginalData("damping_beta_coefficient", curr_info);
+
+        blade_section->young_modulus = 1.4e10;
+        blade_section->area = blade_section->EA / blade_section->young_modulus;
+        blade_section->density = blade_section->mass_per_length / blade_section->area;
+        blade_section->polar_inertia = blade_section->mass_inertia_Jxx_per_length / blade_section->density;
+        //      blade_section->flap_inertia = blade_section->EIyy / blade_section->young_modulus;
+        //      blade_section->edge_inertia = blade_section->EIzz / blade_section->young_modulus;
+        blade_section->edge_inertia = blade_section->polar_inertia / (1 + blade_section->radii_of_gyration_ratio *
+                                                                              blade_section->radii_of_gyration_ratio);
+        blade_section->flap_inertia = blade_section->edge_inertia * blade_section->radii_of_gyration_ratio *
+                                      blade_section->radii_of_gyration_ratio;
+        blade_section->shear_modulus = blade_section->GJ / blade_section->polar_inertia;
+         blade_section->y_shear_coefficient = 1e2;  // IGA单元需要构造一个很大的剪切刚度，但似乎太大了也不行
+         blade_section->z_shear_coefficient = 1e2;
+        // Bladed文件中没有给定GAEDGE，则JSON文件中GAyy为0，这里需要构造一个GAyy，用于IGA单元
+         if (abs(blade_section->GAyy) < 0.001) {
+            blade_section->GAyy =
+                blade_section->shear_modulus * blade_section->area * blade_section->y_shear_coefficient;
+        }
+        // Bladed文件中没有给定GAFLAP，则JSON文件中GAzz为0，这里需要构造一个GAzz，用于IGA单元
+         if (abs(blade_section->GAzz) < 0.001) {
+            blade_section->GAzz =
+                blade_section->shear_modulus * blade_section->area * blade_section->z_shear_coefficient;
+        }
+
+        blade_section->Klaw.setIdentity(6,6);
+        blade_section->Klaw(0, 0) = blade_section->EA;
+        blade_section->Klaw(1, 1) = blade_section->GAyy;
+        blade_section->Klaw(2, 2) = blade_section->GAzz;
+        blade_section->Klaw(3, 3) = blade_section->GJ;
+        blade_section->Klaw(4, 4) = blade_section->EIyy;
+        blade_section->Klaw(5, 5) = blade_section->EIzz;
+
+        blade_original_section_list_.push_back(blade_section);
+    }
+
+    std::vector<ChFrame<double>> middle_section_frame;
+    for (int i = 0; i < blade_node_counts - 1; i++) {
+        auto node_A = blade_original_section_list_[i];
+        auto node_B = blade_original_section_list_[i + 1];
+        auto average_twist = (node_A->ref_twist + node_B->ref_twist) * 0.5;
+        auto tmp = GetLocalFrameInBladeRootFrame(node_A->position, node_B->position, average_twist);
+        middle_section_frame.push_back(tmp);
+    }
+
+    std::vector<ChFrame<double>> blade_node_frame;
+    blade_node_frame.resize(blade_node_counts);
+    // 【除了叶根、叶尖两个node外】
+    // node的quatenion，由相邻两个section的quatenion平均而来
+    for (int i = 1; i < blade_node_counts - 1; i++) {
+        auto q = (middle_section_frame.at(i - 1).GetRot() + middle_section_frame.at(i).GetRot()).GetNormalized();
+        blade_node_frame.at(i) = chrono::ChFrame<double>(blade_original_section_list_[i]->position, q);
+    }
+    blade_node_frame.at(0) = chrono::ChFrame<double>(blade_original_section_list_.at(0)->position, chrono::QUNIT);
+    blade_node_frame.at(blade_node_counts - 1) = chrono::ChFrame<double>(
+        blade_original_section_list_.at(blade_node_counts - 1)->position, middle_section_frame.back().GetRot());
+
+    auto blade_root_coord_ = ChCoordsys<double>(foundation->GetCoord());
+    for (int i = 0; i < blade_node_counts; i++) {
+        //节点的坐标转换
+        auto node_temp = chrono_types::make_shared<ChNodeFEAxyzrot>(blade_node_frame[i]);
+        blade_nodes_.push_back(node_temp);
+        blade_mesh_->AddNode(blade_nodes_.back());  //节点一个个加入到mesh中
+    }
+
+    for (int i = 0; i < blade_node_counts; i++) {
+        //建立截面的数据
+        auto section = chrono_types::make_shared<ChBeamSectionTimoshenkoAdvancedGenericFPM>();
+
+        //截面属性设置
+        section->SetSectionRotation(blade_original_section_list_[i]->twist_rotation);
+        section->SetCenterOfMass(blade_original_section_list_[i]->mass_center.x(),
+                                 blade_original_section_list_[i]->mass_center.y());
+        section->SetCentroidY(blade_original_section_list_[i]->elastic_center.x());
+        section->SetCentroidZ(blade_original_section_list_[i]->elastic_center.y());
+        section->SetShearCenterY(blade_original_section_list_[i]->shear_center.x());
+        section->SetShearCenterZ(blade_original_section_list_[i]->shear_center.y());
+        section->SetMassPerUnitLength(blade_original_section_list_[i]->mass_per_length);
+        double Jmyy = blade_original_section_list_[i]->flap_inertia * blade_original_section_list_[i]->density;
+        double Jmzz = blade_original_section_list_[i]->edge_inertia * blade_original_section_list_[i]->density;
+        double Jmyz = 0.;
+        double mass_phi = blade_original_section_list_[i]->mass_twist - blade_original_section_list_[i]->ref_twist;
+        double Qmy = 0.;
+        double Qmz = 0.;
+        section->SetMainInertiasInMassReference(Jmyy, Jmzz, Jmyz, mass_phi, Qmy, Qmz);
+        section->SetArtificialJyyJzzFactor(1.0 / 500);
+        section->SetAxialRigidity(blade_original_section_list_[i]->EA);
+        section->SetXtorsionRigidity(blade_original_section_list_[i]->GJ);
+        section->SetYbendingRigidity(blade_original_section_list_[i]->EIyy);
+        section->SetZbendingRigidity(blade_original_section_list_[i]->EIzz);
+        section->SetYshearRigidity(blade_original_section_list_[i]->GAyy);
+        section->SetZshearRigidity(blade_original_section_list_[i]->GAyy);
+        DampingCoefficients mdamping_coeff;
+        mdamping_coeff.bx = pow(blade_original_section_list_[i]->rayleigh_damping_beta, 0.5);
+        mdamping_coeff.by = mdamping_coeff.bx;
+        mdamping_coeff.bz = mdamping_coeff.bx;
+        mdamping_coeff.bt = mdamping_coeff.bx;
+        section->SetBeamRaleyghDamping(mdamping_coeff);
+        section->SetStiffnessMatrixFPM(blade_original_section_list_[i]->Klaw);
+
+        blade_sections_.push_back(section);
+    }
+
+    for (int i = 0; i < blade_node_counts - 1; i++) {
+        // 建立变截面属性
+        auto tapered_section = chrono_types::make_shared<chrono::fea::ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM>();
+        tapered_section->SetLumpedMassMatrixType(false);
+        tapered_section->SetSectionA(blade_sections_.at(i));
+        tapered_section->SetSectionB(blade_sections_.at(i + 1));
+        tapered_section->SetLength(
+            (blade_original_section_list_.at(i + 1)->position - blade_original_section_list_.at(i)->position).Length());
+
+        blade_tapered_sections_.push_back(tapered_section);
+
+        blade_beams_.push_back(chrono_types::make_shared<chrono::fea::ChElementBeamTaperedTimoshenkoFPM>());
+        blade_beams_.back()->SetTaperedSection(tapered_section);
+
+        auto section_frame_g = middle_section_frame[i] >> blade_root_coord_;
+        auto node_a_frame_g = blade_nodes_[i]->Frame() >> blade_root_coord_;
+        auto node_b_frame_g = blade_nodes_[i + 1]->Frame() >> blade_root_coord_;
+
+        blade_beams_.back()->SetNodeAreferenceRot(section_frame_g.GetRot().GetConjugate() % node_a_frame_g.GetRot());
+        blade_beams_.back()->SetNodeBreferenceRot(section_frame_g.GetRot().GetConjugate() % node_b_frame_g.GetRot());
+        blade_beams_.back()->SetNodes(blade_nodes_.at(i), blade_nodes_.at(i + 1));
+        //        blade_beams_.back()->SetDisableCorotate(true);
+        blade_mesh_->AddElement(blade_beams_.back());  //单元一个个加入到mesh中
+    }
+
+    blade_mesh_->SetNameString("blade_mesh");
+    my_system.Add(blade_mesh_);
+
+    auto link_blade_root = chrono_types::make_shared<ChLinkMateFix>();
+    // 这里似乎node一定要在前面，否则数值计算稳定性不佳，可能崩溃
+    link_blade_root->Initialize(blade_nodes_[0], foundation);
+    my_system.Add(link_blade_root);
+    // my_system.Set_G_acc({9.81, 9.81, -2.*9.81});
+    my_system.Set_G_acc({0, 0, 0});
+    blade_nodes_.at(3)->SetForce({100., 200., 300.});
+    blade_nodes_.at(3)->SetTorque({400., 500., 600.});
+
+    mkl_solver_->UseSparsityPatternLearner(true);
+    mkl_solver_->LockSparsityPattern(true);
+    mkl_solver_->SetVerbose(false);
+    my_system.SetSolver(mkl_solver_);  //矩阵求解
+
+    my_system.SetTimestepperType(ChTimestepper::Type::HHT);
+    hht_time_stepper_ = std::dynamic_pointer_cast<ChTimestepperHHT>(my_system.GetTimestepper());
+    hht_time_stepper_->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+    hht_time_stepper_->SetMinStepSize(1e-9);
+    hht_time_stepper_->SetAbsTolerances(1e-6);
+    hht_time_stepper_->SetMaxiters(100);
+    hht_time_stepper_->SetStepControl(true);     // 提高数值计算的收敛性
+    hht_time_stepper_->SetModifiedNewton(true);  // 提高数值计算的收敛性
+
+    my_system.Setup();
+
+    // Output some results
+    GetLog() << "test_7: \n";
+    GetLog() << "Simulation starting..............\n";
+    GetLog() << "Blade tip coordinate X: " << blade_nodes_.back()->GetPos().x() << "\n";
+    GetLog() << "Blade tip coordinate Y: " << blade_nodes_.back()->GetPos().y() << "\n";
+    GetLog() << "Blade tip coordinate Z: " << blade_nodes_.back()->GetPos().z() << "\n";
+    my_system.DoStaticNonlinear(100, false);
+
+    GetLog() << "\n\n\n";
+    GetLog() << "Simulation finished..............\n";
+    GetLog() << "Blade tip coordinate X: " << blade_nodes_.back()->GetPos().x() << "\n";
+    GetLog() << "Blade tip coordinate Y: " << blade_nodes_.back()->GetPos().y() << "\n";
+    GetLog() << "Blade tip coordinate Z: " << blade_nodes_.back()->GetPos().z() << "\n";
+    GetLog() << "\n\n\n";
+
+    int node_ct = 5;
+    int start_node = 0;
+    ChMatrixDynamic<> Fout;
+    Fout.resize(12, node_ct * 2);
+    ChMatrixDynamic<> Fout1;
+    Fout1.resize(12, node_ct);
+    ChMatrixDynamic<> Fout2;
+    Fout2.resize(12, node_ct);
+    for (int i = 0; i < node_ct; i++) {
+        int j = i + start_node;
+
+        ChVectorDynamic<> Fi1;
+        Fi1.resize(12);
+        blade_beams_.at(j)->ComputeInternalForces(Fi1);
+
+        ChVectorN<double, 12> Fi2;
+        ChVector<> Fforce;
+        ChVector<> Mtorque;
+        blade_beams_.at(j)->EvaluateSectionForceTorque(-1, Fforce, Mtorque);
+        // blade_beams_.at(j)->EvaluateSectionForceTorque0(-1, Fforce, Mtorque);
+        Fi2.segment(0, 3) = Fforce.eigen() * (-1.0);
+        Fi2.segment(3, 3) = Mtorque.eigen() * (-1.0);
+        blade_beams_.at(j)->EvaluateSectionForceTorque(1, Fforce, Mtorque);
+        // blade_beams_.at(j)->EvaluateSectionForceTorque0(1, Fforce, Mtorque);
+        Fi2.segment(6, 3) = Fforce.eigen();
+        Fi2.segment(9, 3) = Mtorque.eigen();
+
+        auto q_element_abs_rot = blade_beams_.at(j)->GetAbsoluteRotation();
+        ChMatrix33<> Atoabs(q_element_abs_rot);
+        ChMatrix33<> AtolocwelA(blade_beams_.at(j)->GetNodeA()->Frame().GetRot().GetConjugate() % q_element_abs_rot);
+        ChMatrix33<> AtolocwelB(blade_beams_.at(j)->GetNodeB()->Frame().GetRot().GetConjugate() % q_element_abs_rot);
+        std::vector<ChMatrix33<>*> R;
+        R.push_back(&Atoabs);
+        R.push_back(&AtolocwelA);
+        R.push_back(&Atoabs);
+        R.push_back(&AtolocwelB);
+        ChVectorN<double, 12> Fi2abs;
+        ChMatrixCorotation::ComputeCK(Fi2, R, 4, Fi2abs);
+
+        Fout1.col(i) = Fi1;
+        Fout2.col(i) = Fi2abs;
+        Fout.col(2 * i) = Fi1;
+        Fout.col(2 * i + 1) = Fi2abs;
+    }
+
+    ChVectorDynamic<> Fi0;
+    Fi0.resize(6);
+    Fi0.segment(0, 3) = link_blade_root->Get_react_force().eigen();
+    Fi0.segment(3, 3) = link_blade_root->Get_react_torque().eigen();
+
+    GetLog() << "\n\n check Fout: \n";
+    GetLog() << (Fout1+Fout2);
+    GetLog() << "\n\n\n";
+
+    std::string asciifile_static = R"(E:\pengchao\matlab_work\blade\Fout_static_FPM.dat)";
+    chrono::ChStreamOutAsciiFile mfileo(asciifile_static.c_str());
+    mfileo.SetNumFormat("%.12g");
+    mfileo << "Fout0:\n" << Fi0 << "\n";
+    mfileo << "Fout1:\n" << Fout1 << "\n";
+    mfileo << "Fout2:\n" << Fout2 << "\n";
+    mfileo << "Fout:\n" << Fout << "\n";
+
+    bool bSolveMode = true;
+    if (bSolveMode) {  // start of modal solving
+        bool save_M = true;
+        bool save_K = true;
+        bool save_R = true;
+        bool save_Cq = true;
+        auto sysMat_name_temp = R"(E:\pengchao\matlab_work\blade\blade)";
+        const char* path_sysMatMKR = R"(E:\pengchao\matlab_work\blade\blade)";
+        //输出 M K R 矩阵到文本文件，方便matlab处理
+        my_system.DumpSystemMatrices(save_M, save_K, save_R, save_Cq, path_sysMatMKR);
+        //直接提取 M K R 矩阵，并计算特征值和特征向量
+        chrono::ChSparseMatrix sysMat_M;
+        my_system.GetMassMatrix(&sysMat_M);
+        chrono::ChSparseMatrix sysMat_K;
+        my_system.GetStiffnessMatrix(&sysMat_K);
+        chrono::ChSparseMatrix sysMat_R;
+        my_system.GetDampingMatrix(&sysMat_R);
+        chrono::ChSparseMatrix sysMat_Cq;
+        my_system.GetConstraintJacobianMatrix(&sysMat_Cq);
+        // 调用EIGEN3求解dense matrix的特征值和特征向量
+        Eigen::MatrixXd dense_sysMat_M = sysMat_M.toDense();
+        Eigen::MatrixXd dense_sysMat_K = sysMat_K.toDense();
+        Eigen::MatrixXd dense_sysMat_R = sysMat_R.toDense();
+        Eigen::MatrixXd dense_sysMat_Cq = sysMat_Cq.toDense();
+        // 计算Cq矩阵的null space（零空间）
+        Eigen::MatrixXd Cq_null_space = dense_sysMat_Cq.fullPivLu().kernel();
+        Eigen::MatrixXd M_hat = Cq_null_space.transpose() * dense_sysMat_M * Cq_null_space;
+        Eigen::MatrixXd K_hat = Cq_null_space.transpose() * dense_sysMat_K * Cq_null_space;
+        Eigen::MatrixXd R_hat = Cq_null_space.transpose() * dense_sysMat_R * Cq_null_space;
+        // frequency-shift，解决矩阵奇异问题，现在还用不着，可以置0
+        double freq_shift = 0.0;  //偏移值，可取1~10等任意数值
+        Eigen::MatrixXd M_bar = M_hat;
+        Eigen::MatrixXd K_bar = pow(freq_shift, 2) * M_hat + freq_shift * R_hat + K_hat;
+        Eigen::MatrixXd R_bar = 2 * freq_shift * M_hat + R_hat;
+        Eigen::MatrixXd M_bar_inv = M_bar.inverse();  //直接用dense matrix求逆也不慢
+        // 生成状态方程的 A 矩阵，其特征值就是模态频率
+        int dim = M_bar.rows();
+        Eigen::MatrixXd A_tilde(2 * dim, 2 * dim);  // 拼成系统矩阵 A 矩阵，dense matrix。
+        A_tilde << Eigen::MatrixXd::Zero(dim, dim), Eigen::MatrixXd::Identity(dim, dim), -M_bar_inv * K_bar,
+            -M_bar_inv * R_bar;
+        // 调用EIGEN3，dense matrix直接求解特征值和特征向量
+        // NOTE：EIGEN3在release模式下计算速度非常快[~1s]，在debug模式下计算速度非常慢[>100s]
+        Eigen::EigenSolver<Eigen::MatrixXd> eigenSolver(A_tilde);
+        Eigen::VectorXcd sys_eValues = eigenSolver.eigenvalues() + freq_shift;
+        Eigen::MatrixXcd sys_eVectors = eigenSolver.eigenvectors();
+
+        typedef std::tuple<double, double, double, std::complex<double>, Eigen::VectorXcd> myEigenRes;
+        std::vector<myEigenRes> eigen_vectors_and_values;
+        for (int i = 0; i < sys_eValues.size(); i++) {
+            myEigenRes vec_and_val(
+                std::abs(sys_eValues(i)) / (2 * PI),  // index：0     特征值的绝对值, 无阻尼模态频率
+                sys_eValues(i).imag() / (2 * PI),     // index：1     特征值的虚部,有阻尼模态频率
+                -sys_eValues(i).real() / std::abs(sys_eValues(i)),  // index：2     特征值的实部代表了阻尼比
+                sys_eValues(i),                                     // index：3     复数形式的特征值
+                sys_eVectors.col(i)                                 // index：4     振型
+            );
+            if (std::abs(sys_eValues(i).imag()) > 1.0e-6) {  // 只有虚部不为零的特征值会放入结果中
+                eigen_vectors_and_values.push_back(vec_and_val);
+            }
+        }
+        std::sort(eigen_vectors_and_values.begin(), eigen_vectors_and_values.end(),
+                  [&](const myEigenRes& a, const myEigenRes& b) -> bool {
+                      return std::get<1>(a) < std::get<1>(b);
+                  });  // index：1，表示按照特征值的虚部进行排序，‘ < ’为升序
+
+        int size = eigen_vectors_and_values.size();
+        int midN = (int)(size / 2);
+        int nModes = 20;  // 提取20阶模态频率，不要修改这个数值，因为与之对比的Bladed的模态结果只给了20阶
+        std::vector<Eigen::VectorXcd> res_Modeshapes;
+        Eigen::MatrixXd res_Modes(nModes, 3);
+        int jj = 0;
+        int i = 0;
+        while ((jj + midN) < size && i < nModes) {
+            // 前面一半的特征值的虚部为负数，没有意义，需要丢掉【QUESTION：这部分的特征值到底是什么物理意义？】
+            double damping_ratio = std::get<2>(eigen_vectors_and_values.at(jj + midN));
+            if (damping_ratio < 0.5) {  // 只提取模态阻尼比小于0.5的模态
+                res_Modes(i, 0) = std::get<0>(eigen_vectors_and_values.at(jj + midN));  // 无阻尼模态频率
+                res_Modes(i, 1) = std::get<1>(eigen_vectors_and_values.at(jj + midN));  // 有阻尼模态频率
+                res_Modes(i, 2) = std::get<2>(eigen_vectors_and_values.at(jj + midN));  // 阻尼比
+                // Eigen::VectorXcd tempVector = std::get<4>(eigen_vectors_and_values.at(jj + midN));
+                // res_Modeshapes.push_back(Cq_null_space * tempVector.head(midN));
+                i++;
+            }  // TODO：阵型提取，参考单叶片稳定性分析python代码中的算法
+            jj++;
+        }
+
+        // 与Bladed计算的单叶片模态频率对比，计算误差，%
+        Eigen::MatrixXd res_Bladed;
+        res_Bladed.resize(nModes, 1);
+        res_Bladed << 2.866, 4.5783, 8.0878, 14.44, 17.243, 29.435, 32.57, 43.261, 45.452, 60.195, 65.468, 71.914,
+            84.706, 97.478, 104.66, 109.45, 126.07, 130.82, 136.21, 146.88;
+        res_Bladed /= (2 * PI);  // 转换为Hz
+        Eigen::MatrixXd error_to_Bladed = (res_Modes.col(0).array() - res_Bladed.array()) / res_Bladed.array() * 100.0;
+
+        // 模态计算结果输出到屏幕
+        Eigen::MatrixXd res_output(nModes, 4);
+        res_output << res_Modes, error_to_Bladed;
+        std::cout << "The eigenvalues of single blade are:\t\n"
+                  << "01 undamped frequency/Hz\t"
+                  << "02 damped frequency/Hz\t"
+                  << "03 damping ratio\t"
+                  << "04 dfferences[%]\n"
+                  << res_output << std::endl;
+    }  // end of modal solving
+}
+
+
+void test_8() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko beam element  \n\n";
+    GetLog() << "TEST: To check the shear locking effect...  \n\n";
+
+    struct BladeSection {
+        double ref_twist;
+        double mass_twist;
+        double elastic_twist;
+        double aero_twist;
+        double twist_rotation;  // nodal section rotational angle, between elastic principal axis and reference axis
+        double area;            // A
+        double flap_inertia;    // Iyy
+        double edge_inertia;    // Izz
+        double polar_inertia;   // Ixx, Ip
+        double y_shear_coefficient;    // Ksy
+        double z_shear_coefficient;    // Ksz
+        double density;                // pho
+        double young_modulus;          // E
+        double shear_modulus;          // G
+        double rayleigh_damping_beta;  // beta
+        double EA;                     // axial stiffness
+        double GJ;                     // torsional stiffness
+        double EIyy;                   // flapwise stiffness, bending about y-axis
+        double EIzz;                   // edgewise stiffness, bending about z-axis
+        double GAyy;                   // shear stiffness along edgewise direction, along y-axis
+        double GAzz;                   // shear stiffness along flapwise direction, along z-axis
+        double mass_per_length;
+        double mass_inertia_Jxx_per_length;
+        double radii_of_gyration_ratio;
+        // double prebend_rotational_angle;
+        // double presweep_rotation_angle;
+
+        ChVector<double> position;
+        ChVector2<double> elastic_center;
+        ChVector2<double> mass_center;
+        ChVector2<double> shear_center;
+        ChVector2<double> aerodynamic_center;
+        ChFrame<double> section_frame_in_blade_root_frame;
+        ChQuaternion<double> q;
+
+        ChMatrixNM<double, 6, 6> Klaw;  // fully populated material stiffness matrix
+    };
+
+    auto GetLocalFrameInBladeRootFrame = [&](const ChVector<double>& nodeA_position,
+                                             const ChVector<double>& nodeB_position, const double local_twist) {
+        // 按照Bladed中的坐标变换顺序进行建模
+
+        // translation: 从叶根平移到截面处，不旋转
+        ChVector<double> section_position = 0.5 * (nodeA_position, nodeB_position);
+        ChFrame<double> translation(section_position, QUNIT);
+
+        ChVector<double> section_X_dir = (nodeB_position - nodeA_position).GetNormalized();
+
+        ChFrame<double> pretorsion_rotation({0, 0, 0}, Q_from_AngAxis(local_twist, VECT_X));
+        ChMatrix33<double> pretorsion_A = pretorsion_rotation.GetA();
+
+        double rx = nodeB_position.x() - nodeA_position.x();
+        double ry = nodeB_position.y() - nodeA_position.y();
+        double rz = nodeB_position.z() - nodeA_position.z();
+
+        double prebend_rot_angle = -atan2(rz, rx);
+        ChFrame<double> prebend_rotation({0, 0, 0}, Q_from_AngAxis(prebend_rot_angle, VECT_Y));
+        ChMatrix33<double> prebend_A = prebend_rotation.GetA();
+
+        double presweep_rot_angle = atan2(ry, rx);
+        ChFrame<double> presweep_rotation({0, 0, 0}, Q_from_AngAxis(presweep_rot_angle, VECT_Z));
+        ChMatrix33<double> presweep_A = presweep_rotation.GetA();
+
+        ChFrame<double> section_frame_tmp = pretorsion_rotation >> prebend_rotation >> presweep_rotation;
+        ChMatrix33<double> section_A_tmp = presweep_A * prebend_A * pretorsion_A;
+
+        ChVector<double> section_Z_dir = (section_A_tmp * chrono::VECT_Z).GetNormalized();
+        ChVector<double> section_Y_dir = Vcross(section_Z_dir, section_X_dir);
+        ChMatrix33<double> section_A = ChMatrix33<double>(section_X_dir, section_Y_dir, section_Z_dir);
+        // chrono::GetLog() << "section_X_dir: \t" << section_X_dir << "\n";
+        // chrono::GetLog() << "section_Y_dir: \t" << section_Y_dir << "\n";
+        // chrono::GetLog() << "section_Z_dir: \t" << section_Z_dir << "\n";
+        // chrono::GetLog() << "section_A: \t" << section_A << "\n";
+        ChFrame<double> section_frame = ChFrame<double>(section_position, section_A);
+        return section_frame;
+    };
+
+    double PI = 3.1415926535897932384626;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    std::vector<std::shared_ptr<ChBeamSectionTimoshenkoAdvancedGeneric>> blade_sections_;
+    std::vector<std::shared_ptr<ChBeamSectionTaperedTimoshenkoAdvancedGeneric>> blade_tapered_sections_;
+    std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenko>> blade_beams_;
+    auto blade_mesh_ = chrono_types::make_shared<ChMesh>();
+    auto blade_nodes_ = std::vector<std::shared_ptr<ChNodeFEAxyzrot>>();
+    auto mkl_solver_ = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper_ = chrono_types::make_shared<ChTimestepperHHT>();
+
+    Json json_info;
+    std::string JsonPath = "C:/Users/31848/Desktop/goldflex_chrono20210126/goldflex-mb/resource/case.example.gf.json";
+    std::ifstream case_stream{JsonPath};
+    case_stream >> json_info;
+    case_stream.close();
+    Json blade_section_info = json_info["blade1"]["sections"];
+    int blade_node_counts = blade_section_info.size();
+    std::vector<std::shared_ptr<BladeSection>> blade_original_section_list_;
+
+    auto GetOriginalData = [&](const std::string& key, const Json& current) { return current[key].get<double>(); };
+
+    double switchOff = 0.0;
+    double switchOn = 0.0;
+
+    for (int iSec = 0; iSec < blade_node_counts; iSec++) {
+        auto blade_section = std::make_shared<BladeSection>();
+        auto curr_info = blade_section_info[iSec];
+        // 暂时关掉预弯，避免quatenion变换太复杂 ChQuaternion
+        blade_section->position = ChVector<double>(curr_info["ref_location_z"].get<double>(),
+                                                   curr_info["ref_location_y"].get<double>() * switchOn,
+                                                   -curr_info["ref_location_x"].get<double>() * switchOn);
+        blade_section->ref_twist = GetOriginalData("ref_twist", curr_info) * switchOn;
+        blade_section->mass_twist = GetOriginalData("mass_twist", curr_info) * switchOn;
+        blade_section->elastic_twist = GetOriginalData("elastic_twist", curr_info) * switchOn;
+        blade_section->aero_twist = GetOriginalData("aerodynamic_twist", curr_info) * switchOn;
+        blade_section->twist_rotation = (blade_section->elastic_twist - blade_section->ref_twist) * switchOn;
+        blade_section->mass_center =
+            ChVector2<double>(GetOriginalData("mass_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("mass_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->aerodynamic_center =
+            ChVector2<double>(GetOriginalData("aerodynamic_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("aerodynamic_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->elastic_center =
+            ChVector2<double>(GetOriginalData("elastic_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("elastic_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->shear_center =
+            ChVector2<double>(GetOriginalData("shear_location_y_local", curr_info) * switchOn,
+                              GetOriginalData("shear_location_x_local", curr_info) * (-1.0) * switchOn);
+        blade_section->mass_per_length = GetOriginalData("mass_per_unit_length", curr_info);
+        blade_section->mass_inertia_Jxx_per_length = GetOriginalData("mass_inertia_Jzz_per_unit_length", curr_info);
+        blade_section->radii_of_gyration_ratio = GetOriginalData("radii_of_gyration_ratio", curr_info);
+        blade_section->EA = GetOriginalData("axial_stiffness", curr_info);
+        blade_section->GJ = GetOriginalData("torsional_stiffness", curr_info);
+        blade_section->EIyy = GetOriginalData("flapwise_bending_stiffness", curr_info);
+        blade_section->EIzz = GetOriginalData("edgewise_bending_stiffness", curr_info);
+        blade_section->GAyy = GetOriginalData("edgewise_shear_stiffness", curr_info);
+        blade_section->GAzz = GetOriginalData("flapwise_shear_stiffness", curr_info);
+        blade_section->rayleigh_damping_beta = GetOriginalData("damping_beta_coefficient", curr_info);
+
+        blade_section->young_modulus = 1.4e10;
+        blade_section->area = blade_section->EA / blade_section->young_modulus;
+        blade_section->density = blade_section->mass_per_length / blade_section->area;
+        blade_section->polar_inertia = blade_section->mass_inertia_Jxx_per_length / blade_section->density;
+        //      blade_section->flap_inertia = blade_section->EIyy / blade_section->young_modulus;
+        //      blade_section->edge_inertia = blade_section->EIzz / blade_section->young_modulus;
+        blade_section->edge_inertia = blade_section->polar_inertia / (1 + blade_section->radii_of_gyration_ratio *
+                                                                              blade_section->radii_of_gyration_ratio);
+        blade_section->flap_inertia = blade_section->edge_inertia * blade_section->radii_of_gyration_ratio *
+                                      blade_section->radii_of_gyration_ratio;
+        blade_section->shear_modulus = blade_section->GJ / blade_section->polar_inertia;
+        blade_section->y_shear_coefficient = 1e2;  // IGA单元需要构造一个很大的剪切刚度，但似乎太大了也不行
+        blade_section->z_shear_coefficient = 1e2;
+        // Bladed文件中没有给定GAEDGE，则JSON文件中GAyy为0，这里需要构造一个GAyy，用于IGA单元
+        if (abs(blade_section->GAyy) < 0.001) {
+            blade_section->GAyy =
+                blade_section->shear_modulus * blade_section->area * blade_section->y_shear_coefficient;
+        }
+        // Bladed文件中没有给定GAFLAP，则JSON文件中GAzz为0，这里需要构造一个GAzz，用于IGA单元
+        if (abs(blade_section->GAzz) < 0.001) {
+            blade_section->GAzz =
+                blade_section->shear_modulus * blade_section->area * blade_section->z_shear_coefficient;
+        }
+
+        blade_section->Klaw.setIdentity(6, 6);
+        blade_section->Klaw(0, 0) = blade_section->EA;
+        blade_section->Klaw(1, 1) = blade_section->GAyy;
+        blade_section->Klaw(2, 2) = blade_section->GAzz;
+        blade_section->Klaw(3, 3) = blade_section->GJ;
+        blade_section->Klaw(4, 4) = blade_section->EIyy;
+        blade_section->Klaw(5, 5) = blade_section->EIzz;
+
+        blade_original_section_list_.push_back(blade_section);
+    }
+
+    for (int i = 0; i < blade_node_counts; i++) {
+        //建立截面的数据
+        auto section = chrono_types::make_shared<ChBeamSectionTimoshenkoAdvancedGeneric>();
+
+        //截面属性设置
+        section->SetSectionRotation(blade_original_section_list_[i]->twist_rotation);
+        section->SetCenterOfMass(blade_original_section_list_[i]->mass_center.x(),
+                                 blade_original_section_list_[i]->mass_center.y());
+        section->SetCentroidY(blade_original_section_list_[i]->elastic_center.x());
+        section->SetCentroidZ(blade_original_section_list_[i]->elastic_center.y());
+        section->SetShearCenterY(blade_original_section_list_[i]->shear_center.x());
+        section->SetShearCenterZ(blade_original_section_list_[i]->shear_center.y());
+        section->SetMassPerUnitLength(blade_original_section_list_[i]->mass_per_length);
+        double Jmyy = blade_original_section_list_[i]->flap_inertia * blade_original_section_list_[i]->density;
+        double Jmzz = blade_original_section_list_[i]->edge_inertia * blade_original_section_list_[i]->density;
+        double Jmyz = 0.;
+        double mass_phi = blade_original_section_list_[i]->mass_twist - blade_original_section_list_[i]->ref_twist;
+        double Qmy = 0.;
+        double Qmz = 0.;
+        section->SetMainInertiasInMassReference(Jmyy, Jmzz, Jmyz, mass_phi, Qmy, Qmz);
+        section->SetArtificialJyyJzzFactor(1.0 / 500);
+        section->SetAxialRigidity(blade_original_section_list_[i]->EA);
+        section->SetXtorsionRigidity(blade_original_section_list_[i]->GJ);
+        section->SetYbendingRigidity(blade_original_section_list_[i]->EIyy);
+        section->SetZbendingRigidity(blade_original_section_list_[i]->EIzz);
+        DampingCoefficients mdamping_coeff;
+        mdamping_coeff.bx = pow(blade_original_section_list_[i]->rayleigh_damping_beta, 0.5);
+        mdamping_coeff.by = mdamping_coeff.bx;
+        mdamping_coeff.bz = mdamping_coeff.bx;
+        mdamping_coeff.bt = mdamping_coeff.bx;
+        section->SetBeamRaleyghDamping(mdamping_coeff);
+        section->SetYshearRigidity(blade_original_section_list_[i]->GAyy);
+        section->SetZshearRigidity(blade_original_section_list_[i]->GAyy);
+
+        blade_sections_.push_back(section);
+    }
+
+    double beam_length = 10.0;
+    auto mnodeA = chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(ChVector<>(0, 0, 0)));
+    auto mnodeB = chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(ChVector<>(beam_length, 0, 0)));
+    int beam_count = 10;
+
+
+    for (int i = 0; i < blade_node_counts - 1; i++) {
+        // 建立变截面属性
+        auto tapered_section = chrono_types::make_shared<chrono::fea::ChBeamSectionTaperedTimoshenkoAdvancedGeneric>();
+        tapered_section->SetLumpedMassMatrixType(false);
+        tapered_section->SetSectionA(blade_sections_.at(i));
+        tapered_section->SetSectionB(blade_sections_.at(i));
+        tapered_section->SetLength(beam_length / beam_count);
+
+        blade_tapered_sections_.push_back(tapered_section);
+    }
+
+    chrono::fea::ChBuilderBeamTaperedTimoshenko bladeBuilder;
+    blade_mesh_->AddNode(mnodeA);
+    blade_mesh_->AddNode(mnodeB);
+    bladeBuilder.BuildBeam(
+                           blade_mesh_,                 ///< mesh to store the resulting elements
+                           blade_tapered_sections_[0],  ///< section material for beam elements
+                           beam_count,                  ///< number of elements in the segment
+                           mnodeA,                      ///< starting point
+                           mnodeB,                      ///< ending point
+                           ChVector<>{0,1,0});
+
+    blade_mesh_->SetNameString("blade_mesh");
+    blade_mesh_->SetAutomaticGravity(true);
+
+    my_system.Set_G_acc({0,0,9.81});
+    //my_system.Set_G_acc({0, 0, 0});
+    
+    blade_nodes_ = bladeBuilder.GetLastBeamNodes();
+    blade_beams_ = bladeBuilder.GetLastBeamElements();
+    blade_nodes_.front()->SetFixed(true);
+    blade_nodes_.back()->SetForce(ChVector<>(0,0,1.e4));
+    my_system.Add(blade_mesh_);
+
+
+    mkl_solver_->UseSparsityPatternLearner(true);
+    mkl_solver_->LockSparsityPattern(true);
+    mkl_solver_->SetVerbose(false);
+    my_system.SetSolver(mkl_solver_);  //矩阵求解
+
+    my_system.SetTimestepperType(ChTimestepper::Type::HHT);
+    hht_time_stepper_ = std::dynamic_pointer_cast<ChTimestepperHHT>(my_system.GetTimestepper());
+    hht_time_stepper_->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+    hht_time_stepper_->SetMinStepSize(1e-9);
+    hht_time_stepper_->SetAbsTolerances(1e-6);
+    hht_time_stepper_->SetMaxiters(100);
+    hht_time_stepper_->SetStepControl(true);     // 提高数值计算的收敛性
+    hht_time_stepper_->SetModifiedNewton(true);  // 提高数值计算的收敛性
+
+    my_system.Setup();
+
+    // Output some results
+    GetLog() << "test_8: \n";
+    GetLog() << "Simulation starting..............\n";
+    GetLog() << "Blade tip coordinate X: " << blade_nodes_.back()->GetPos().x() << "\n";
+    GetLog() << "Blade tip coordinate Y: " << blade_nodes_.back()->GetPos().y() << "\n";
+    GetLog() << "Blade tip coordinate Z: " << blade_nodes_.back()->GetPos().z() << "\n";
+    my_system.DoStaticNonlinear(100, false);
+
+    GetLog() << "\n\n\n";
+    GetLog() << "Simulation finished..............\n";
+    GetLog() << "Blade tip coordinate X: " << blade_nodes_.back()->GetPos().x() << "\n";
+    GetLog() << "Blade tip coordinate Y: " << blade_nodes_.back()->GetPos().y() << "\n";
+    GetLog() << "Blade tip coordinate Z: " << blade_nodes_.back()->GetPos().z() << "\n";
+    GetLog() << "\n\n\n";
+
+  
+    /*std::string asciifile_static = R"(E:\pengchao\matlab_work\blade\Fout_static_FPM.dat)";
+    chrono::ChStreamOutAsciiFile mfileo(asciifile_static.c_str());
+    mfileo.SetNumFormat("%.12g");
+    mfileo << "Fout0:\n" << Fi0 << "\n";
+    mfileo << "Fout1:\n" << Fout1 << "\n";
+    mfileo << "Fout2:\n" << Fout2 << "\n";
+    mfileo << "Fout:\n" << Fout << "\n";*/
+
+}
+
+void test_9() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko beam element  \n\n";
+    GetLog() << "TEST: To check the shear locking effect...  \n\n";
+
+
+    double PI = 3.1415926535897932384626;
+    double rad2deg = 180.0 / PI;
+    double deg2rad = 1. / rad2deg;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    auto mynodes = std::vector<std::shared_ptr<ChNodeFEAxyzrot>>();
+    auto mkl_solver = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper = chrono_types::make_shared<ChTimestepperHHT>();
+
+    double P1 = 4.448;
+    double P2 = 8.896;
+    double P3 = 13.345;
+    //double P_load = P1;
+    //double theta = 45.0 * deg2rad;
+
+    std::vector<double> vec_P_load = {P1,P2,P3};
+    std::vector<double> vec_theta = { 0,15,30,45,60,75,90};
+
+    double pho = 2.7e3;
+    double L = 0.508;
+    double H = 12.77*0.001;
+    double T = 3.2024*0.001;
+    double E = 71.7 * 1e9;
+    double miu = 0.31;
+    double G = E * (1. + miu) / 2.0;
+    double A = H*T;
+    double Iyy = 1./12.*T*H*H*H;
+    double Izz = 1./12.*H*T*T*T;
+    double Ixx = Iyy + Izz;
+    double ky = 6. / 5.;  // for rectangle section
+    double kz = ky;
+    double EA = E*A;
+    double GAyy = ky*G*A;
+    double GAzz = kz*G*A;
+    double GJ = G * Ixx;
+    double EIyy = E * Iyy;
+    double EIzz = E * Izz;
+    double Jyy = pho*Iyy;
+    double Jzz = pho*Izz;
+    double Jxx = Jyy+Jzz;
+    double Jyz = 0.0;
+    double Qy = 0;
+    double Qz = 0;
+
+    double H22 = EIyy;
+    double H33 = EIzz;
+    double K22 = GAyy;
+    double K33 = GAzz;
+
+    bool file_flag = false;
+    for (int i_Pload = 0; i_Pload < 3; i_Pload++) {
+        for (int i_theta = 0; i_theta < 7; i_theta++) {
+            double P_load = vec_P_load[i_Pload] * (-1);
+            double theta = vec_theta[i_theta] * deg2rad * (-1);
+            double u2_ref = (P_load * L * L * L / (3 * H33) + P_load * L / K22) * sin(theta);
+            double u3_ref = (P_load * L * L * L / (3 * H22) + P_load * L / K33) * cos(theta);
+
+            ChFrame<> root_frame_local = ChFrame<>({0, 0, 0}, Q_from_AngX(theta));
+
+            auto section = chrono_types::make_shared<ChBeamSectionTimoshenkoAdvancedGeneric>();
+            //截面属性设置
+            section->SetSectionRotation(theta*0);
+            section->SetCenterOfMass(0, 0);
+            section->SetCentroidY(0);
+            section->SetCentroidZ(0);
+            section->SetShearCenterY(0);
+            section->SetShearCenterZ(0);
+            section->SetMassPerUnitLength(pho * A);
+            double Jmyy = Jyy;
+            double Jmzz = Jzz;
+            double Jmyz = 0.;
+            double mass_phi = theta*0;
+            double Qmy = 0.;
+            double Qmz = 0.;
+            section->SetMainInertiasInMassReference(Jmyy, Jmzz, Jmyz, mass_phi, Qmy, Qmz);
+            section->SetArtificialJyyJzzFactor(1.0 / 500.);
+            section->SetAxialRigidity(EA);
+            section->SetXtorsionRigidity(GJ);
+            section->SetYbendingRigidity(EIyy);
+            section->SetZbendingRigidity(EIzz);
+            DampingCoefficients mdamping_coeff;
+            mdamping_coeff.bx = pow(0.0007, 0.5);
+            mdamping_coeff.by = mdamping_coeff.bx;
+            mdamping_coeff.bz = mdamping_coeff.bx;
+            mdamping_coeff.bt = mdamping_coeff.bx;
+            section->SetBeamRaleyghDamping(mdamping_coeff);
+            section->SetYshearRigidity(GAyy);
+            section->SetZshearRigidity(GAyy);
+
+            double beam_length = L;
+            auto mnodeA =
+                chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(ChVector<>(0, 0, 0), root_frame_local.GetRot()));
+            auto mnodeB = chrono_types::make_shared<ChNodeFEAxyzrot>(
+                ChFrame<>(ChVector<>(beam_length, 0, 0), root_frame_local.GetRot()));
+            int beam_count = 2;
+
+            auto tapered_section =
+                chrono_types::make_shared<chrono::fea::ChBeamSectionTaperedTimoshenkoAdvancedGeneric>();
+            tapered_section->SetLumpedMassMatrixType(false);
+            tapered_section->SetSectionA(section);
+            tapered_section->SetSectionB(section);
+            tapered_section->SetLength(beam_length / beam_count);
+
+            chrono::fea::ChBuilderBeamTaperedTimoshenko bladeBuilder;
+
+            std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenko>> mybeams;
+            auto mymesh = chrono_types::make_shared<ChMesh>();
+            mymesh->AddNode(mnodeA);
+            mymesh->AddNode(mnodeB);
+            bladeBuilder.BuildBeam(mymesh,           ///< mesh to store the resulting elements
+                                   tapered_section,  ///< section material for beam elements
+                                   beam_count,       ///< number of elements in the segment
+                                   mnodeA,           ///< starting point
+                                   mnodeB,           ///< ending point
+                                   // ChVector<>{0, 1, 0}, //the 'up' Y direction of the beam
+                                   root_frame_local.TransformLocalToParent(ChVector<>{0, 1, 0})
+            );
+
+            mymesh->SetAutomaticGravity(true);
+
+            my_system.Set_G_acc({0, 0, -9.81});
+            // my_system.Set_G_acc({0, 0, 0});
+
+            mynodes = bladeBuilder.GetLastBeamNodes();
+            mybeams = bladeBuilder.GetLastBeamElements();
+            mynodes.front()->SetFixed(true);
+            mynodes.back()->SetForce(ChVector<>(0, 0, P_load));
+            my_system.Add(mymesh);
+
+            mkl_solver->UseSparsityPatternLearner(true);
+            mkl_solver->LockSparsityPattern(true);
+            mkl_solver->SetVerbose(false);
+            my_system.SetSolver(mkl_solver);  //矩阵求解
+
+            my_system.SetTimestepperType(ChTimestepper::Type::HHT);
+            hht_time_stepper = std::dynamic_pointer_cast<ChTimestepperHHT>(my_system.GetTimestepper());
+            hht_time_stepper->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+            hht_time_stepper->SetMinStepSize(1e-9);
+            hht_time_stepper->SetAbsTolerances(1e-6);
+            hht_time_stepper->SetMaxiters(100);
+            hht_time_stepper->SetStepControl(true);     // 提高数值计算的收敛性
+            hht_time_stepper->SetModifiedNewton(false);  // 提高数值计算的收敛性
+
+            my_system.Setup();
+
+            // Output some results
+            GetLog() << "test_9: \n";
+            GetLog() << "Simulation starting..............\n";
+            GetLog() << "Blade tip coordinate X: " << mynodes.back()->GetPos().x() << "\n";
+            GetLog() << "Blade tip coordinate Y: " << mynodes.back()->GetPos().y() << "\n";
+            GetLog() << "Blade tip coordinate Z: " << mynodes.back()->GetPos().z() << "\n";
+            my_system.DoStaticNonlinear(100, false);
+
+            ChFrame<> tip_rel_frame;
+            ChFrame<> tip_abs_frame = ChFrame<>(mynodes.back()->GetCoord());
+            root_frame_local.TransformParentToLocal(tip_abs_frame, tip_rel_frame);
+            // Beam tip coordinate
+            double PosX = tip_rel_frame.GetPos().x();
+            double PosY = tip_rel_frame.GetPos().y();
+            double PosZ = tip_rel_frame.GetPos().z();
+
+            ChMatrix33<> matrix_beam_tip;
+            // matrix_beam_tip.Set_A_quaternion(mynodes.back()->GetRot());
+            matrix_beam_tip.Set_A_quaternion(tip_abs_frame.GetRot());
+            double R33 = matrix_beam_tip(2, 2);
+            double R23 = matrix_beam_tip(1, 2);
+            double tip_rotation_angle = (-atan2(R23, R33) - theta) * rad2deg;
+
+            // Beam tip Euler Angle
+            double RotX_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().x() * rad2deg - theta * rad2deg;
+            double RotY_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().y() * rad2deg;
+            double RotZ_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().z() * rad2deg;
+            // Beam tip rotation angle using Axis-Angle(旋转向量法)
+            double rot_alpha = tip_rel_frame.GetRotAngle();
+            ChVector<> rot_vector = tip_rel_frame.GetRotAxis();
+            double RotX_AxisAngle = rot_alpha * rot_vector.x() * rad2deg;
+            double RotY_AxisAngle = rot_alpha * rot_vector.y() * rad2deg;
+            double RotZ_AxisAngle = rot_alpha * rot_vector.z() * rad2deg;
+
+            static std::string asciifile_static = R"(E:\pengchao\matlab_work\PrincetonBeam\result_timoshenko.dat)";
+            static chrono::ChStreamOutAsciiFile mfileo(asciifile_static.c_str());
+            if (file_flag == false) {
+                mfileo.SetNumFormat("%.12g");
+                mfileo << "\t P_load Y:\t"
+                       << "theta:\t"
+                       << "Beam Tip Deflection:\n";
+                file_flag = true;  //只执行一次
+            }
+
+            mfileo << -P_load << "\t" << -theta * rad2deg << "\t" << PosX << "\t" << PosY << "\t" << -PosZ << "\t"
+                   << RotX_EulerAngle << "\t" << RotY_EulerAngle << "\t" << RotZ_EulerAngle << "\t" << RotX_AxisAngle
+                   << "\t" << RotY_AxisAngle << "\t" << RotZ_AxisAngle << "\t" << tip_rotation_angle << "\t" << u2_ref
+                   << "\t" << -u3_ref << "\n";
+            // clear system
+            my_system.RemoveAllBodies();
+            my_system.RemoveAllLinks();
+            my_system.RemoveAllMeshes();
+            my_system.RemoveAllOtherPhysicsItems();
+        }
+    }
+}
+
+void test_10() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the Euler beam element  \n\n";
+    GetLog() << "TEST: To compare with Timoshenko beam  \n\n";
+
+    double PI = 3.1415926535897932384626;
+    double rad2deg = 180.0 / PI;
+    double deg2rad = 1. / rad2deg;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    auto mynodes = std::vector<std::shared_ptr<ChNodeFEAxyzrot>>();
+    auto mkl_solver = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper = chrono_types::make_shared<ChTimestepperHHT>();
+
+    double P1 = 4.448;
+    double P2 = 8.896;
+    double P3 = 13.345;
+    // double P_load = P1;
+    // double theta = 45.0 * deg2rad;
+
+    std::vector<double> vec_P_load = {P1, P2, P3};
+    std::vector<double> vec_theta = {0, 15, 30, 45, 60, 75, 90};
+
+    double pho = 2.7e3;
+    double L = 0.508;
+    double H = 12.77 * 0.001;
+    double T = 3.2024 * 0.001;
+    double E = 71.7 * 1.e9;
+    double miu = 0.31;
+    double G = E * (1. + miu) / 2.0;
+    double A = H * T;
+    double Iyy = 1. / 12. * T * H * H * H;
+    double Izz = 1. / 12. * H * T * T * T;
+    double Ixx = Iyy + Izz;
+    double ky = 6. / 5.;  // for rectangle section
+    double kz = ky;
+    double EA = E * A;
+    double GAyy = ky * G * A;
+    double GAzz = kz * G * A;
+    double GJ = G * Ixx;
+    double EIyy = E * Iyy;
+    double EIzz = E * Izz;
+    double Jyy = pho * Iyy;
+    double Jzz = pho * Izz;
+    double Jxx = Jyy + Jzz;
+    double Jyz = 0.0;
+    double Qy = 0;
+    double Qz = 0;
+
+    double H22 = EIyy;
+    double H33 = EIzz;
+    double K22 = GAyy;
+    double K33 = GAzz;
+
+    bool file_flag = false;
+    for (int i_Pload = 0; i_Pload < 3; i_Pload++) {
+        for (int i_theta = 0; i_theta < 7; i_theta++) {
+            double P_load = vec_P_load[i_Pload] * (-1);
+            double theta = vec_theta[i_theta] * deg2rad * (-1);
+            double u2_ref = (P_load * L * L * L / (3 * H33) + P_load * L / K22) * sin(theta);
+            double u3_ref = (P_load * L * L * L / (3 * H22) + P_load * L / K33) * cos(theta);
+
+            ChFrame<> root_frame_local = ChFrame<>({0, 0, 0}, Q_from_AngX(theta));
+
+            auto msection = chrono_types::make_shared<ChBeamSectionEulerAdvancedGeneric>();
+            //截面属性设置
+            msection->SetSectionRotation(theta*0);
+            msection->SetCenterOfMass(0, 0);
+            msection->SetCentroidY(0);
+            msection->SetCentroidZ(0);
+            msection->SetShearCenterY(0);
+            msection->SetShearCenterZ(0);
+            msection->SetMassPerUnitLength(pho * A);
+            msection->SetArtificialJyyJzzFactor(1.0 / 500.);
+            msection->SetAxialRigidity(EA);
+            msection->SetXtorsionRigidity(GJ);
+            msection->SetYbendingRigidity(EIyy);
+            msection->SetZbendingRigidity(EIzz);
+            msection->SetBeamRaleyghDamping(0.0007);
+            msection->SetInertiaJxxPerUnitLength(Jxx);
+
+            double beam_length = L;
+            auto mnodeA =
+                chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(ChVector<>(0, 0, 0), root_frame_local.GetRot()));
+            auto mnodeB = chrono_types::make_shared<ChNodeFEAxyzrot>(
+                ChFrame<>(ChVector<>(beam_length, 0, 0), root_frame_local.GetRot()));
+            int beam_count = 2;
+
+            chrono::fea::ChBuilderBeamEuler beamBuilder;
+            auto mymesh = chrono_types::make_shared<ChMesh>();
+            mymesh->AddNode(mnodeA);
+            mymesh->AddNode(mnodeB);
+            beamBuilder.BuildBeam(mymesh,      ///< mesh to store the resulting elements
+                                  msection,    ///< section material for beam elements
+                                  beam_count,  ///< number of elements in the segment
+                                  mnodeA,      ///< starting point
+                                  mnodeB,      ///< ending point
+                                  // ChVector<>{0, 1, 0}, //the 'up' Y direction of the beam
+                                  root_frame_local.TransformLocalToParent(ChVector<>{0, 1, 0})
+                                    );
+
+            mymesh->SetAutomaticGravity(true);
+
+            // mnodeA->SetFixed(true);
+            my_system.Set_G_acc({0, 0, -9.81});
+            // my_system.Set_G_acc({0, 0, 0});
+
+            auto mynodes = beamBuilder.GetLastBeamNodes();
+            auto mybeams = beamBuilder.GetLastBeamElements();
+            mynodes.front()->SetFixed(true);
+            mynodes.back()->SetForce(ChVector<>(0, 0, P_load));
+            my_system.Add(mymesh);
+
+            mkl_solver->UseSparsityPatternLearner(true);
+            mkl_solver->LockSparsityPattern(true);
+            mkl_solver->SetVerbose(false);
+            my_system.SetSolver(mkl_solver);  //矩阵求解
+
+            my_system.SetTimestepperType(ChTimestepper::Type::HHT);
+            hht_time_stepper = std::dynamic_pointer_cast<ChTimestepperHHT>(my_system.GetTimestepper());
+            hht_time_stepper->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+            hht_time_stepper->SetMinStepSize(1.e-9);
+            hht_time_stepper->SetAbsTolerances(1.e-6);
+            hht_time_stepper->SetMaxiters(100);
+            hht_time_stepper->SetStepControl(true);     // 提高数值计算的收敛性
+            hht_time_stepper->SetModifiedNewton(false);  // 提高数值计算的收敛性
+
+            my_system.Setup();
+
+            // Output some results
+            GetLog() << "test_10: \n";
+            GetLog() << "Simulation starting..............\n";
+            GetLog() << "Blade tip coordinate X: " << mynodes.back()->GetPos().x() << "\n";
+            GetLog() << "Blade tip coordinate Y: " << mynodes.back()->GetPos().y() << "\n";
+            GetLog() << "Blade tip coordinate Z: " << mynodes.back()->GetPos().z() << "\n";
+            my_system.DoStaticNonlinear(100, false);
+
+            ChFrame<> tip_rel_frame;
+            ChFrame<> tip_abs_frame = ChFrame<>(mynodes.back()->GetCoord());
+            root_frame_local.TransformParentToLocal(tip_abs_frame, tip_rel_frame);
+            // Beam tip coordinate
+            double PosX = tip_rel_frame.GetPos().x();
+            double PosY = tip_rel_frame.GetPos().y();
+            double PosZ = tip_rel_frame.GetPos().z();
+
+            ChMatrix33<> matrix_beam_tip;
+            // matrix_beam_tip.Set_A_quaternion(mynodes.back()->GetRot());
+            matrix_beam_tip.Set_A_quaternion(tip_abs_frame.GetRot());
+            double R33 = matrix_beam_tip(2, 2);
+            double R23 = matrix_beam_tip(1, 2);
+            double tip_rotation_angle = (-atan2(R23, R33) - theta) * rad2deg;
+
+            // Beam tip Euler Angle
+            double RotX_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().x() * rad2deg - theta * rad2deg;
+            double RotY_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().y() * rad2deg;
+            double RotZ_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().z() * rad2deg;
+            // Beam tip rotation angle using Axis-Angle(旋转向量法)
+            double rot_alpha = tip_rel_frame.GetRotAngle();
+            ChVector<> rot_vector = tip_rel_frame.GetRotAxis();
+            double RotX_AxisAngle = rot_alpha * rot_vector.x() * rad2deg;
+            double RotY_AxisAngle = rot_alpha * rot_vector.y() * rad2deg;
+            double RotZ_AxisAngle = rot_alpha * rot_vector.z() * rad2deg;
+
+            static std::string asciifile_static = R"(E:\pengchao\matlab_work\PrincetonBeam\result_euler.dat)";
+            static chrono::ChStreamOutAsciiFile mfileo(asciifile_static.c_str());
+            if (file_flag == false) {
+                mfileo.SetNumFormat("%.12g");
+                mfileo << "\t P_load Y:\t"
+                       << "theta:\t"
+                       << "Beam Tip Deflection:\n";
+                file_flag = true;  //只执行一次
+            }
+
+            mfileo << -P_load << "\t" << -theta * rad2deg << "\t" << PosX << "\t" << PosY << "\t" << -PosZ << "\t"
+                   << RotX_EulerAngle << "\t" << RotY_EulerAngle << "\t" << RotZ_EulerAngle << "\t" << RotX_AxisAngle
+                   << "\t" << RotY_AxisAngle << "\t" << RotZ_AxisAngle << "\t" << tip_rotation_angle << "\t" << u2_ref
+                   << "\t" << -u3_ref << "\n";
+            // clear system
+            my_system.RemoveAllBodies();
+            my_system.RemoveAllLinks();
+            my_system.RemoveAllMeshes();
+            my_system.RemoveAllOtherPhysicsItems();
+        }
+    }
+
+}
+
+void test_11() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the IGA beam element  \n\n";
+    GetLog() << "TEST: To compare with Timoshenko beam  \n\n";
+
+    double PI = 3.1415926535897932384626;
+    double rad2deg = 180.0 / PI;
+    double deg2rad = 1. / rad2deg;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    auto mynodes = std::vector<std::shared_ptr<ChNodeFEAxyzrot>>();
+    auto mkl_solver = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper = chrono_types::make_shared<ChTimestepperHHT>();
+
+    double P1 = 4.448;
+    double P2 = 8.896;
+    double P3 = 13.345;
+    // double P_load = P1;
+    // double theta = 45.0 * deg2rad;
+
+    std::vector<double> vec_P_load = {P1, P2, P3};
+    std::vector<double> vec_theta = {0, 15, 30, 45, 60, 75, 90};
+
+    double pho = 2.7e3;
+    double L = 0.508;
+    double H = 12.77 * 0.001;
+    double T = 3.2024 * 0.001;
+    double E = 71.7 * 1.e9;
+    double miu = 0.31;
+    double G = E * (1. + miu) / 2.0;
+    double A = H * T;
+    double Iyy = 1. / 12. * T * H * H * H;
+    double Izz = 1. / 12. * H * T * T * T;
+    double Ixx = Iyy + Izz;
+    double ky = 6. / 5.;  // for rectangle section
+    double kz = ky;
+    double EA = E * A;
+    double GAyy = ky * G * A;
+    double GAzz = kz * G * A;
+    double GJ = G * Ixx;
+    double EIyy = E * Iyy;
+    double EIzz = E * Izz;
+    double Jyy = pho * Iyy;
+    double Jzz = pho * Izz;
+    double Jxx = Jyy + Jzz;
+    double Jyz = 0.0;
+    double Qy = 0;
+    double Qz = 0;
+
+    double H22 = EIyy;
+    double H33 = EIzz;
+    double K22 = GAyy;
+    double K33 = GAzz;
+
+    bool file_flag = false;
+    for (int i_Pload = 0; i_Pload < 3; i_Pload++) {
+        for (int i_theta = 0; i_theta < 7; i_theta++) {
+            double P_load = vec_P_load[i_Pload] * (-1);
+            double theta = vec_theta[i_theta] * deg2rad * (-1);
+            double u2_ref = (P_load * L * L * L / (3 * H33) + P_load * L / K22) * sin(theta);
+            double u3_ref = (P_load * L * L * L / (3 * H22) + P_load * L / K33) * cos(theta);
+
+            ChFrame<> root_frame_local = ChFrame<>({0, 0, 0}, Q_from_AngX(theta));
+
+            auto section_inertia = chrono_types::make_shared<ChInertiaCosseratAdvanced>();
+            section_inertia->SetMassPerUnitLength(pho * A);
+            section_inertia->SetCenterOfMass(0,0);
+            double ArtificialJyyJzzFactor = 1.0 / 2;
+            section_inertia->SetMainInertiasInMassReference(Jyy, Jzz, 0);
+
+            auto section_elasticity = chrono_types::make_shared<chrono::fea::ChElasticityCosseratAdvancedGeneric>();
+            section_elasticity->SetCentroid(0,0);
+            section_elasticity->SetSectionRotation(theta*0);
+            section_elasticity->SetShearCenter(0,0);
+            section_elasticity->SetShearRotation(theta*0);
+            section_elasticity->SetAxialRigidity(EA);
+            section_elasticity->SetXtorsionRigidity(GJ);
+            section_elasticity->SetYbendingRigidity(EIyy);
+            section_elasticity->SetZbendingRigidity(EIzz);
+            section_elasticity->SetYshearRigidity(GAyy);
+            section_elasticity->SetZshearRigidity(GAzz);
+
+            auto section_elasticity_fpm = chrono_types::make_shared<chrono::fea::ChElasticityCosseratAdvancedGenericFPM>();
+            section_elasticity_fpm->SetCentroid(0, 0);
+            section_elasticity_fpm->SetSectionRotation(theta * 0);
+            section_elasticity_fpm->SetShearCenter(0, 0);
+            section_elasticity_fpm->SetShearRotation(theta * 0);
+            ChMatrixNM<double, 6, 6> mKlaw;
+            mKlaw(0, 0) = EA;
+            mKlaw(1, 1) = GAyy;
+            mKlaw(2, 2) = GAzz;
+            mKlaw(3, 3) = GJ;
+            mKlaw(4, 4) = EIyy;
+            mKlaw(5, 5) = EIzz;
+            section_elasticity_fpm->UpdateEMatrix();
+
+
+            auto section_damping =
+                chrono_types::make_shared<chrono::fea::ChDampingCosseratRayleigh>(section_elasticity, 0);
+            // TODO: IGA的阻尼似乎大了一倍
+            section_damping->SetBeta(0.0007);
+
+
+            bool use_fpm = true;
+            std::shared_ptr<chrono::fea::ChBeamSectionCosserat> msection;
+            if (use_fpm) {
+                msection = chrono_types::make_shared<chrono::fea::ChBeamSectionCosserat>(section_inertia,
+                                                                                         section_elasticity_fpm);
+            } else {
+                msection =
+                    chrono_types::make_shared<chrono::fea::ChBeamSectionCosserat>(section_inertia, section_elasticity);
+            }
+            msection->SetDamping(section_damping);
+
+
+            double beam_length = L;
+            auto mnodeA = chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(ChVector<>(0, 0, 0), root_frame_local.GetRot()));
+            auto mnodeB = chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(ChVector<>(beam_length, 0, 0), root_frame_local.GetRot()));
+            int beam_count = 2;
+
+            chrono::fea::ChBuilderBeamIGA beamBuilder;
+            auto mymesh = chrono_types::make_shared<ChMesh>();
+            mymesh->AddNode(mnodeA);
+            mymesh->AddNode(mnodeB);
+            int spline_order = 3;
+            beamBuilder.BuildBeam(mymesh,      ///< mesh to store the resulting elements
+                                  msection,    ///< section material for beam elements
+                                  beam_count,  ///< number of elements in the segment
+                                  mnodeA->GetPos(),      ///< starting point
+                                  mnodeB->GetPos(),  ///< ending point
+                                  //ChVector<>{0, 1, 0}, //the 'up' Y direction of the beam
+                                  root_frame_local.TransformLocalToParent(ChVector<>{0, 1, 0}),
+                                  spline_order);    //  the order of spline
+
+            mymesh->SetAutomaticGravity(true);
+
+            // mnodeA->SetFixed(true);
+            my_system.Set_G_acc({0, 0, -9.81});
+            // my_system.Set_G_acc({0, 0, 0});
+
+            auto mynodes = beamBuilder.GetLastBeamNodes();
+            auto mybeams = beamBuilder.GetLastBeamElements();
+            mynodes.front()->SetFixed(true);
+            mynodes.back()->SetForce(ChVector<>(0, 0, P_load));
+            my_system.Add(mymesh);
+
+            mkl_solver->UseSparsityPatternLearner(true);
+            mkl_solver->LockSparsityPattern(true);
+            mkl_solver->SetVerbose(false);
+            my_system.SetSolver(mkl_solver);  //矩阵求解
+
+            my_system.SetTimestepperType(ChTimestepper::Type::HHT);
+            hht_time_stepper = std::dynamic_pointer_cast<ChTimestepperHHT>(my_system.GetTimestepper());
+            hht_time_stepper->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+            hht_time_stepper->SetMinStepSize(1.e-9);
+            hht_time_stepper->SetAbsTolerances(1.e-6);
+            hht_time_stepper->SetMaxiters(100);
+            hht_time_stepper->SetStepControl(true);      // 提高数值计算的收敛性
+            hht_time_stepper->SetModifiedNewton(false);  // 提高数值计算的收敛性
+
+            my_system.Setup();
+
+            // Output some results
+            GetLog() << "test_10: \n";
+            GetLog() << "Simulation starting..............\n";
+            GetLog() << "Beam tip coordinate X: " << mynodes.back()->GetPos().x() << "\n";
+            GetLog() << "Beam tip coordinate Y: " << mynodes.back()->GetPos().y() << "\n";
+            GetLog() << "Beam tip coordinate Z: " << mynodes.back()->GetPos().z() << "\n";
+            my_system.DoStaticNonlinear(100, false);
+
+            ChFrame<> tip_rel_frame;
+            ChFrame<> tip_abs_frame = ChFrame<> (mynodes.back()->GetCoord());
+            root_frame_local.TransformParentToLocal(tip_abs_frame, tip_rel_frame);
+            // Beam tip coordinate
+            double PosX = tip_rel_frame.GetPos().x();
+            double PosY = tip_rel_frame.GetPos().y();
+            double PosZ = tip_rel_frame.GetPos().z();
+
+            ChMatrix33<> matrix_beam_tip;
+            //matrix_beam_tip.Set_A_quaternion(mynodes.back()->GetRot());
+            matrix_beam_tip.Set_A_quaternion(tip_abs_frame.GetRot());
+            double R33 = matrix_beam_tip(2, 2);
+            double R23 = matrix_beam_tip(1, 2);
+            double tip_rotation_angle = ( - atan2(R23, R33) - theta) * rad2deg;
+            
+            // Beam tip Euler Angle
+            double RotX_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().x() * rad2deg - theta * rad2deg;
+            double RotY_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().y() * rad2deg;
+            double RotZ_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().z() * rad2deg;
+            // Beam tip rotation angle using Axis-Angle(旋转向量法)
+            double rot_alpha = tip_rel_frame.GetRotAngle();
+            ChVector<> rot_vector = tip_rel_frame.GetRotAxis();
+            double RotX_AxisAngle = rot_alpha * rot_vector.x() * rad2deg;
+            double RotY_AxisAngle = rot_alpha * rot_vector.y() * rad2deg;
+            double RotZ_AxisAngle = rot_alpha * rot_vector.z() * rad2deg;
+
+            static std::string asciifile_static = R"(E:\pengchao\matlab_work\PrincetonBeam\result_iga.dat)";
+            static chrono::ChStreamOutAsciiFile mfileo(asciifile_static.c_str());
+            if (file_flag == false) {
+                mfileo.SetNumFormat("%.12g");
+                mfileo << "\t P_load Y:\t"
+                       << "theta:\t"
+                       << "Beam Tip Deflection:\n";
+                file_flag = true;  //只执行一次
+            }
+
+            mfileo << -P_load << "\t" << -theta * rad2deg << "\t" << PosX << "\t" << PosY << "\t" << -PosZ << "\t"
+                   << RotX_EulerAngle << "\t" << RotY_EulerAngle << "\t" << RotZ_EulerAngle << "\t" << RotX_AxisAngle
+                   << "\t" << RotY_AxisAngle << "\t" << RotZ_AxisAngle << "\t" 
+                << tip_rotation_angle << "\t" <<  u2_ref << "\t" << - u3_ref << "\n";
+            // clear system
+            my_system.RemoveAllBodies();
+            my_system.RemoveAllLinks();
+            my_system.RemoveAllMeshes();
+            my_system.RemoveAllOtherPhysicsItems();
+        }
+    }
+}
+
+void test_12() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the constraint of ChLinkMotorRotationSpeed<> \n\n";
+
+    double PI = 3.1415926535897932384626;
+    double rad2deg = 180.0 / PI;
+    double DEG_TO_RAD = 1. / rad2deg;
+    double rotor_speed_rpm = 10.0;
+    double azimuth_angle_deg = 83.0;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    Json json_info;
+    std::string JsonPath = "C:/Users/31848/Desktop/goldflex_chrono20210126/goldflex-mb/resource/case.example.gf.json";
+    std::ifstream case_stream{JsonPath};
+    case_stream >> json_info;
+    case_stream.close();
+    Json blade_section_info = json_info["blade1"]["sections"];
+
+    auto hub_ = chrono_types::make_shared<chrono::ChBody>();
+    auto ISYS_ = chrono_types::make_shared<chrono::ChBody>();
+    // 轮毂约束铰接、驱动
+    auto constraint_hub_rotation_ = chrono_types::make_shared<chrono::ChLinkMateFix>();
+    auto motor_hub_rotation_ = chrono_types::make_shared<chrono::ChLinkMotorRotationSpeed>();
+    auto fun_hub_rotation_speed_ = chrono_types::make_shared<chrono::ChFunction_Setpoint>();
+
+    // 大地，惯性参考系
+    ISYS_->SetCoord({0, 0, 0}, chrono::QUNIT);
+    ISYS_->SetMass(1.123456);
+    ISYS_->SetInertiaXX(chrono::ChVector<>(1.111, 1.222, 1.333));
+    ISYS_->SetNameString("Foundation body of whole system");
+    ISYS_->SetBodyFixed(true);
+    my_system.AddBody(ISYS_);
+
+    // 生成轮毂的rigid body，给定方位角azimuth
+    // hub_->SetCoord({ 0,0,0 }, chrono::Q_from_AngX(azimuth_angle_deg * DEG_TO_RAD));
+    hub_->SetCoord({0, 0, 0}, chrono::QUNIT);
+    hub_->SetMass(2.123456);
+    hub_->SetInertiaXX(chrono::ChVector<>(2.111, 2.222, 2.333));
+    hub_->SetNameString(
+        "hub:hub_center_body");  //名字一定要是这个，否则在rotor_fsi.cc的InitializeSubsystem()中找不到hub这个body
+    my_system.AddBody(hub_);
+
+    // 轮毂固定
+    /*constraint_hub_rotation_->Initialize(hub_, ISYS_);
+    constraint_hub_rotation_->SetNameString("hub: fixed to ground");
+    ISharedData::system_data_.wind_turbine->Add(constraint_hub_rotation_);*/
+
+    // 添加转动驱动，【轮毂绕着大地转动】
+    motor_hub_rotation_->Initialize(
+        hub_, ISYS_, chrono::ChFrame<>(ISYS_->GetPos(), ISYS_->GetRot() >> chrono::Q_from_AngY(90.0 * DEG_TO_RAD)));
+    motor_hub_rotation_->SetSpeedFunction(fun_hub_rotation_speed_);
+    // 设定一个初始转速后，static计算的效率会下降很多；
+    // 可是如果不在构造函数中设置初始转速，则默认置0，
+    // 后续再突然给定一个转速进行dynamics计算，则会导致转动的角加速度太大，冲击非常大，进而求解极易发散
+    fun_hub_rotation_speed_->SetSetpoint(rotor_speed_rpm * PI / 30, 0.0);
+    motor_hub_rotation_->SetAngleOffset(azimuth_angle_deg * DEG_TO_RAD);
+    // motor_blade_root_rotation_->SetDisabled(false);
+    motor_hub_rotation_->SetNameString("motor of hub rotating");
+    my_system.Add(motor_hub_rotation_);
+
+
+
+      auto mkl_solver_ = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper_ = chrono_types::make_shared<ChTimestepperHHT>();
+     // 仿真参数：仿真时长、步长、重力场
+    double time_step = 0.02;
+    chrono::Vector m_acc_noG = {0, 0, 0};    // No Gravity
+    chrono::Vector m_acc_G = {0, 0, -9.81};  // With Gravity
+    my_system.SetStep(time_step);
+    my_system.Set_G_acc(m_acc_noG);
+
+
+        mkl_solver_->UseSparsityPatternLearner(true);
+        mkl_solver_->LockSparsityPattern(true);
+        mkl_solver_->SetVerbose(false);
+        //my_system.SetSolver(mkl_solver_);  //矩阵求解
+
+        //my_system.SetTimestepperType(chrono::ChTimestepper::Type::HHT);
+        hht_time_stepper_ = std::dynamic_pointer_cast<chrono::ChTimestepperHHT>(my_system.GetTimestepper());
+        hht_time_stepper_->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+        hht_time_stepper_->SetMinStepSize(1e-9);
+        hht_time_stepper_->SetAbsTolerances(1e-6);
+        hht_time_stepper_->SetMaxiters(100);
+        hht_time_stepper_->SetStepControl(true);
+        hht_time_stepper_->SetModifiedNewton(false);
+
+    // 整个模型组装
+        my_system.Setup();
+
+        // 提取叶片受气动载荷后模型的系统矩阵 M  K  R  Cq
+        bool save_M = true;
+        bool save_K = true;
+        bool save_R = true;
+        bool save_Cq = true;
+        const char* path_sysMatMKR =
+            R"(C:\Users\31848\Desktop\goldflex_chrono20210318\goldflex-lin\out\result\test_constraint)";
+        //输出 M K R 矩阵到文本文件，方便matlab处理
+        my_system.DumpSystemMatrices(save_M, save_K, save_R, save_Cq, path_sysMatMKR);
+
+        std::cout << "Test case simulation DONE." << std::endl;
+}
+
 // Do some tests in a single run, inside the main() function.
 // Results will be simply text-formatted outputs in the console..
 
@@ -597,10 +2610,18 @@ int main(int argc, char* argv[]) {
     GetLog() << " Example: the FEM technology for finite elements \n\n\n";
 
     //test_1(); //// NOT WORKING
-    test_2();
-    test_3();
-    test_4();
-    test_5();
+    //test_2();
+    //test_3();
+    //test_4();
+    //test_5();
+
+    //test_6();
+    //test_7();
+    //test_8();
+    //test_9();
+    //test_10();
+    //test_11();
+    test_12();
 
     return 0;
 }

--- a/src/demos/fea/demo_FEA_basic.cpp
+++ b/src/demos/fea/demo_FEA_basic.cpp
@@ -606,7 +606,8 @@ void test_5() {
 // ============================================================ //
 void test_6() {
     GetLog() << "\n-------------------------------------------------\n";
-    GetLog() << "TEST: To test the new developed Tapered Timoshenko beam element  \n\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko "
+             <<" beam element with blade model, also check the section force/torque \n\n";
 
     struct BladeSection {
         double ref_twist;
@@ -1092,10 +1093,10 @@ void test_6() {
 
 }
 
-
 void test_7() {
     GetLog() << "\n-------------------------------------------------\n";
-    GetLog() << "TEST: To test the new developed Tapered Timoshenko FPM beam element  \n\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko FPM"
+             << " beam element with blade model, also check the section force/torque \n\n";
 
     struct BladeSection {
         double ref_twist;
@@ -1581,7 +1582,6 @@ void test_7() {
     }  // end of modal solving
 }
 
-
 void test_8() {
     GetLog() << "\n-------------------------------------------------\n";
     GetLog() << "TEST: To test the new developed Tapered Timoshenko beam element  \n\n";
@@ -1851,7 +1851,7 @@ void test_8() {
     hht_time_stepper_->SetAbsTolerances(1e-6);
     hht_time_stepper_->SetMaxiters(100);
     hht_time_stepper_->SetStepControl(true);     // 提高数值计算的收敛性
-    hht_time_stepper_->SetModifiedNewton(true);  // 提高数值计算的收敛性
+    hht_time_stepper_->SetModifiedNewton(false);  // 提高数值计算的收敛性
 
     my_system.Setup();
 
@@ -1883,7 +1883,7 @@ void test_8() {
 
 void test_9() {
     GetLog() << "\n-------------------------------------------------\n";
-    GetLog() << "TEST: To test the new developed Tapered Timoshenko beam element  \n\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko beam element with Princeton beam experiment \n\n";
     GetLog() << "TEST: To check the shear locking effect...  \n\n";
 
 
@@ -2092,7 +2092,7 @@ void test_9() {
 
 void test_10() {
     GetLog() << "\n-------------------------------------------------\n";
-    GetLog() << "TEST: To test the Euler beam element  \n\n";
+    GetLog() << "TEST: To test the Euler beam element with Princeton beam experiment \n\n";
     GetLog() << "TEST: To compare with Timoshenko beam  \n\n";
 
     double PI = 3.1415926535897932384626;
@@ -2104,6 +2104,7 @@ void test_10() {
     auto mynodes = std::vector<std::shared_ptr<ChNodeFEAxyzrot>>();
     auto mkl_solver = chrono_types::make_shared<ChSolverPardisoMKL>();
     auto hht_time_stepper = chrono_types::make_shared<ChTimestepperHHT>();
+    auto minres_solver = chrono_types::make_shared<ChSolverMINRES>();
 
     double P1 = 4.448;
     double P2 = 8.896;
@@ -2195,14 +2196,17 @@ void test_10() {
             mymesh->SetAutomaticGravity(true);
 
             // mnodeA->SetFixed(true);
-            my_system.Set_G_acc({0, 0, -9.81});
-            // my_system.Set_G_acc({0, 0, 0});
+            //my_system.Set_G_acc({0, 0, -9.81});
+             my_system.Set_G_acc({0, 0, 0});
 
             auto mynodes = beamBuilder.GetLastBeamNodes();
             auto mybeams = beamBuilder.GetLastBeamElements();
             mynodes.front()->SetFixed(true);
             mynodes.back()->SetForce(ChVector<>(0, 0, P_load));
             my_system.Add(mymesh);
+
+            //my_system.SetSolver(minres_solver);
+            //minres_solver->SetTolerance(1e-6);
 
             mkl_solver->UseSparsityPatternLearner(true);
             mkl_solver->LockSparsityPattern(true);
@@ -2280,7 +2284,7 @@ void test_10() {
 
 void test_11() {
     GetLog() << "\n-------------------------------------------------\n";
-    GetLog() << "TEST: To test the IGA beam element  \n\n";
+    GetLog() << "TEST: To test the IGA beam element with Princeton beam experiment \n\n";
     GetLog() << "TEST: To compare with Timoshenko beam  \n\n";
 
     double PI = 3.1415926535897932384626;
@@ -2559,47 +2563,521 @@ void test_12() {
     motor_hub_rotation_->SetNameString("motor of hub rotating");
     my_system.Add(motor_hub_rotation_);
 
-
-
-      auto mkl_solver_ = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto mkl_solver_ = chrono_types::make_shared<ChSolverPardisoMKL>();
     auto hht_time_stepper_ = chrono_types::make_shared<ChTimestepperHHT>();
-     // 仿真参数：仿真时长、步长、重力场
+    // 仿真参数：仿真时长、步长、重力场
     double time_step = 0.02;
     chrono::Vector m_acc_noG = {0, 0, 0};    // No Gravity
     chrono::Vector m_acc_G = {0, 0, -9.81};  // With Gravity
     my_system.SetStep(time_step);
     my_system.Set_G_acc(m_acc_noG);
 
+    mkl_solver_->UseSparsityPatternLearner(true);
+    mkl_solver_->LockSparsityPattern(true);
+    mkl_solver_->SetVerbose(false);
+    // my_system.SetSolver(mkl_solver_);  //矩阵求解
 
-        mkl_solver_->UseSparsityPatternLearner(true);
-        mkl_solver_->LockSparsityPattern(true);
-        mkl_solver_->SetVerbose(false);
-        //my_system.SetSolver(mkl_solver_);  //矩阵求解
-
-        //my_system.SetTimestepperType(chrono::ChTimestepper::Type::HHT);
-        hht_time_stepper_ = std::dynamic_pointer_cast<chrono::ChTimestepperHHT>(my_system.GetTimestepper());
-        hht_time_stepper_->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
-        hht_time_stepper_->SetMinStepSize(1e-9);
-        hht_time_stepper_->SetAbsTolerances(1e-6);
-        hht_time_stepper_->SetMaxiters(100);
-        hht_time_stepper_->SetStepControl(true);
-        hht_time_stepper_->SetModifiedNewton(false);
+    // my_system.SetTimestepperType(chrono::ChTimestepper::Type::HHT);
+    hht_time_stepper_ = std::dynamic_pointer_cast<chrono::ChTimestepperHHT>(my_system.GetTimestepper());
+    hht_time_stepper_->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+    hht_time_stepper_->SetMinStepSize(1e-9);
+    hht_time_stepper_->SetAbsTolerances(1e-6);
+    hht_time_stepper_->SetMaxiters(100);
+    hht_time_stepper_->SetStepControl(true);
+    hht_time_stepper_->SetModifiedNewton(false);
 
     // 整个模型组装
-        my_system.Setup();
+    my_system.Setup();
 
-        // 提取叶片受气动载荷后模型的系统矩阵 M  K  R  Cq
+    // 提取叶片受气动载荷后模型的系统矩阵 M  K  R  Cq
+    bool save_M = true;
+    bool save_K = true;
+    bool save_R = true;
+    bool save_Cq = true;
+    const char* path_sysMatMKR =
+        R"(C:\Users\31848\Desktop\goldflex_chrono20210318\goldflex-lin\out\result\test_constraint)";
+    //输出 M K R 矩阵到文本文件，方便matlab处理
+    my_system.DumpSystemMatrices(save_M, save_K, save_R, save_Cq, path_sysMatMKR);
+
+    std::cout << "Test case simulation DONE." << std::endl;
+}
+
+void test_13() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko FPM beam element "
+             << " with a coupled cantilever box beam proposed by Hodges et al. \n";
+    // Reference paper:
+    // D.H.Hodges, A.R.Atilgan, M.V.Fulton, and L.W.Rehfield.
+    // Free vibration analysis of composite beams.
+    // Journal of the American Helicopter Society,36(3) : 36– 47, 1991, DOI : 10.4050 / jahs .36.36.
+
+    double PI = 3.1415926535897932384626;
+    double rad2deg = 180.0 / PI;
+    double deg2rad = 1. / rad2deg;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    auto mkl_solver = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper = chrono_types::make_shared<ChTimestepperHHT>();
+
+    double L = 2.54;                                        // length
+    double H = 16.76 * 0.001;                               // heigth
+    double W = 33.53 * 0.001;                               // width
+    double t = 0.84 * 0.001;                                // wall thickness
+    double pho = 1604;                                      // density
+    double mu = pho * (W * H - (W - 2 * t) * (H - 2 * t));  // beam单位长度的质量,kg/m
+    double Jyy = pho * (1 / 12.0 * W * H * H * H - 1 / 12.0 * (W - 2 * t) * pow(H - 2 * t, 3.0));
+    double Jzz = pho * (1 / 12.0 * H * W * W * W - 1 / 12.0 * (H - 2 * t) * pow(W - 2 * t, 3.0));
+    double Jxx = Jyy + Jzz;
+    double Jyz = 0;
+    double Qy = 0;
+    double Qz = 0;
+
+    ChMatrixNM<double, 6, 6> Klaw;
+    Klaw.row(0) << 5.0576E+06, 0.0000E+00, 0.0000E+00, -1.7196E+04, 0.0000E+00, 0.0000E+00;
+    Klaw.row(1) << 0.0000E+00, 7.7444E+05, 0.0000E+00, 0.0000E+00, 8.3270E+03, 0.0000E+00;
+    Klaw.row(2) << 0.0000E+00, 0.0000E+00, 2.9558E+05, 0.0000E+00, 0.0000E+00, 9.0670E+03;
+    Klaw.row(3) << -1.7196E+04, 0.0000E+00, 0.0000E+00, 1.5041E+02, 0.0000E+00, 0.0000E+00;
+    Klaw.row(4) << 0.0000E+00, 8.3270E+03, 0.0000E+00, 0.0000E+00, 2.4577E+02, 0.0000E+00;
+    Klaw.row(5) << 0.0000E+00, 0.0000E+00, 9.0670E+03, 0.0000E+00, 0.0000E+00, 7.4529E+02;
+
+    ChMatrixNM<double, 6, 6> Mlaw;
+    Mlaw.row(0) << mu, 0, 0, 0, Qy, -Qz;
+    Mlaw.row(1) << 0, mu, 0, -Qy, 0, 0;
+    Mlaw.row(2) << 0, 0, mu, Qz, 0, 0;
+    Mlaw.row(3) << 0, -Qy, Qz, Jxx, 0, 0;
+    Mlaw.row(4) << Qy, 0, 0, 0, Jyy, -Jyz;
+    Mlaw.row(5) << -Qz, 0, 0, 0, -Jyz, Jzz;
+
+    auto section = chrono_types::make_shared<ChBeamSectionTimoshenkoAdvancedGenericFPM>();
+    //截面属性设置
+    section->SetSectionRotation(0);
+    section->SetCenterOfMass(0, 0);
+    section->SetCentroidY(0);
+    section->SetCentroidZ(0);
+    section->SetShearCenterY(0);
+    section->SetShearCenterZ(0);
+    section->SetMassPerUnitLength(mu);
+    section->SetArtificialJyyJzzFactor(0.0 / 500.);
+    section->SetMassMatrixFPM(Mlaw);
+    section->SetStiffnessMatrixFPM(Klaw);
+
+    DampingCoefficients mdamping_coeff;
+    mdamping_coeff.bx = pow(0.000007, 0.5);
+    mdamping_coeff.by = mdamping_coeff.bx;
+    mdamping_coeff.bz = mdamping_coeff.bx;
+    mdamping_coeff.bt = mdamping_coeff.bx;
+    section->SetBeamRaleyghDamping(mdamping_coeff);
+    section->compute_inertia_damping_matrix = true;  // gyroscopic damping matrix
+    section->compute_inertia_stiffness_matrix = true;
+    section->compute_Ri_Ki_by_num_diff = false;
+
+    double beam_length = L;
+    auto mnodeA =
+        chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(ChVector<>(0, 0, 0), ChQuaternion<>(1, 0, 0, 0)));
+    auto mnodeB = chrono_types::make_shared<ChNodeFEAxyzrot>(
+        ChFrame<>(ChVector<>(beam_length, 0, 0), ChQuaternion<>(1, 0, 0, 0)));
+    int beam_count = 16;
+
+    bool use_lumped_mass_matrix = false;
+    auto tapered_section_fpm = chrono_types::make_shared<chrono::fea::ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM>();
+    tapered_section_fpm->SetLumpedMassMatrixType(use_lumped_mass_matrix); 
+    tapered_section_fpm->SetSectionA(section);
+    tapered_section_fpm->SetSectionB(section);
+    tapered_section_fpm->SetLength(beam_length / beam_count);
+    tapered_section_fpm->compute_inertia_damping_matrix = true;  // 是否自动计入离心力、陀螺力项产生的阻尼矩阵
+    tapered_section_fpm->compute_inertia_stiffness_matrix = true;  // 是否自动计入离心力、陀螺力项产生的刚度矩阵
+    tapered_section_fpm->compute_Ri_Ki_by_num_diff = false;
+
+    chrono::fea::ChBuilderBeamTaperedTimoshenkoFPM bladeBuilder;
+    std::vector<std::shared_ptr<ChNodeFEAxyzrot>> mynodes;
+    std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenkoFPM>> mybeams;
+    auto mymesh = chrono_types::make_shared<ChMesh>();
+    mymesh->AddNode(mnodeA);
+    mymesh->AddNode(mnodeB);
+    bladeBuilder.BuildBeam(mymesh,              ///< mesh to store the resulting elements
+                           tapered_section_fpm,  ///< section material for beam elements
+                           beam_count,          ///< number of elements in the segment
+                           mnodeA,              ///< starting point
+                           mnodeB,              ///< ending point
+                           ChVector<>{0, 1, 0}  // the 'up' Y direction of the beam
+    );
+    mynodes = bladeBuilder.GetLastBeamNodes();
+    mybeams = bladeBuilder.GetLastBeamElements();
+    for (int i_beam = 0; i_beam < mybeams.size();i_beam++) {
+        mybeams.at(i_beam)->SetUseGeometricStiffness(true);
+        mybeams.at(i_beam)->SetUseRc(true);
+        mybeams.at(i_beam)->SetUseRs(true);
+        mybeams.at(i_beam)->SetIntegrationPoints(4);  //高斯积分的阶次
+    }
+
+    mymesh->SetAutomaticGravity(true);
+    my_system.Add(mymesh);
+
+    //my_system.Set_G_acc({0, 0, -9.81});
+     my_system.Set_G_acc({0, 0, 0});
+
+    mynodes.front()->SetFixed(true);
+    //mynodes.back()->SetFixed(true);
+    // mynodes.back()->SetForce(ChVector<>(0, 0, 0));
+
+    mkl_solver->UseSparsityPatternLearner(true);
+    mkl_solver->LockSparsityPattern(true);
+    mkl_solver->SetVerbose(false);
+    my_system.SetSolver(mkl_solver);  //矩阵求解
+
+    my_system.SetTimestepperType(ChTimestepper::Type::HHT);
+    hht_time_stepper = std::dynamic_pointer_cast<ChTimestepperHHT>(my_system.GetTimestepper());
+    hht_time_stepper->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+    hht_time_stepper->SetMinStepSize(1e-9);
+    hht_time_stepper->SetAbsTolerances(1e-6);
+    hht_time_stepper->SetMaxiters(100);
+    hht_time_stepper->SetStepControl(true);      // 提高数值计算的收敛性
+    hht_time_stepper->SetModifiedNewton(false);  // 提高数值计算的收敛性
+
+    my_system.Setup();
+
+    // Output some results
+    GetLog() << "test_13: \n";
+    GetLog() << "Simulation starting..............\n";
+    GetLog() << "Beam tip coordinate X: " << mynodes.back()->GetPos().x() << "\n";
+    GetLog() << "Beam tip coordinate Y: " << mynodes.back()->GetPos().y() << "\n";
+    GetLog() << "Beam tip coordinate Z: " << mynodes.back()->GetPos().z() << "\n";
+    my_system.DoStaticNonlinear(100, false);
+
+    bool bSolveMode = true;
+    if (bSolveMode) {  // start of modal solving
         bool save_M = true;
         bool save_K = true;
         bool save_R = true;
         bool save_Cq = true;
-        const char* path_sysMatMKR =
-            R"(C:\Users\31848\Desktop\goldflex_chrono20210318\goldflex-lin\out\result\test_constraint)";
+        auto sysMat_name_temp = R"(E:\pengchao\matlab_work\HodgesBeam\Hodges)";
+        const char* path_sysMatMKR = R"(E:\pengchao\matlab_work\HodgesBeam\Hodges)";
         //输出 M K R 矩阵到文本文件，方便matlab处理
         my_system.DumpSystemMatrices(save_M, save_K, save_R, save_Cq, path_sysMatMKR);
+        //直接提取 M K R 矩阵，并计算特征值和特征向量
+        chrono::ChSparseMatrix sysMat_M;
+        my_system.GetMassMatrix(&sysMat_M);
+        chrono::ChSparseMatrix sysMat_K;
+        my_system.GetStiffnessMatrix(&sysMat_K);
+        chrono::ChSparseMatrix sysMat_R;
+        my_system.GetDampingMatrix(&sysMat_R);
+        chrono::ChSparseMatrix sysMat_Cq;
+        my_system.GetConstraintJacobianMatrix(&sysMat_Cq);
+        // 调用EIGEN3求解dense matrix的特征值和特征向量
+        Eigen::MatrixXd dense_sysMat_M = sysMat_M.toDense();
+        Eigen::MatrixXd dense_sysMat_K = sysMat_K.toDense();
+        Eigen::MatrixXd dense_sysMat_R = sysMat_R.toDense();
+        Eigen::MatrixXd dense_sysMat_Cq = sysMat_Cq.toDense();
+        // 计算Cq矩阵的null space（零空间）
+        Eigen::MatrixXd Cq_null_space = dense_sysMat_Cq.fullPivLu().kernel();
+        Eigen::MatrixXd M_hat = Cq_null_space.transpose() * dense_sysMat_M * Cq_null_space;
+        Eigen::MatrixXd K_hat = Cq_null_space.transpose() * dense_sysMat_K * Cq_null_space;
+        Eigen::MatrixXd R_hat = Cq_null_space.transpose() * dense_sysMat_R * Cq_null_space;
+        // frequency-shift，解决矩阵奇异问题，现在还用不着，可以置0
+        double freq_shift = 0.0;  //偏移值，可取1~10等任意数值
+        Eigen::MatrixXd M_bar = M_hat;
+        Eigen::MatrixXd K_bar = pow(freq_shift, 2) * M_hat + freq_shift * R_hat + K_hat;
+        Eigen::MatrixXd R_bar = 2 * freq_shift * M_hat + R_hat;
+        Eigen::MatrixXd M_bar_inv = M_bar.inverse();  //直接用dense matrix求逆也不慢
+        // 生成状态方程的 A 矩阵，其特征值就是模态频率
+        int dim = M_bar.rows();
+        Eigen::MatrixXd A_tilde(2 * dim, 2 * dim);  // 拼成系统矩阵 A 矩阵，dense matrix。
+        A_tilde << Eigen::MatrixXd::Zero(dim, dim), Eigen::MatrixXd::Identity(dim, dim), -M_bar_inv * K_bar,
+            -M_bar_inv * R_bar;
+        // 调用EIGEN3，dense matrix直接求解特征值和特征向量
+        // NOTE：EIGEN3在release模式下计算速度非常快[~1s]，在debug模式下计算速度非常慢[>100s]
+        Eigen::EigenSolver<Eigen::MatrixXd> eigenSolver(A_tilde);
+        Eigen::VectorXcd sys_eValues = eigenSolver.eigenvalues() + freq_shift;
+        Eigen::MatrixXcd sys_eVectors = eigenSolver.eigenvectors();
 
-        std::cout << "Test case simulation DONE." << std::endl;
+        typedef std::tuple<double, double, double, std::complex<double>, Eigen::VectorXcd> myEigenRes;
+        std::vector<myEigenRes> eigen_vectors_and_values;
+        for (int i = 0; i < sys_eValues.size(); i++) {
+            myEigenRes vec_and_val(
+                std::abs(sys_eValues(i)) / (2 * PI),  // index：0     特征值的绝对值, 无阻尼模态频率
+                sys_eValues(i).imag() / (2 * PI),     // index：1     特征值的虚部,有阻尼模态频率
+                -sys_eValues(i).real() / std::abs(sys_eValues(i)),  // index：2     特征值的实部代表了阻尼比
+                sys_eValues(i),                                     // index：3     复数形式的特征值
+                sys_eVectors.col(i)                                 // index：4     振型
+            );
+            if (std::abs(sys_eValues(i).imag()) > 1.0e-6) {  // 只有虚部不为零的特征值会放入结果中
+                eigen_vectors_and_values.push_back(vec_and_val);
+            }
+        }
+        std::sort(eigen_vectors_and_values.begin(), eigen_vectors_and_values.end(),
+                  [&](const myEigenRes& a, const myEigenRes& b) -> bool {
+                      return std::get<1>(a) < std::get<1>(b);
+                  });  // index：1，表示按照特征值的虚部进行排序，‘ < ’为升序
+
+        int size = eigen_vectors_and_values.size();
+        int midN = (int)(size / 2);
+        int nModes = 20;  // 提取8阶模态频率，文献中的结果只有8阶模态
+        std::vector<Eigen::VectorXcd> res_Modeshapes;
+        Eigen::MatrixXd res_Modes(nModes, 3);
+        int jj = 0;
+        int i = 0;
+        while ((jj + midN) < size && i < nModes) {
+            // 前面一半的特征值的虚部为负数，没有意义，需要丢掉【QUESTION：这部分的特征值到底是什么物理意义？】
+            double damping_ratio = std::get<2>(eigen_vectors_and_values.at(jj + midN));
+            if (damping_ratio < 0.5) {  // 只提取模态阻尼比小于0.5的模态
+                res_Modes(i, 0) = std::get<0>(eigen_vectors_and_values.at(jj + midN));  // 无阻尼模态频率
+                res_Modes(i, 1) = std::get<1>(eigen_vectors_and_values.at(jj + midN));  // 有阻尼模态频率
+                res_Modes(i, 2) = std::get<2>(eigen_vectors_and_values.at(jj + midN));  // 阻尼比
+                // Eigen::VectorXcd tempVector = std::get<4>(eigen_vectors_and_values.at(jj + midN));
+                // res_Modeshapes.push_back(Cq_null_space * tempVector.head(midN));
+                i++;
+            }  // TODO：阵型提取，参考单叶片稳定性分析python代码中的算法
+            jj++;
+        }
+
+        if (use_lumped_mass_matrix == true) {
+            std::cout << "\n*** The lumped mass matrix is used. ***\n" << std::endl;
+        } else {
+            std::cout << "\n*** The consistent mass matrix is used. ***\n" << std::endl;
+        }
+
+        // 模态计算结果输出到屏幕
+        std::cout << "The eigenvalues of Hodges beam are:\t\n"
+                  << "01 undamped frequency/Hz\t"
+                  << "02 damped frequency/Hz\t"
+                  << "03 damping ratio\n"
+                  << res_Modes << std::endl;
+
+        nModes = 8;
+        Eigen::MatrixXd res_Modes_cmp(nModes, 3);
+        res_Modes_cmp.topRows<6>() = res_Modes.topRows<6>();
+        res_Modes_cmp.row(6) = res_Modes.row(9);
+        res_Modes_cmp.row(7) = res_Modes.row(15);
+        // 与Bladed计算的单叶片模态频率对比，计算误差，%
+        Eigen::MatrixXd res_paper;
+        res_paper.resize(nModes, 1);
+        res_paper << 3.00,5.19,19.04,32.88,54.65,93.39,180.32,544.47;  // Hz
+        Eigen::MatrixXd error_to_paper = (res_Modes_cmp.col(0).array() - res_paper.array()) / res_paper.array() * 100.0;
+
+        // 模态计算结果输出到屏幕
+        Eigen::MatrixXd res_output(nModes, 4);
+        res_output << res_Modes_cmp, error_to_paper;
+        std::cout << "The eigenvalues of Hodges beam to compare with paper are:\t\n"
+                  << "01 undamped frequency/Hz\t"
+                  << "02 damped frequency/Hz\t"
+                  << "03 damping ratio\t"
+                  << "04 dfferences[%]\n"
+                  << res_output << std::endl;
+    }  // end of modal solving
+
+    // clear system
+    my_system.RemoveAllBodies();
+    my_system.RemoveAllLinks();
+    my_system.RemoveAllMeshes();
+    my_system.RemoveAllOtherPhysicsItems();
+
 }
+
+void test_14() {
+    GetLog() << "\n-------------------------------------------------\n";
+    GetLog() << "TEST: To test the new developed Tapered Timoshenko FPM beam element "
+             << " with a coupled cantilever proposed by Wang et al. \n";
+    // Reference paper:
+    // Q. Wang, M. Sprague, J. Jonkman, and N. Johnson. 
+    // Nonlinear legendre spectral finite elements for wind turbine blade dynamics. 
+    // In Proceedings of the 32nd ASME Wind Energy Symposium, National Harbor, Maryland, 2014, 
+    // DOI: 10.2514/6.2014-1224.
+
+    double PI = 3.1415926535897932384626;
+    double rad2deg = 180.0 / PI;
+    double deg2rad = 1. / rad2deg;
+    //double m2inch = 39.3700787;
+    //double inch2m = 1. / m2inch;
+    //double lbs2N = 4.44822162;
+    //double N2lbs = 1. / lbs2N;
+    //m2inch = 1.0;
+    //inch2m = 1.0;
+    //lbs2N = 1.0;
+    //N2lbs = 1.0;
+    // The physical system: it contains all physical objects.
+    ChSystemSMC my_system;
+
+    auto mkl_solver = chrono_types::make_shared<ChSolverPardisoMKL>();
+    auto hht_time_stepper = chrono_types::make_shared<ChTimestepperHHT>();
+
+    double L = 10.0; // length
+    double mu = 1.0;  // beam单位长度的质量,kg/m
+    double Jyy = 1.0;
+    double Jzz = 1.0;
+    double Jxx = Jyy + Jzz;
+    double Jyz = 0;
+    double Qy = 0;
+    double Qz = 0;
+
+    ChMatrixNM<double, 6, 6> Klaw;
+    Klaw.row(0) << 1368.17E+03, 0.000E+00, 0.000E+00, 0.0000E+00, 0.0000E+00, 0.0000E+00;
+    Klaw.row(1) << 0.000E+00, 88.56E+03, 0.000E+00, 0.000E+00, 0.0000E+00, 0.0000E+00;
+    Klaw.row(2) << 0.0000E+00, 0.0000E+00, 38.78E+03, 0.000E+00, 0.000E+00, 0.0000E+00;
+    Klaw.row(3) << 0.0000E+00, 0.0000E+00, 0.0000E+00, 16.96E+03, 17.610E+03, -0.351E+03;
+    Klaw.row(4) << 0.0000E+00, 0.0000E+00, 0.0000E+00, 17.610E+03, 59.12E+03, -0.370E+03;
+    Klaw.row(5) << 0.0000E+00, 0.0000E+00, 0.0000E+00, -0.351E+03, -0.370E+03, 141.47E+03;
+    //Klaw.block<3, 3>(0, 0) *= lbs2N;
+    //Klaw.block<3, 3>(3, 3) *= lbs2N * inch2m * inch2m;
+
+
+    ChMatrixNM<double, 6, 6> Mlaw;
+    Mlaw.row(0) << mu, 0, 0, 0, Qy, -Qz;
+    Mlaw.row(1) << 0, mu, 0, -Qy, 0, 0;
+    Mlaw.row(2) << 0, 0, mu, Qz, 0, 0;
+    Mlaw.row(3) << 0, -Qy, Qz, Jxx, 0, 0;
+    Mlaw.row(4) << Qy, 0, 0, 0, Jyy, -Jyz;
+    Mlaw.row(5) << -Qz, 0, 0, 0, -Jyz, Jzz;
+
+    auto section = chrono_types::make_shared<ChBeamSectionTimoshenkoAdvancedGenericFPM>();
+    //截面属性设置
+    section->SetSectionRotation(0);
+    section->SetCenterOfMass(0, 0);
+    section->SetCentroidY(0);
+    section->SetCentroidZ(0);
+    section->SetShearCenterY(0);
+    section->SetShearCenterZ(0);
+    section->SetMassPerUnitLength(mu);
+    section->SetArtificialJyyJzzFactor(0.0 / 500.);
+    section->SetMassMatrixFPM(Mlaw);
+    section->SetStiffnessMatrixFPM(Klaw);
+
+    DampingCoefficients mdamping_coeff;
+    mdamping_coeff.bx = pow(0.000007, 0.5);
+    mdamping_coeff.by = mdamping_coeff.bx;
+    mdamping_coeff.bz = mdamping_coeff.bx;
+    mdamping_coeff.bt = mdamping_coeff.bx;
+    section->SetBeamRaleyghDamping(mdamping_coeff);
+    section->compute_inertia_damping_matrix = true;  // gyroscopic damping matrix
+    section->compute_inertia_stiffness_matrix = true;
+    section->compute_Ri_Ki_by_num_diff = false;
+
+    double beam_length = L;
+    auto mnodeA =
+        chrono_types::make_shared<ChNodeFEAxyzrot>(ChFrame<>(ChVector<>(0, 0, 0), ChQuaternion<>(1, 0, 0, 0)));
+    auto mnodeB = chrono_types::make_shared<ChNodeFEAxyzrot>(
+        ChFrame<>(ChVector<>(beam_length, 0, 0), ChQuaternion<>(1, 0, 0, 0)));
+    int beam_count = 10;
+
+    bool use_lumped_mass_matrix = true;
+    auto tapered_section_fpm =
+        chrono_types::make_shared<chrono::fea::ChBeamSectionTaperedTimoshenkoAdvancedGenericFPM>();
+    tapered_section_fpm->SetLumpedMassMatrixType(use_lumped_mass_matrix);
+    tapered_section_fpm->SetSectionA(section);
+    tapered_section_fpm->SetSectionB(section);
+    tapered_section_fpm->SetLength(beam_length / beam_count);
+    tapered_section_fpm->compute_inertia_damping_matrix = true;  // 是否自动计入离心力、陀螺力项产生的阻尼矩阵
+    tapered_section_fpm->compute_inertia_stiffness_matrix = true;  // 是否自动计入离心力、陀螺力项产生的刚度矩阵
+    tapered_section_fpm->compute_Ri_Ki_by_num_diff = false;
+
+    chrono::fea::ChBuilderBeamTaperedTimoshenkoFPM bladeBuilder;
+    std::vector<std::shared_ptr<ChNodeFEAxyzrot>> mynodes;
+    std::vector<std::shared_ptr<ChElementBeamTaperedTimoshenkoFPM>> mybeams;
+    auto mymesh = chrono_types::make_shared<ChMesh>();
+    mymesh->AddNode(mnodeA);
+    mymesh->AddNode(mnodeB);
+    bladeBuilder.BuildBeam(mymesh,               ///< mesh to store the resulting elements
+                           tapered_section_fpm,  ///< section material for beam elements
+                           beam_count,           ///< number of elements in the segment
+                           mnodeA,               ///< starting point
+                           mnodeB,               ///< ending point
+                           ChVector<>{0, 1, 0}   // the 'up' Y direction of the beam
+    );
+    mynodes = bladeBuilder.GetLastBeamNodes();
+    mybeams = bladeBuilder.GetLastBeamElements();
+    for (int i_beam = 0; i_beam < mybeams.size(); i_beam++) {
+        mybeams.at(i_beam)->SetUseGeometricStiffness(true);
+        mybeams.at(i_beam)->SetUseRc(true);
+        mybeams.at(i_beam)->SetUseRs(true);
+        mybeams.at(i_beam)->SetIntegrationPoints(4);  //高斯积分的阶次
+    }
+
+    mymesh->SetAutomaticGravity(true);
+    my_system.Add(mymesh);
+
+    // my_system.Set_G_acc({0, 0, -9.81});
+    my_system.Set_G_acc({0, 0, 0});
+
+    mynodes.front()->SetFixed(true);
+    // mynodes.back()->SetFixed(true);
+     //mynodes.back()->SetForce(ChVector<>(0, 0, 150.0));
+
+    mkl_solver->UseSparsityPatternLearner(true);
+    mkl_solver->LockSparsityPattern(true);
+    mkl_solver->SetVerbose(false);
+    my_system.SetSolver(mkl_solver);  //矩阵求解
+
+    my_system.SetTimestepperType(ChTimestepper::Type::HHT);
+    hht_time_stepper = std::dynamic_pointer_cast<ChTimestepperHHT>(my_system.GetTimestepper());
+    hht_time_stepper->SetAlpha(-0.1);  // [-1/3,0], closer to 0,less damping_
+    hht_time_stepper->SetMinStepSize(1e-9);
+    hht_time_stepper->SetAbsTolerances(1e-6);
+    hht_time_stepper->SetMaxiters(100);
+    hht_time_stepper->SetStepControl(true);      // 提高数值计算的收敛性
+    hht_time_stepper->SetModifiedNewton(false);  // 提高数值计算的收敛性
+
+    my_system.Setup();
+
+    ChFrame<> root_frame_local = ChFrame<>(mynodes.front()->GetCoord());
+    ChFrame<> tip_rel_frame;
+    ChFrame<> tip_abs_frame = ChFrame<>(mynodes.back()->GetCoord());
+    root_frame_local.TransformParentToLocal(tip_abs_frame, tip_rel_frame);
+    // Beam tip coordinate
+    double PosX0 = tip_rel_frame.GetPos().x();
+    double PosY0 = tip_rel_frame.GetPos().y();
+    double PosZ0 = tip_rel_frame.GetPos().z();
+
+    // Output some results
+    GetLog() << "test_14: \n";
+    GetLog() << "Simulation starting..............\n";
+    GetLog() << "Beam tip coordinate X: " << mynodes.back()->GetPos().x() << "\n";
+    GetLog() << "Beam tip coordinate Y: " << mynodes.back()->GetPos().y() << "\n";
+    GetLog() << "Beam tip coordinate Z: " << mynodes.back()->GetPos().z() << "\n";
+
+    for (int i_do = 0; i_do < 5; i_do++) {
+        mynodes.back()->SetForce(ChVector<>(0, 0, 150.0));
+        my_system.DoStaticNonlinear(100, false);
+    }
+
+
+    tip_abs_frame = ChFrame<>(mynodes.back()->GetCoord());
+    root_frame_local.TransformParentToLocal(tip_abs_frame, tip_rel_frame);
+    // Beam tip coordinate
+    double PosX = tip_rel_frame.GetPos().x();
+    double PosY = tip_rel_frame.GetPos().y();
+    double PosZ = tip_rel_frame.GetPos().z();
+    double dPosX = PosX - PosX0;
+    double dPosY = PosY - PosY0;
+    double dPosZ = PosZ - PosZ0;
+
+    // Beam tip Euler Angle
+    double RotX_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().x();
+    double RotY_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().y();
+    double RotZ_EulerAngle = tip_abs_frame.GetRot().Q_to_Euler123().z();
+    // Beam tip rotation angle using Axis-Angle(旋转向量法)
+    double rot_alpha = tip_rel_frame.GetRotAngle();
+    ChVector<> rot_vector = tip_rel_frame.GetRotAxis();
+    double RotX_AxisAngle = rot_alpha * rot_vector.x();
+    double RotY_AxisAngle = rot_alpha * rot_vector.y();
+    double RotZ_AxisAngle = rot_alpha * rot_vector.z();
+    //Transform rotations into Wiener - Milenkovic Parameter
+    double P1 = 4.0 * tan(rot_alpha / 4.0) * rot_vector.x();
+    double P2 = 4.0 * tan(rot_alpha / 4.0) * rot_vector.y();
+    double P3 = 4.0 * tan(rot_alpha / 4.0) * rot_vector.z();
+
+    std::cout << "Tip displacements and rotations of WANG beam:\n "
+        << dPosX << "\t" << dPosY << "\t" << dPosZ << "\n"
+        //<< RotX_EulerAngle << "\t" << RotY_EulerAngle << "\t" << RotZ_EulerAngle << "\n" 
+        //<< RotX_AxisAngle << "\t" << RotY_AxisAngle << "\t" << RotZ_AxisAngle << "\n"
+              << P1 << "\t" << P2 << "\t" << P3 << std::endl;
+
+    // clear system
+    my_system.RemoveAllBodies();
+    my_system.RemoveAllLinks();
+    my_system.RemoveAllMeshes();
+    my_system.RemoveAllOtherPhysicsItems();
+}
+
 
 // Do some tests in a single run, inside the main() function.
 // Results will be simply text-formatted outputs in the console..
@@ -2615,13 +3093,40 @@ int main(int argc, char* argv[]) {
     //test_4();
     //test_5();
 
+    //TEST: To test the new developed Tapered Timoshenko beam element with GW blade model, 
+    // also check the section force/torque
     //test_6();
+
+    // TEST: To test the new developed Tapered Timoshenko FPM beam element with GW blade model,
+    // also check the section force/torque
     //test_7();
+
+    //TEST: To test the new developed Tapered Timoshenko beam element with GW blade model,
+    // check the shear locking effect
     //test_8();
+
+    //TEST: To test the new developed Tapered Timoshenko beam element with Princeton beam experiment,
+    // To check the shear locking effect
     //test_9();
+
+    //TEST: To test the Euler beam element with Princeton beam experiment,
+    // to compare with Timoshenko beam
     //test_10();
+
+    //TEST: To test the IGA beam element with Princeton beam experiment,
+    //to compare with Timoshenko beam
     //test_11();
-    test_12();
+
+    //TEST: To test the constraint of ChLinkMotorRotationSpeed<> 
+    //test_12();
+
+    //TEST: To test the new developed Tapered Timoshenko FPM beam element
+    // with a coupled cantilever box beam proposed by Hodges et al.
+    test_13();
+
+    //TEST: To test the new developed Tapered Timoshenko FPM beam element 
+    // with a coupled cantilever proposed by Wang et al.
+    test_14();
 
     return 0;
 }


### PR DESCRIPTION
1. Use the inertial Ki and Ri (gyroscopic/centrifugal damping) in Timoshenko beams
2. rename several variables in fpm beam, but this fpm beam is still not usable. Be careful about it.