### PR TITLE
fix faulty acceleration calculation in chrono vehicle module

### DIFF
--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChFialaTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChFialaTire.h
@@ -54,7 +54,7 @@ class CH_VEHICLE_API ChFialaTire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_unloaded_radius; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return m_tireforce; }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override;
 
     /// Get the width of the tire.
     virtual double GetWidth() const override { return m_width; }
@@ -111,13 +111,11 @@ class CH_VEHICLE_API ChFialaTire : public ChForceElementTire {
     double m_time;        // actual system time
     double m_time_trans;  // end of start transient
 
-  //private:
     /// Get the tire force and moment.
-    /// This represents the output from this tire system that is passed to the
-    /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
-    /// to the appropriate suspension subsystem which applies it as an external
-    /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override { return m_tireforce; }
+    /// This represents the output from this tire system that is passed to the vehicle system.  Typically, the vehicle
+    /// subsystem will pass the tire force to the appropriate suspension subsystem which applies it as an external force
+    /// one the wheel body.
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
@@ -213,16 +213,17 @@ ChPac02Tire::ChPac02Tire(const std::string& name)
 }
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-TerrainForce ChPac02Tire::GetTireForce() const{ 
+TerrainForce ChPac02Tire::GetGlobalTireForce() const {
+    TerrainForce global_tireforce;
     // Rotate into global coordinates
-    m_tireforce.point = m_data.frame.pos;
-    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
+    global_tireforce.point = m_data.frame.pos;
+    global_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    global_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
     // Move the tire forces from the contact patch to the wheel center
-    m_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
-    return m_tireforce;
+    global_tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - global_tireforce.point, global_tireforce.force);
+    return global_tireforce;
 }
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
@@ -30,8 +30,6 @@
 namespace chrono {
 namespace vehicle {
 
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
 ChPac02Tire::ChPac02Tire(const std::string& name)
     : ChForceElementTire(name),
       m_kappa(0),
@@ -211,22 +209,9 @@ ChPac02Tire::ChPac02Tire(const std::string& name)
     m_PacCoeff.qtz1 = 0.0;
     m_PacCoeff.mbelt = 0.0;
 }
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
-TerrainForce ChPac02Tire::GetGlobalTireForce() const {
-    TerrainForce global_tireforce;
-    // Rotate into global coordinates
-    global_tireforce.point = m_data.frame.pos;
-    global_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    global_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
-    // Move the tire forces from the contact patch to the wheel center
-    global_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - global_tireforce.point, global_tireforce.force);
-    return global_tireforce;
-}
 // -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
