### PR TITLE
By default use the friction ellipsis now.

### DIFF
--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
@@ -38,7 +38,7 @@ ChPac02Tire::ChPac02Tire(const std::string& name)
       m_alpha(0),
       m_gamma(0),
       m_gamma_limit(3.0 * CH_C_DEG_TO_RAD),
-      m_use_friction_ellipsis(false),
+      m_use_friction_ellipsis(true),
       m_mu(0),
       m_Shf(0),
       m_measured_side(LEFT),

--- a/src/chrono_vehicle/wheeled_vehicle/tire/Pac02Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/Pac02Tire.cpp
@@ -54,6 +54,10 @@ void Pac02Tire::Create(const rapidjson::Document& d) {  // Invoke base class met
         // Default value = 3
         m_use_mode = d["Use Mode"].GetInt();
     }
+    if (d.HasMember("Use Friction Ellipsis")) {
+        // Default value = true
+        m_use_friction_ellipsis = d["Use Friction Ellipsis"].GetBool();
+    }
     if (d.HasMember("Coefficient of Friction")) {
         // Default value = 0.8
         m_PacCoeff.mu0 = d["Coefficient of Friction"].GetDouble();


### PR DESCRIPTION
 Also make it configurable in the json for a Pac02 tire. This change was made so when you're driving these tires on the limit, you can apply the friction ellipsis instead of ending up with (for lack of an official term) a friction square. You need to make sure your tires have "Use Mode" set to 4 for this to work.