### PR TITLE
Fix demo asset and output locations

### DIFF
--- a/src/demos/irrlicht/demo_IRR_cohesion.cpp
+++ b/src/demos/irrlicht/demo_IRR_cohesion.cpp
@@ -142,7 +142,7 @@ void create_some_falling_items(ChSystemNSC& mphysicalSystem) {
 
         // optional, attach a texture for better visualization
         auto mtexture = chrono_types::make_shared<ChTexture>();
-        mtexture->SetTextureFilename(GetChronoDataFile("rock.jpg"));
+        mtexture->SetTextureFilename(GetChronoDataFile("textures/rock.jpg"));
         mrigidBody->AddAsset(mtexture);
     }
 

--- a/src/demos/irrlicht/demo_IRR_soilbin.cpp
+++ b/src/demos/irrlicht/demo_IRR_soilbin.cpp
@@ -123,7 +123,7 @@ class ParticleGenerator {
             auto cubeMap = chrono_types::make_shared<ChTexture>();
             cubeMap->SetTextureFilename(GetChronoDataFile("textures/concrete.jpg"));
             auto rockMap = chrono_types::make_shared<ChTexture>();
-            rockMap->SetTextureFilename(GetChronoDataFile("rock.jpg"));
+            rockMap->SetTextureFilename(GetChronoDataFile("textures/rock.jpg"));
 
             // I should really check these
             ChCollisionModel::SetDefaultSuggestedEnvelope(0.003);

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacle.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacle.cpp
@@ -79,8 +79,8 @@ ChVector<> trackPoint(0.0, 2.0, 0.0);
 
 // Driver input files
 std::string path_file("paths/straightOrigin.txt");
-std::string steering_controller_file("marder/driver/SteeringController.json");
-std::string speed_controller_file("marder/driver/SpeedController.json");
+std::string steering_controller_file("Marder/driver/SteeringController.json");
+std::string speed_controller_file("Marder/driver/SpeedController.json");
 
 // Output directories
 const std::string out_top_dir = GetChronoOutputPath() + "Marder";

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacle.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacle.cpp
@@ -239,21 +239,16 @@ int main(int argc, char* argv[]) {
     // Initialize output
     // -----------------
 
-    if (!filesystem::create_directory(filesystem::path(out_top_dir))) {
-        std::cout << "Error creating directory " << out_top_dir << std::endl;
-        return 1;
-    }
-
-    if (!filesystem::create_directory(filesystem::path(out_dir))) {
-        std::cout << "Error creating directory " << out_dir << std::endl;
-        return 1;
-    }
-
+    std::vector<std::string> dirs_to_create = {out_top_dir, out_dir};
     if (img_output) {
-        if (!filesystem::create_directory(filesystem::path(img_dir))) {
-            std::cout << "Error creating directory " << img_dir << std::endl;
-            return 1;
-        }
+      dirs_to_create.push_back(img_dir);
+    }
+
+    for (const auto& dir : dirs_to_create) {
+      if (!filesystem::create_directory(filesystem::path(dir))) {
+          std::cout << "Error creating directory " << dir << std::endl;
+          return 1;
+      }
     }
 
     // Set up vehicle output

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacle.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacle.cpp
@@ -83,7 +83,7 @@ std::string steering_controller_file("marder/driver/SteeringController.json");
 std::string speed_controller_file("marder/driver/SpeedController.json");
 
 // Output directories
-const std::string out_top_dir = GetChronoOutputPath() + "MARDER";
+const std::string out_top_dir = GetChronoOutputPath() + "Marder";
 const std::string out_dir = out_top_dir + "/OBSTACLE";
 const std::string pov_dir = out_dir + "/POVRAY";
 const std::string img_dir = out_dir + "/IMG";
@@ -238,6 +238,11 @@ int main(int argc, char* argv[]) {
     // -----------------
     // Initialize output
     // -----------------
+
+    if (!filesystem::create_directory(filesystem::path(out_top_dir))) {
+        std::cout << "Error creating directory " << out_top_dir << std::endl;
+        return 1;
+    }
 
     if (!filesystem::create_directory(filesystem::path(out_dir))) {
         std::cout << "Error creating directory " << out_dir << std::endl;

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacleTool.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacleTool.cpp
@@ -86,7 +86,7 @@ std::string steering_controller_file("marder/driver/SteeringController.json");
 std::string speed_controller_file("marder/driver/SpeedController.json");
 
 // Output directories
-const std::string out_top_dir = GetChronoOutputPath() + "MARDER";
+const std::string out_top_dir = GetChronoOutputPath() + "Marder";
 const std::string out_dir = out_top_dir + "/OBSTACLE_TOOL";
 const std::string pov_dir = out_dir + "/POVRAY";
 const std::string img_dir = out_dir + "/IMG";
@@ -293,16 +293,16 @@ int main(int argc, char* argv[]) {
                 // Initialize output
                 // -----------------
 
-                if (!filesystem::create_directory(filesystem::path(out_dir))) {
-                    std::cout << "Error creating directory " << out_dir << std::endl;
-                    return 1;
+                std::vector<std::string> dirs_to_create = {out_top_dir, out_dir};
+                if (img_output) {
+                  dirs_to_create.push_back(img_dir);
                 }
 
-                if (img_output) {
-                    if (!filesystem::create_directory(filesystem::path(img_dir))) {
-                        std::cout << "Error creating directory " << img_dir << std::endl;
-                        return 1;
-                    }
+                for (const auto& dir : dirs_to_create) {
+                  if (!filesystem::create_directory(filesystem::path(dir))) {
+                    std::cout << "Error creating directory " << dir << std::endl;
+                    return 1;
+                  }
                 }
 
                 // Set up vehicle output

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacleTool.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderObstacleTool.cpp
@@ -82,8 +82,8 @@ ChVector<> trackPoint(0.0, 2.0, 0.0);
 
 // Driver input files
 std::string path_file("paths/straightOrigin.txt");
-std::string steering_controller_file("marder/driver/SteeringController.json");
-std::string speed_controller_file("marder/driver/SpeedController.json");
+std::string steering_controller_file("Marder/driver/SteeringController.json");
+std::string speed_controller_file("Marder/driver/SpeedController.json");
 
 // Output directories
 const std::string out_top_dir = GetChronoOutputPath() + "Marder";

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderRide.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderRide.cpp
@@ -82,7 +82,7 @@ std::string steering_controller_file("marder/driver/SteeringController.json");
 std::string speed_controller_file("marder/driver/SpeedController.json");
 
 // Output directories
-const std::string out_top_dir = GetChronoOutputPath() + "MARDER";
+const std::string out_top_dir = GetChronoOutputPath() + "Marder";
 const std::string out_dir = out_top_dir + "/RIDE";
 const std::string pov_dir = out_dir + "/POVRAY";
 const std::string img_dir = out_dir + "/IMG";
@@ -262,16 +262,16 @@ int main(int argc, char* argv[]) {
     // Initialize output
     // -----------------
 
-    if (!filesystem::create_directory(filesystem::path(out_dir))) {
-        std::cout << "Error creating directory " << out_dir << std::endl;
-        return 1;
+    std::vector<std::string> dirs_to_create = {out_top_dir, out_dir};
+    if (img_output) {
+      dirs_to_create.push_back(img_dir);
     }
 
-    if (img_output) {
-        if (!filesystem::create_directory(filesystem::path(img_dir))) {
-            std::cout << "Error creating directory " << img_dir << std::endl;
-            return 1;
-        }
+    for (const auto& dir : dirs_to_create) {
+      if (!filesystem::create_directory(filesystem::path(dir))) {
+          std::cout << "Error creating directory " << dir << std::endl;
+          return 1;
+      }
     }
 
     // Set up vehicle output

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderRide.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderRide.cpp
@@ -78,8 +78,8 @@ ChVector<> trackPoint(0.0, 2.0, 0.0);
 
 // Driver input files
 std::string path_file("paths/straightOrigin.txt");
-std::string steering_controller_file("marder/driver/SteeringController.json");
-std::string speed_controller_file("marder/driver/SpeedController.json");
+std::string steering_controller_file("Marder/driver/SteeringController.json");
+std::string speed_controller_file("Marder/driver/SpeedController.json");
 
 // Output directories
 const std::string out_top_dir = GetChronoOutputPath() + "Marder";

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderShock.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderShock.cpp
@@ -77,8 +77,8 @@ ChVector<> trackPoint(0.0, 0.0, 0.0);
 
 // Driver input files
 std::string path_file("paths/straightOrigin.txt");
-std::string steering_controller_file("marder/driver/SteeringController.json");
-std::string speed_controller_file("marder/driver/SpeedController.json");
+std::string steering_controller_file("Marder/driver/SteeringController.json");
+std::string speed_controller_file("Marder/driver/SpeedController.json");
 
 // Output directories
 const std::string out_top_dir = GetChronoOutputPath() + "Marder";

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderShock.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderShock.cpp
@@ -81,7 +81,7 @@ std::string steering_controller_file("marder/driver/SteeringController.json");
 std::string speed_controller_file("marder/driver/SpeedController.json");
 
 // Output directories
-const std::string out_top_dir = GetChronoOutputPath() + "MARDER";
+const std::string out_top_dir = GetChronoOutputPath() + "Marder";
 const std::string out_dir = out_top_dir + "/SHOCK";
 const std::string pov_dir = out_dir + "/POVRAY";
 const std::string img_dir = out_dir + "/IMG";
@@ -251,24 +251,23 @@ int main(int argc, char* argv[]) {
     // Initialize output
     // -----------------
 
-    if (!filesystem::create_directory(filesystem::path(out_dir))) {
-        std::cout << "Error creating directory " << out_dir << std::endl;
-        return 1;
+    std::vector<std::string> dirs_to_create = {out_top_dir, out_dir};
+    if (povray_output) {
+      dirs_to_create.push_back(pov_dir);
+    }
+    if (img_output) {
+      dirs_to_create.push_back(img_dir);
+    }
+
+    for (const auto& dir : dirs_to_create) {
+      if (!filesystem::create_directory(filesystem::path(dir))) {
+          std::cout << "Error creating directory " << dir << std::endl;
+          return 1;
+      }
     }
 
     if (povray_output) {
-        if (!filesystem::create_directory(filesystem::path(pov_dir))) {
-            std::cout << "Error creating directory " << pov_dir << std::endl;
-            return 1;
-        }
         terrain.ExportMeshPovray(out_dir);
-    }
-
-    if (img_output) {
-        if (!filesystem::create_directory(filesystem::path(img_dir))) {
-            std::cout << "Error creating directory " << img_dir << std::endl;
-            return 1;
-        }
     }
 
     // Set up vehicle output

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderShockTool.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderShockTool.cpp
@@ -81,7 +81,7 @@ std::string steering_controller_file("marder/driver/SteeringController.json");
 std::string speed_controller_file("marder/driver/SpeedController.json");
 
 // Output directories
-const std::string out_top_dir = GetChronoOutputPath() + "MARDER";
+const std::string out_top_dir = GetChronoOutputPath() + "Marder";
 const std::string out_dir = out_top_dir + "/SHOCK_TOOL";
 const std::string pov_dir = out_dir + "/POVRAY";
 const std::string img_dir = out_dir + "/IMG";
@@ -272,25 +272,25 @@ int main(int argc, char* argv[]) {
         // Initialize output
         // -----------------
 
-        if (!filesystem::create_directory(filesystem::path(out_dir))) {
-            std::cout << "Error creating directory " << out_dir << std::endl;
-            return 1;
+        std::vector<std::string> dirs_to_create = {out_top_dir, out_dir};
+        if (povray_output) {
+          dirs_to_create.push_back(pov_dir);
+        }
+        if (img_output) {
+          dirs_to_create.push_back(img_dir);
+        }
+
+        for (const auto& dir : dirs_to_create) {
+          if (!filesystem::create_directory(filesystem::path(dir))) {
+              std::cout << "Error creating directory " << dir << std::endl;
+              return 1;
+          }
         }
 
         if (povray_output) {
-            if (!filesystem::create_directory(filesystem::path(pov_dir))) {
-                std::cout << "Error creating directory " << pov_dir << std::endl;
-                return 1;
-            }
             terrain.ExportMeshPovray(out_dir);
         }
 
-        if (img_output) {
-            if (!filesystem::create_directory(filesystem::path(img_dir))) {
-                std::cout << "Error creating directory " << img_dir << std::endl;
-                return 1;
-            }
-        }
 
         // Set up vehicle output
         marder.GetVehicle().SetChassisOutput(true);

--- a/src/demos/vehicle/tracked_models/demo_VEH_MarderShockTool.cpp
+++ b/src/demos/vehicle/tracked_models/demo_VEH_MarderShockTool.cpp
@@ -77,8 +77,8 @@ ChVector<> trackPoint(0.0, 3.0, 0.0);
 
 // Driver input files
 std::string path_file("paths/straightOrigin.txt");
-std::string steering_controller_file("marder/driver/SteeringController.json");
-std::string speed_controller_file("marder/driver/SpeedController.json");
+std::string steering_controller_file("Marder/driver/SteeringController.json");
+std::string speed_controller_file("Marder/driver/SpeedController.json");
 
 // Output directories
 const std::string out_top_dir = GetChronoOutputPath() + "Marder";


### PR DESCRIPTION
Fixes a `Marder` vs. `marder` capitalization issue, rock.jpg is in a subdirectory, and demo output intermediate directories need to be created before lower level dirs.

Instead of renaming the Marder dir, maybe the preference would be for changing every place in code that assumes it is lowercase?