+
 void ChPac02Tire::Initialize(std::shared_ptr<ChWheel> wheel) {
     ChTire::Initialize(wheel);
 
@@ -280,28 +265,6 @@ void ChPac02Tire::Initialize(std::shared_ptr<ChWheel> wheel) {
     m_states.cp_side_slip = 0;
 }
 
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
-void ChPac02Tire::AddVisualizationAssets(VisualizationType vis) {
-    if (vis == VisualizationType::NONE)
-        return;
-
-    m_cyl_shape = chrono_types::make_shared<ChCylinderShape>();
-    m_cyl_shape->GetCylinderGeometry().rad = m_PacCoeff.R0;
-    m_cyl_shape->GetCylinderGeometry().p1 = ChVector<>(0, GetOffset() + GetVisualizationWidth() / 2, 0);
-    m_cyl_shape->GetCylinderGeometry().p2 = ChVector<>(0, GetOffset() - GetVisualizationWidth() / 2, 0);
-    m_cyl_shape->SetTexture(GetChronoDataFile("textures/greenwhite.png"));
-    m_wheel->GetSpindle()->AddVisualShape(m_cyl_shape);
-}
-
-void ChPac02Tire::RemoveVisualizationAssets() {
-    // Make sure we only remove the assets added by ChPac02Tire::AddVisualizationAssets.
-    // This is important for the ChTire object because a wheel may add its own assets to the same body (the spindle/wheel).
-    ChPart::RemoveVisualizationAsset(m_wheel->GetSpindle(), m_cyl_shape);
-}
-
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
 void ChPac02Tire::Synchronize(double time, const ChTerrain& terrain) {
     WheelState wheel_state = m_wheel->GetState();
     CalculateKinematics(time, wheel_state, terrain);
@@ -368,11 +331,8 @@ void ChPac02Tire::Synchronize(double time, const ChTerrain& terrain) {
     }
 }
 
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
 void ChPac02Tire::Advance(double step) {
     // Set tire forces to zero.
-    m_tireforce.point = m_wheel->GetPos();
     m_tireforce.force = ChVector<>(0, 0, 0);
     m_tireforce.moment = ChVector<>(0, 0, 0);
 
@@ -465,6 +425,51 @@ void ChPac02Tire::Advance(double step) {
     m_tireforce.force = ChVector<>(Fx, -Fy, m_data.normal_force);
     m_tireforce.moment = ChVector<>(Mx, -My, -Mz);
 }
+
+// -----------------------------------------------------------------------------
+
+TerrainForce ChPac02Tire::ReportTireForce(ChTerrain* terrain) const {
+    return GetTireForce();
+}
+
+TerrainForce ChPac02Tire::GetTireForce() const {
+    TerrainForce tireforce;
+    tireforce.point = m_wheel->GetPos();
+
+    // Rotate into global coordinates
+    tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
+
+    // Move the tire forces from the contact patch to the wheel center
+    tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - tireforce.point, tireforce.force);
+
+    return tireforce;
+}
+
+// -----------------------------------------------------------------------------
+
+void ChPac02Tire::AddVisualizationAssets(VisualizationType vis) {
+    if (vis == VisualizationType::NONE)
+        return;
+
+    m_cyl_shape = chrono_types::make_shared<ChCylinderShape>();
+    m_cyl_shape->GetCylinderGeometry().rad = m_PacCoeff.R0;
+    m_cyl_shape->GetCylinderGeometry().p1 = ChVector<>(0, GetOffset() + GetVisualizationWidth() / 2, 0);
+    m_cyl_shape->GetCylinderGeometry().p2 = ChVector<>(0, GetOffset() - GetVisualizationWidth() / 2, 0);
+    m_cyl_shape->SetTexture(GetChronoDataFile("textures/greenwhite.png"));
+    m_wheel->GetSpindle()->AddVisualShape(m_cyl_shape);
+}
+
+void ChPac02Tire::RemoveVisualizationAssets() {
+    // Make sure we only remove the assets added by ChPac02Tire::AddVisualizationAssets.
+    // This is important for the ChTire object because a wheel may add its own assets to the same body (the
+    // spindle/wheel).
+    ChPart::RemoveVisualizationAsset(m_wheel->GetSpindle(), m_cyl_shape);
+}
+
+// -----------------------------------------------------------------------------
+
 
 double ChPac02Tire::CalcFx(double kappa, double Fz, double gamma) {
     // calculates the longitudinal force based on a limited parameter set.

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
@@ -211,7 +211,19 @@ ChPac02Tire::ChPac02Tire(const std::string& name)
     m_PacCoeff.qtz1 = 0.0;
     m_PacCoeff.mbelt = 0.0;
 }
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+TerrainForce ChPac02Tire::GetTireForce() const{ 
+    // Rotate into global coordinates
+    m_tireforce.point = m_data.frame.pos;
+    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
+    // Move the tire forces from the contact patch to the wheel center
+    m_tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
+    return m_tireforce;
+}
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 void ChPac02Tire::Initialize(std::shared_ptr<ChWheel> wheel) {
@@ -451,14 +463,6 @@ void ChPac02Tire::Advance(double step) {
     // Convert from SAE to ISO Coordinates at the contact patch.
     m_tireforce.force = ChVector<>(Fx, -Fy, m_data.normal_force);
     m_tireforce.moment = ChVector<>(Mx, -My, -Mz);
-
-    // Rotate into global coordinates
-    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
-
-    // Move the tire forces from the contact patch to the wheel center
-    m_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
 }
 
 double ChPac02Tire::CalcFx(double kappa, double Fz, double gamma) {

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
@@ -298,7 +298,7 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
     /// to the appropriate suspension subsystem which applies it as an external
     /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override { return m_tireforce; }
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;
@@ -335,7 +335,7 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     ContactData m_data;
     TireStates m_states;
 
-    TerrainForce m_tireforce;
+    TerrainForce mutable m_tireforce;
 
     std::shared_ptr<ChCylinderShape> m_cyl_shape;  ///< visualization cylinder asset
 

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
@@ -63,7 +63,7 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return GetGlobalTireForce(); }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override;
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -78,8 +78,8 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     virtual double GetVisualizationWidth() const { return m_PacCoeff.width; }
 
     /// Get the slip angle used in Pac89 (expressed in radians).
-    /// The reported value will have opposite sign to that reported by ChTire::GetSlipAngle
-    /// because ChPac89 uses internally a different frame convention.
+    /// The reported value will have opposite sign to that reported by ChTire::GetSlipAngle because ChPac89 uses
+    /// internally a different frame convention.
     double GetSlipAngle_internal() const { return m_states.cp_side_slip; }
 
     /// Get the longitudinal slip used in Pac89.
@@ -292,16 +292,11 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     Pac02ScalingFactors m_PacScal;
     Pac02Coeff m_PacCoeff;
 
-  //private:
     /// Get the tire force and moment.
-    /// This represents the output from this tire system that is passed to the
-    /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
-    /// to the appropriate suspension subsystem which applies it as an external
-    /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override{ return GetGlobalTireForce(); }
-
-    ///Transform the tireforce from wheel frame to global frame
-    TerrainForce GetGlobalTireForce() const;
+    /// This represents the output from this tire system that is passed to the vehicle system.  Typically, the vehicle
+    /// subsystem will pass the tire force to the appropriate suspension subsystem which applies it as an external force
+    /// one the wheel body.
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
@@ -63,7 +63,7 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return m_tireforce; }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return GetGlobalTireForce(); }
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -298,7 +298,10 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
     /// to the appropriate suspension subsystem which applies it as an external
     /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override;
