### PR TITLE
Fix cmake config install folder on Unix systems

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -962,7 +962,7 @@ configure_file("${PROJECT_SOURCE_DIR}/cmake/ChronoConfig.cmake.in"
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(CH_CONFIG_INSTALL_PATH "cmake")
 else()
-    set(CH_CONFIG_INSTALL_PATH "lib/cmake")
+    set(CH_CONFIG_INSTALL_PATH "lib/cmake/Chrono")
 endif()
 
 install(FILES "${PROJECT_BINARY_DIR}/cmake/ChronoConfig.cmake.install"


### PR DESCRIPTION
As noted in #300, for Unix systems Chrono's cmake config file is installed to `<prefix>/lib/cmake/`, but this is not a [default search location for cmake's find_package function](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure). This changes the install path to `<prefix>/lib/cmake/Chrono`, which is one of the default search paths.

Fixes #300.