### PR TITLE
Fix typos for translation and transformation

### DIFF
--- a/doxygen/documentation/manuals/sensor/lidar_sensor.md
+++ b/doxygen/documentation/manuals/sensor/lidar_sensor.md
@@ -3,7 +3,7 @@ Lidar Sensor Model {#lidar_sensor}
 
 \tableofcontents
 
-In chrono:sensor:ChLidarSensor, the synthetic data is generated via GPU-based ray-tracing. By leveraging hardware acclereated support and the headless rendering capablities provided by NVIDIA Optix Library. For each lidar beam, a group of rays are traced that sample that lidar beam. The number of samples, along with beam divergence angle, are set by the user. The entire frame/scan of the lidar is processed in a single render step. To account for the time difference of rays across the scan, keyframes and motion blur techniques are used. With these keyframes, each beam in the scan traces the scene at a specific time, reproducing the motion of objects and the lidar. The intensity returned by the lidar beams is based on diffuse reflectance.
+In chrono:sensor:ChLidarSensor, the synthetic data is generated via GPU-based ray-tracing. By leveraging hardware accelerated support and the headless rendering capabilities provided by NVIDIA Optix Library. For each lidar beam, a group of rays are traced that sample that lidar beam. The number of samples, along with beam divergence angle, are set by the user. The entire frame/scan of the lidar is processed in a single render step. To account for the time difference of rays across the scan, keyframes and motion blur techniques are used. With these keyframes, each beam in the scan traces the scene at a specific time, reproducing the motion of objects and the lidar. The intensity returned by the lidar beams is based on diffuse reflectance.
 
 #### Creating a Lidar
 ~~~{.cpp}

--- a/src/chrono/physics/ChLinkLock.cpp
+++ b/src/chrono/physics/ChLinkLock.cpp
@@ -849,7 +849,7 @@ void ChLinkLock::IntStateScatterReactions(const unsigned int off_L, const ChVect
         local_off++;
     }
 
-    // ***TO DO***?: TRASFORMATION FROM delta COORDS TO LINK COORDS, if
+    // ***TO DO***?: TRANSFORMATION FROM delta COORDS TO LINK COORDS, if
     // non-default delta
     // if delta rotation?
 

--- a/src/demos/core/demo_CH_coords.cpp
+++ b/src/demos/core/demo_CH_coords.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* argv[]) {
     // local frame coordinate.
     ChVector<> mvect1(2, 3, 4);
 
-    // Define a vector representing the TRASLATION of the frame
+    // Define a vector representing the TRANSLATION of the frame
     // respect to absolute (world) coordinates.
     ChVector<> vtraslA(5, 6, 7);
 
@@ -69,17 +69,17 @@ int main(int argc, char* argv[]) {
     // the coordinates of mvect1 in absolute coordinates.
     // This can be achieved in many ways. Let's see them.
 
-    // TRASFORM USING ROTATION MATRIX AND LINEAR ALGEBRA
+    // TRANSFORM USING ROTATION MATRIX AND LINEAR ALGEBRA
     //
     mvect2 = vtraslA + mrotA * mvect1;  // like:  v2 = t + [A]*v1
     GetLog() << mvect2 << " ..using linear algebra, \n";
 
-    // TRASFORM USING QUATERNION ROTATION
+    // TRANSFORM USING QUATERNION ROTATION
 
     mvect2 = vtraslA + qrotA.Rotate(mvect1);
     GetLog() << mvect2 << " ..using quaternion rotation, \n";
 
-    // TRASFORM USING THE ChTransform STATIC METHODS
+    // TRANSFORM USING THE ChTransform STATIC METHODS
 
     mvect2 = ChTransform<>::TransformLocalToParent(mvect1, vtraslA, mrotA);
     GetLog() << mvect2 << " ..using the ChTransform- vect and rot.matrix, \n";
@@ -87,7 +87,7 @@ int main(int argc, char* argv[]) {
     mvect2 = ChTransform<>::TransformLocalToParent(mvect1, vtraslA, qrotA);
     GetLog() << mvect2 << " ..using the ChTransform- vect and quat, \n";
 
-    // TRASFORM USING A ChCoordys OBJECT
+    // TRANSFORM USING A ChCoordys OBJECT
 
     mvect2 = csysA.TransformLocalToParent(mvect1);
     GetLog() << mvect2 << " ..using a ChChCoordsys<> object, \n";
@@ -98,7 +98,7 @@ int main(int argc, char* argv[]) {
     mvect2 = csysA * mvect1;
     GetLog() << mvect2 << " ..using a ChChCoordsys<> '*' operator, \n";
 
-    // TRASFORM USING A ChFrame OBJECT
+    // TRANSFORM USING A ChFrame OBJECT
 
     ChFrame<> mframeA(vtraslA, qrotA);  // or ChFrame<> mframeA(csysA);
 
@@ -179,19 +179,19 @@ int main(int argc, char* argv[]) {
     // ways to accomplish this.
     //
 
-    // TRASFORM USING ROTATION MATRIX AND LINEAR ALGEBRA
+    // TRANSFORM USING ROTATION MATRIX AND LINEAR ALGEBRA
     //
 
     GetLog() << mvect1 << " ..mvect1 \n";
     mvect1 = mrotA.transpose() * (mvect2 - vtraslA);  // like:  v1 = [A]'*(v2-t)
     GetLog() << mvect1 << " ..inv, using linear algebra, \n";
 
-    // TRASFORM USING QUATERNION ROTATION
+    // TRANSFORM USING QUATERNION ROTATION
 
     mvect1 = qrotA.RotateBack(mvect2 - vtraslA);
     GetLog() << mvect1 << " ..inv, using quaternion rotation, \n";
 
-    // TRASFORM USING THE ChTransform STATIC METHODS
+    // TRANSFORM USING THE ChTransform STATIC METHODS
 
     mvect1 = ChTransform<>::TransformParentToLocal(mvect2, vtraslA, mrotA);
     GetLog() << mvect1 << " ..inv, using the ChTransform- vect and rot.matrix, \n";
@@ -199,12 +199,12 @@ int main(int argc, char* argv[]) {
     mvect1 = ChTransform<>::TransformParentToLocal(mvect2, vtraslA, qrotA);
     GetLog() << mvect1 << " ..inv, using the ChTransform- vect and quat, \n";
 
-    // TRASFORM USING A ChCoordys OBJECT
+    // TRANSFORM USING A ChCoordys OBJECT
 
     mvect1 = csysA.TransformParentToLocal(mvect2);
     GetLog() << mvect1 << " ..inv, using a ChChCoordsys<> object, \n";
 
-    // TRASFORM USING A ChFrame OBJECT
+    // TRANSFORM USING A ChFrame OBJECT
 
     mvect1 = mframeA.TransformParentToLocal(mvect2);
     GetLog() << mvect1 << " ..inv, using a ChFrame object function, \n";

--- a/src/demos/irrlicht/demo_IRR_motors.cpp
+++ b/src/demos/irrlicht/demo_IRR_motors.cpp
@@ -12,7 +12,7 @@
 // Authors: Alessandro Tasora
 // =============================================================================
 //
-//   Demo code about using motors to impose rotation or traslation between parts
+//  Demo code about using motors to impose rotation or translation between parts
 //
 // =============================================================================
 
@@ -141,7 +141,7 @@ int main(int argc, char* argv[]) {
 
     // Create a ChFunction to be used for the ChLinkMotorRotationSpeed
     auto mwspeed =
-        chrono_types::make_shared<ChFunction_Const>(CH_C_PI_2);  // constant angular speed, in [rad/s], 1PI/s =180°/s
+        chrono_types::make_shared<ChFunction_Const>(CH_C_PI_2);  // constant angular speed, in [rad/s], 1PI/s =180Â°/s
     // Let the motor use this motion function:
     rotmotor1->SetSpeedFunction(mwspeed);
 

--- a/src/demos/python/irrlicht/demo_IRR_motors.py
+++ b/src/demos/python/irrlicht/demo_IRR_motors.py
@@ -12,7 +12,7 @@
 # Authors: Simone Benatti
 # =============================================================================
 #
-#   Demo code about using motors to impose rotation or traslation between parts
+#  Demo code about using motors to impose rotation or translation between parts
 #
 # =============================================================================
 


### PR DESCRIPTION
This is a tiny merge request that fixes typos discovered when reading tutorials

See issue https://github.com/projectchrono/chrono/issues/417