+    virtual TerrainForce GetTireForce() const override{ return GetGlobalTireForce(); }
+
+    ///Transform the tireforce from wheel frame to global frame
+    TerrainForce GetGlobalTireForce() const;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;
@@ -335,7 +338,7 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     ContactData m_data;
     TireStates m_states;
 
-    TerrainForce mutable m_tireforce;
+    TerrainForce m_tireforce;
 
     std::shared_ptr<ChCylinderShape> m_cyl_shape;  ///< visualization cylinder asset
 

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.cpp
@@ -48,16 +48,17 @@ ChPac89Tire::ChPac89Tire(const std::string& name)
 }
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-TerrainForce ChPac89Tire::GetTireForce() const{ 
+TerrainForce ChPac89Tire::GetGlobalTireForce() const {
+    TerrainForce global_tireforce;
     // Rotate into global coordinates
-    m_tireforce.point = m_data.frame.pos;
-    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
+    global_tireforce.point = m_data.frame.pos;
+    global_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    global_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
     // Move the tire forces from the contact patch to the wheel center
-    m_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
-    return m_tireforce;
+    global_tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - global_tireforce.point, global_tireforce.force);
+    return global_tireforce;
 }
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.cpp
@@ -38,29 +38,13 @@
 namespace chrono {
 namespace vehicle {
 
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
 ChPac89Tire::ChPac89Tire(const std::string& name)
     : ChForceElementTire(name), m_kappa(0), m_alpha(0), m_gamma(0), m_gamma_limit(3), m_mu(0), m_mu0(0.8) {
     m_tireforce.force = ChVector<>(0, 0, 0);
     m_tireforce.point = ChVector<>(0, 0, 0);
     m_tireforce.moment = ChVector<>(0, 0, 0);
 }
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
-TerrainForce ChPac89Tire::GetGlobalTireForce() const {
-    TerrainForce global_tireforce;
-    // Rotate into global coordinates
-    global_tireforce.point = m_data.frame.pos;
-    global_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    global_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
-    // Move the tire forces from the contact patch to the wheel center
-    global_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - global_tireforce.point, global_tireforce.force);
-    return global_tireforce;
-}
-// -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 void ChPac89Tire::Initialize(std::shared_ptr<ChWheel> wheel) {
     ChTire::Initialize(wheel);
@@ -77,28 +61,6 @@ void ChPac89Tire::Initialize(std::shared_ptr<ChWheel> wheel) {
     m_states.R_eff = m_unloaded_radius;
 }
 
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
-void ChPac89Tire::AddVisualizationAssets(VisualizationType vis) {
-    if (vis == VisualizationType::NONE)
-        return;
-
-    m_cyl_shape = chrono_types::make_shared<ChCylinderShape>();
-    m_cyl_shape->GetCylinderGeometry().rad = m_unloaded_radius;
-    m_cyl_shape->GetCylinderGeometry().p1 = ChVector<>(0, GetOffset() + GetVisualizationWidth() / 2, 0);
-    m_cyl_shape->GetCylinderGeometry().p2 = ChVector<>(0, GetOffset() - GetVisualizationWidth() / 2, 0);
-    m_cyl_shape->SetTexture(GetChronoDataFile("textures/greenwhite.png"));
-    m_wheel->GetSpindle()->AddVisualShape(m_cyl_shape);
-}
-
-void ChPac89Tire::RemoveVisualizationAssets() {
-    // Make sure we only remove the assets added by ChPac89Tire::AddVisualizationAssets.
-    // This is important for the ChTire object because a wheel may add its own assets to the same body (the spindle/wheel).
-    ChPart::RemoveVisualizationAsset(m_wheel->GetSpindle(), m_cyl_shape);
-}
-
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
 void ChPac89Tire::Synchronize(double time,
                               const ChTerrain& terrain) {
     WheelState wheel_state = m_wheel->GetState();
@@ -166,11 +128,8 @@ void ChPac89Tire::Synchronize(double time,
     }
 }
 
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
 void ChPac89Tire::Advance(double step) {
     // Set tire forces to zero.
-    m_tireforce.point = m_wheel->GetPos();
     m_tireforce.force = ChVector<>(0, 0, 0);
     m_tireforce.moment = ChVector<>(0, 0, 0);
 
@@ -305,6 +264,48 @@ void ChPac89Tire::Advance(double step) {
     // Convert from SAE to ISO Coordinates at the contact patch.
     m_tireforce.force = ChVector<>(Fx, -Fy, m_data.normal_force);
     m_tireforce.moment = ChVector<>(Mx, -My, -Mz);
+}
+
+// -----------------------------------------------------------------------------
+
+TerrainForce ChPac89Tire::ReportTireForce(ChTerrain* terrain) const {
+    return GetTireForce();
+}
+
+TerrainForce ChPac89Tire::GetTireForce() const {
+    TerrainForce tireforce;
+    tireforce.point = m_wheel->GetPos();
+
+    // Rotate into global coordinates
+    tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
+
+    // Move the tire forces from the contact patch to the wheel center
+    tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - tireforce.point, tireforce.force);
+
+    return tireforce;
+}
+
+// -----------------------------------------------------------------------------
+
+void ChPac89Tire::AddVisualizationAssets(VisualizationType vis) {
+    if (vis == VisualizationType::NONE)
+        return;
+
+    m_cyl_shape = chrono_types::make_shared<ChCylinderShape>();
+    m_cyl_shape->GetCylinderGeometry().rad = m_unloaded_radius;
+    m_cyl_shape->GetCylinderGeometry().p1 = ChVector<>(0, GetOffset() + GetVisualizationWidth() / 2, 0);
+    m_cyl_shape->GetCylinderGeometry().p2 = ChVector<>(0, GetOffset() - GetVisualizationWidth() / 2, 0);
+    m_cyl_shape->SetTexture(GetChronoDataFile("textures/greenwhite.png"));
+    m_wheel->GetSpindle()->AddVisualShape(m_cyl_shape);
+}
+
+void ChPac89Tire::RemoveVisualizationAssets() {
+    // Make sure we only remove the assets added by ChPac89Tire::AddVisualizationAssets.
+    // This is important for the ChTire object because a wheel may add its own assets to the same body (the
+    // spindle/wheel).
+    ChPart::RemoveVisualizationAsset(m_wheel->GetSpindle(), m_cyl_shape);
 }
 
 }  // end namespace vehicle

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.cpp
@@ -46,7 +46,19 @@ ChPac89Tire::ChPac89Tire(const std::string& name)
     m_tireforce.point = ChVector<>(0, 0, 0);
     m_tireforce.moment = ChVector<>(0, 0, 0);
 }
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+TerrainForce ChPac89Tire::GetTireForce() const{ 
+    // Rotate into global coordinates
+    m_tireforce.point = m_data.frame.pos;
+    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
+    // Move the tire forces from the contact patch to the wheel center
+    m_tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
+    return m_tireforce;
+}
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 void ChPac89Tire::Initialize(std::shared_ptr<ChWheel> wheel) {
@@ -292,14 +304,6 @@ void ChPac89Tire::Advance(double step) {
     // Convert from SAE to ISO Coordinates at the contact patch.
     m_tireforce.force = ChVector<>(Fx, -Fy, m_data.normal_force);
     m_tireforce.moment = ChVector<>(Mx, -My, -Mz);
-
-    // Rotate into global coordinates
-    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
-
-    // Move the tire forces from the contact patch to the wheel center
-    m_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
 }
 
 }  // end namespace vehicle

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
@@ -59,7 +59,7 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return GetGlobalTireForce(); }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override;
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -158,16 +158,11 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
 
     PacCoeff m_PacCoeff;
 
