### PR TITLE
Added explicit include for ChVisualSystem.h, to avoid error when buil…

### DIFF
--- a/src/chrono_gpu/utils/ChGpuVisualization.h
+++ b/src/chrono_gpu/utils/ChGpuVisualization.h
@@ -23,6 +23,8 @@
 #include "chrono_gpu/ChApiGpu.h"
 #include "chrono_gpu/physics/ChSystemGpu.h"
 
+#include "chrono/assets/ChVisualSystem.h"
+
 #ifdef CHRONO_OPENGL
     #include "chrono_opengl/ChVisualSystemOpenGL.h"
 #endif


### PR DESCRIPTION
…ding with CHRONO_GPU but no CHRONO_OPENGL

When building with the GPU module but _not_ the OPENGL module, `CameraVerticalDir` is undefined within `src/chrono_gpu/utils/ChGpuVisualization.h`, because a header defining it is currently only included within an `ifdef` for the OPENGL module, so I added an include statement outside of that `ifdef`.  This is probably a unusual situation, but one we ran into.