### PR TITLE
Used the old carsound sample as it loops properly and is monotonous.

### DIFF
--- a/src/chrono_vehicle/utils/ChVehicleVisualSystemIrrlicht.cpp
+++ b/src/chrono_vehicle/utils/ChVehicleVisualSystemIrrlicht.cpp
@@ -165,7 +165,7 @@ void ChVehicleVisualSystemIrrlicht::EnableSound(bool sound) {
         // play it looped.
         if (m_sound_engine) {
             m_car_sound =
-                m_sound_engine->play2D(GetChronoDataFile("vehicle/sounds/carsound.ogg").c_str(), true, false, true);
+                m_sound_engine->play2D(GetChronoDataFile("vehicle/sounds/carsound_old.ogg").c_str(), true, false, true);
             m_car_sound->setIsPaused(true);
         } else
             GetLog() << "Cannot start sound engine Irrklang \n";


### PR DESCRIPTION
If you listen to carsound.ogg you will hear that is not monotonous at all, but a car slowly accelerating. This makes it unsuited for use in this location. The carsound_old.ogg is monotonous, and therefore works a lot better, so it should be the default here.