-  //private:
     /// Get the tire force and moment.
-    /// This represents the output from this tire system that is passed to the
-    /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
-    /// to the appropriate suspension subsystem which applies it as an external
-    /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override{ return GetGlobalTireForce(); }
-
-    ///Transform the tireforce from wheel frame to global frame
-    TerrainForce GetGlobalTireForce() const;
+    /// This represents the output from this tire system that is passed to the vehicle system.  Typically, the vehicle
+    /// subsystem will pass the tire force to the appropriate suspension subsystem which applies it as an external force
+    /// one the wheel body.
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
@@ -59,7 +59,7 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return m_tireforce; }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return GetGlobalTireForce(); }
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -164,7 +164,10 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
     /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
     /// to the appropriate suspension subsystem which applies it as an external
     /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override;
+    virtual TerrainForce GetTireForce() const override{ return GetGlobalTireForce(); }
+
+    ///Transform the tireforce from wheel frame to global frame
+    TerrainForce GetGlobalTireForce() const;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;
@@ -201,7 +204,7 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
     ContactData m_data;
     TireStates m_states;
 
-    TerrainForce mutable m_tireforce;
+    TerrainForce m_tireforce;
 
     std::shared_ptr<ChCylinderShape> m_cyl_shape;  ///< visualization cylinder asset
 };

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
@@ -164,7 +164,7 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
     /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
     /// to the appropriate suspension subsystem which applies it as an external
     /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override { return m_tireforce; }
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;
@@ -201,7 +201,7 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
     ContactData m_data;
     TireStates m_states;
 
