### PR TITLE
Add an extra check to make sure we don't reference a non-existent member.

### DIFF
--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChLugreTire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChLugreTire.cpp
@@ -79,7 +79,7 @@ void ChLugreTire::AddVisualizationAssets(VisualizationType vis) {
 void ChLugreTire::RemoveVisualizationAssets() {
     // Make sure we only remove the assets added by ChLugreTire::AddVisualizationAssets.
     // This is important for the ChTire object because a wheel may add its own assets to the same body (the spindle/wheel).
-    for (int id = 0; id < GetNumDiscs(); id++) {
+    for (int id = 0; id < GetNumDiscs() && id < m_cyl_shapes.size(); id++) {
         ChPart::RemoveVisualizationAsset(m_wheel->GetSpindle(), m_cyl_shapes[id]);
     }
     m_cyl_shapes.clear();


### PR DESCRIPTION
The code that tries to remove visualization assets is apparently sometimes invoked before there are any, leading to the loop that was patched referencing members that don't exist (index out of bound). Added an extra check to the for loop to ensure that can no longer happen.