### PR TITLE
Initialized real-time force to false in constructor.

### DIFF
--- a/src/chrono_vehicle/ChVehicle.cpp
+++ b/src/chrono_vehicle/ChVehicle.cpp
@@ -50,7 +50,7 @@ ChVehicle::ChVehicle(const std::string& name, ChContactMethod contact_method)
       m_output_frame(0),
       m_mass(0),
       m_inertia(0),
-      m_realtime_force(true),
+      m_realtime_force(false),
       m_initialized(false) {
     m_system = (contact_method == ChContactMethod::NSC) ? static_cast<ChSystem*>(new ChSystemNSC)
                                                         : static_cast<ChSystem*>(new ChSystemSMC);
@@ -84,7 +84,7 @@ ChVehicle::ChVehicle(const std::string& name, ChSystem* system)
       m_output_frame(0),
       m_mass(0),
       m_inertia(0),
-      m_realtime_force(true),
+      m_realtime_force(false),
       m_initialized(false) {}
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This should be a clean PR, replacing the one I did before. It will disable the code that will force the vehicle to run in real-time, leaving that to whatever "main" loop that it's being called from.