-    TerrainForce m_tireforce;
+    TerrainForce mutable m_tireforce;
 
     std::shared_ptr<ChCylinderShape> m_cyl_shape;  ///< visualization cylinder asset
 };

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.cpp
@@ -82,7 +82,19 @@ ChTMeasyTire::ChTMeasyTire(const std::string& name)
     m_TMeasyCoeff.pn = 0.0;
     m_TMeasyCoeff.mu_0 = 0.8;
 }
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+TerrainForce ChTMeasyTire::GetTireForce() const{ 
+    // Rotate into global coordinates
+    m_tireforce.point = m_data.frame.pos;
+    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
+    // Move the tire forces from the contact patch to the wheel center
+    m_tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
+    return m_tireforce;
+}
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 void ChTMeasyTire::Initialize(std::shared_ptr<ChWheel> wheel) {
@@ -476,13 +488,6 @@ void ChTMeasyTire::Advance(double step) {
         m_tireforce.force = ChVector<>(startup * m_states.Fx, startup * m_states.Fy, m_data.normal_force);
         m_tireforce.moment = startup * ChVector<>(Mx, My, Mz);
     }
-    // Rotate into global coordinates
-    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
-
-    // Move the tire forces from the contact patch to the wheel center
-    m_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
 }
 
 void ChTMeasyTire::tmxy_combined(double& f,

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.cpp
@@ -84,16 +84,17 @@ ChTMeasyTire::ChTMeasyTire(const std::string& name)
 }
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-TerrainForce ChTMeasyTire::GetTireForce() const{ 
+TerrainForce ChTMeasyTire::GetGlobalTireForce() const {
+    TerrainForce global_tireforce;
     // Rotate into global coordinates
-    m_tireforce.point = m_data.frame.pos;
-    m_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    m_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
+    global_tireforce.point = m_data.frame.pos;
+    global_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    global_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
     // Move the tire forces from the contact patch to the wheel center
-    m_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - m_tireforce.point, m_tireforce.force);
-    return m_tireforce;
+    global_tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - global_tireforce.point, global_tireforce.force);
+    return global_tireforce;
 }
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.cpp
@@ -65,8 +65,6 @@ namespace vehicle {
 const double kN2N = 1000.0;
 const double N2kN = 0.001;
 
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
 ChTMeasyTire::ChTMeasyTire(const std::string& name)
     : ChForceElementTire(name),
       m_vnum(0.01),
@@ -82,22 +80,9 @@ ChTMeasyTire::ChTMeasyTire(const std::string& name)
     m_TMeasyCoeff.pn = 0.0;
     m_TMeasyCoeff.mu_0 = 0.8;
 }
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
-TerrainForce ChTMeasyTire::GetGlobalTireForce() const {
-    TerrainForce global_tireforce;
-    // Rotate into global coordinates
-    global_tireforce.point = m_data.frame.pos;
-    global_tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
-    global_tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
 
-    // Move the tire forces from the contact patch to the wheel center
-    global_tireforce.moment +=
-        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - global_tireforce.point, global_tireforce.force);
-    return global_tireforce;
-}
 // -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
