### PR TITLE
fix the faulty acceleration calculation

### DIFF
--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChFialaTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChFialaTire.h
@@ -54,7 +54,7 @@ class CH_VEHICLE_API ChFialaTire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_unloaded_radius; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return m_tireforce; }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override;
 
     /// Get the width of the tire.
     virtual double GetWidth() const override { return m_width; }
@@ -111,13 +111,11 @@ class CH_VEHICLE_API ChFialaTire : public ChForceElementTire {
     double m_time;        // actual system time
     double m_time_trans;  // end of start transient
 
-  //private:
     /// Get the tire force and moment.
-    /// This represents the output from this tire system that is passed to the
-    /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
-    /// to the appropriate suspension subsystem which applies it as an external
-    /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override { return m_tireforce; }
+    /// This represents the output from this tire system that is passed to the vehicle system.  Typically, the vehicle
+    /// subsystem will pass the tire force to the appropriate suspension subsystem which applies it as an external force
+    /// one the wheel body.
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
@@ -63,7 +63,7 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return m_tireforce; }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override;
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -78,8 +78,8 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     virtual double GetVisualizationWidth() const { return m_PacCoeff.width; }
 
     /// Get the slip angle used in Pac89 (expressed in radians).
-    /// The reported value will have opposite sign to that reported by ChTire::GetSlipAngle
-    /// because ChPac89 uses internally a different frame convention.
+    /// The reported value will have opposite sign to that reported by ChTire::GetSlipAngle because ChPac89 uses
+    /// internally a different frame convention.
     double GetSlipAngle_internal() const { return m_states.cp_side_slip; }
 
     /// Get the longitudinal slip used in Pac89.
@@ -292,13 +292,11 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
     Pac02ScalingFactors m_PacScal;
     Pac02Coeff m_PacCoeff;
 
-  //private:
     /// Get the tire force and moment.
-    /// This represents the output from this tire system that is passed to the
-    /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
-    /// to the appropriate suspension subsystem which applies it as an external
-    /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override { return m_tireforce; }
+    /// This represents the output from this tire system that is passed to the vehicle system.  Typically, the vehicle
+    /// subsystem will pass the tire force to the appropriate suspension subsystem which applies it as an external force
+    /// one the wheel body.
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.h
@@ -59,7 +59,7 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return m_tireforce; }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override;
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -158,13 +158,11 @@ class CH_VEHICLE_API ChPac89Tire : public ChForceElementTire {
 
     PacCoeff m_PacCoeff;
 
-  //private:
     /// Get the tire force and moment.
-    /// This represents the output from this tire system that is passed to the
-    /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
-    /// to the appropriate suspension subsystem which applies it as an external
-    /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override { return m_tireforce; }
+    /// This represents the output from this tire system that is passed to the vehicle system.  Typically, the vehicle
+    /// subsystem will pass the tire force to the appropriate suspension subsystem which applies it as an external force
+    /// one the wheel body.
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
@@ -85,7 +85,7 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     virtual double GetRadius() const override { return m_states.R_eff; }
 
     /// Report the tire force and moment.
-    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override { return m_tireforce; }
+    virtual TerrainForce ReportTireForce(ChTerrain* terrain) const override;
 
     /// Set the limit for camber angle (in degrees).  Default: 3 degrees.
     void SetGammaLimit(double gamma_limit) { m_gamma_limit = gamma_limit; }
@@ -284,11 +284,10 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
     void UpdateVerticalStiffness();
 
     /// Get the tire force and moment.
-    /// This represents the output from this tire system that is passed to the
-    /// vehicle system.  Typically, the vehicle subsystem will pass the tire force
-    /// to the appropriate suspension subsystem which applies it as an external
-    /// force one the wheel body.
-    virtual TerrainForce GetTireForce() const override { return m_tireforce; }
+    /// This represents the output from this tire system that is passed to the vehicle system.  Typically, the vehicle
+    /// subsystem will pass the tire force to the appropriate suspension subsystem which applies it as an external force
+    /// one the wheel body.
+    virtual TerrainForce GetTireForce() const override;
 
     /// Initialize this tire by associating it to the specified wheel.
     virtual void Initialize(std::shared_ptr<ChWheel> wheel) override;


### PR DESCRIPTION
The tire force calculated in this calculation step should be applied to the next calculation step in the vehicle simulation. Therefore, the contact frame in the next calculation step should be used when the tire force is transformed to the global coordinates. If not, the acceleration will increase or decrease with the vehicle speed under the constant torque. It is unreasonable.
Now the problem has been solved and the simulation results of acceleration do not depend on the time step and reasonable simulation results can be got under the time step of 1e-3s. In this way, real-time simulation can be guaranteed.