+
 void ChTMeasyTire::Initialize(std::shared_ptr<ChWheel> wheel) {
     ChTire::Initialize(wheel);
 
@@ -130,32 +115,6 @@ void ChTMeasyTire::Initialize(std::shared_ptr<ChWheel> wheel) {
 }
 
 // -----------------------------------------------------------------------------
-void ChTMeasyTire::AddVisualizationAssets(VisualizationType vis) {
-    if (vis == VisualizationType::NONE)
-        return;
-
-    m_cyl_shape = chrono_types::make_shared<ChCylinderShape>();
-    m_cyl_shape->GetCylinderGeometry().rad = m_unloaded_radius;
-    m_cyl_shape->GetCylinderGeometry().p1 = ChVector<>(0, GetOffset() + GetVisualizationWidth() / 2, 0);
-    m_cyl_shape->GetCylinderGeometry().p2 = ChVector<>(0, GetOffset() - GetVisualizationWidth() / 2, 0);
-    m_cyl_shape->SetTexture(GetChronoDataFile("textures/greenwhite.png"));
-    m_wheel->GetSpindle()->AddVisualShape(m_cyl_shape);
-}
-
-void ChTMeasyTire::RemoveVisualizationAssets() {
-    // Make sure we only remove the assets added by ChTMeasyTire::AddVisualizationAssets.
-    // This is important for the ChTire object because a wheel may add its own assets to the same body (the spindle/wheel).
-    ChPart::RemoveVisualizationAsset(m_wheel->GetSpindle(), m_cyl_shape);
-}
-
-// -----------------------------------------------------------------------------
-double ChTMeasyTire::GetNormalStiffnessForce(double depth) const {
-    return m_TMeasyCoeff.cz * depth;
-}
-
-double ChTMeasyTire::GetNormalDampingForce(double depth, double velocity) const {
-    return m_TMeasyCoeff.dz * velocity;
-}
 
 void ChTMeasyTire::Synchronize(double time, const ChTerrain& terrain) {
     WheelState wheel_state = m_wheel->GetState();
@@ -249,11 +208,8 @@ void ChTMeasyTire::Synchronize(double time, const ChTerrain& terrain) {
     }
 }
 
-// -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
 void ChTMeasyTire::Advance(double step) {
     // Set tire forces to zero.
-    m_tireforce.point = m_wheel->GetPos();
     m_tireforce.force = ChVector<>(0, 0, 0);
     m_tireforce.moment = ChVector<>(0, 0, 0);
 
@@ -490,6 +446,58 @@ void ChTMeasyTire::Advance(double step) {
         m_tireforce.moment = startup * ChVector<>(Mx, My, Mz);
     }
 }
+
+// -----------------------------------------------------------------------------
+
+TerrainForce ChTMeasyTire::ReportTireForce(ChTerrain* terrain) const {
+    return GetTireForce();
+}
+
+TerrainForce ChTMeasyTire::GetTireForce() const {
+    TerrainForce tireforce;
+    tireforce.point = m_wheel->GetPos();
+
+    // Rotate into global coordinates
+    tireforce.force = m_data.frame.TransformDirectionLocalToParent(m_tireforce.force);
+    tireforce.moment = m_data.frame.TransformDirectionLocalToParent(m_tireforce.moment);
+
+    // Move the tire forces from the contact patch to the wheel center
+    tireforce.moment +=
+        Vcross((m_data.frame.pos + m_data.depth * m_data.frame.rot.GetZaxis()) - tireforce.point, tireforce.force);
+
+    return tireforce;
+}
+
+double ChTMeasyTire::GetNormalStiffnessForce(double depth) const {
+    return m_TMeasyCoeff.cz * depth;
+}
+
+double ChTMeasyTire::GetNormalDampingForce(double depth, double velocity) const {
+    return m_TMeasyCoeff.dz * velocity;
+}
+
+// -----------------------------------------------------------------------------
+
+void ChTMeasyTire::AddVisualizationAssets(VisualizationType vis) {
+    if (vis == VisualizationType::NONE)
+        return;
+
+    m_cyl_shape = chrono_types::make_shared<ChCylinderShape>();
+    m_cyl_shape->GetCylinderGeometry().rad = m_unloaded_radius;
+    m_cyl_shape->GetCylinderGeometry().p1 = ChVector<>(0, GetOffset() + GetVisualizationWidth() / 2, 0);
+    m_cyl_shape->GetCylinderGeometry().p2 = ChVector<>(0, GetOffset() - GetVisualizationWidth() / 2, 0);
+    m_cyl_shape->SetTexture(GetChronoDataFile("textures/greenwhite.png"));
+    m_wheel->GetSpindle()->AddVisualShape(m_cyl_shape);
+}
+
+void ChTMeasyTire::RemoveVisualizationAssets() {
+    // Make sure we only remove the assets added by ChTMeasyTire::AddVisualizationAssets.
+    // This is important for the ChTire object because a wheel may add its own assets to the same body (the
+    // spindle/wheel).
+    ChPart::RemoveVisualizationAsset(m_wheel->GetSpindle(), m_cyl_shape);
+}
+
+// -----------------------------------------------------------------------------
 
 void ChTMeasyTire::tmxy_combined(double& f,
                                  double& fos,

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
@@ -85,7 +85,7 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return GetGlobalTireForce(); }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override;
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -284,14 +284,10 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     void UpdateVerticalStiffness();
 
     /// Get the tire force and moment.
-    /// This represents the output from this tire system that is passed to the
-    /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
-    /// to the appropriate suspension subsystem which applies it as an external
-    /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override{ return GetGlobalTireForce(); }
-
-    ///Transform the tireforce from wheel frame to global frame
-    TerrainForce GetGlobalTireForce() const;
+    /// This represents the output from this tire system that is passed to the vehicle system.  Typically, the vehicle
+    /// subsystem will pass the tire force to the appropriate suspension subsystem which applies it as an external force
+    /// one the wheel body.
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
@@ -85,7 +85,7 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return m_tireforce; }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return GetGlobalTireForce(); }
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -288,7 +288,10 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
     /// to the appropriate suspension subsystem which applies it as an external
     /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override;
+    virtual TerrainForce GetTireForce() const override{ return GetGlobalTireForce(); }
+
+    ///Transform the tireforce from wheel frame to global frame
+    TerrainForce GetGlobalTireForce() const;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;
@@ -343,7 +346,7 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     ContactData m_data;
     TireStates m_states;
 
-    TerrainForce mutable m_tireforce;
+    TerrainForce m_tireforce;
 
     std::shared_ptr<ChCylinderShape> m_cyl_shape;  ///< visualization cylinder asset
 };

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
@@ -288,7 +288,7 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
     /// to the appropriate suspension subsystem which applies it as an external
     /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override { return m_tireforce; }
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;
@@ -343,7 +343,7 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     ContactData m_data;
     TireStates m_states;
 
-    TerrainForce m_tireforce;
+    TerrainForce mutable m_tireforce;
 
     std::shared_ptr<ChCylinderShape> m_cyl_shape;  ///< visualization cylinder asset
 };


### PR DESCRIPTION
The tire force calculated in this calculation step should be applied to the next calculation step in the vehicle simulation. Therefore,  the contact frame in the next calculation step should be used when the tire force is transformed to the global coordinates. If not, the acceleration will increase with the vehicle speed under the constant torque. It is unreasonable.
Now the problem is solved and the simulation results of acceleration do not depend on the time step and reasonable simulation results can be got under the time step of 1e-3s. In this way, real-time simulation can be guaranteed.
I have modified the code of Pac02, Pac89, and TMeasy.

