### PR TITLE
Fix missing curly bracket

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -498,7 +498,7 @@ if(ENABLE_HDF5)
         if (HDF5_FOUND)
             set(HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIR})
             set(HDF5_C_LIBRARIES ${HDF5_C_${LIB_TYPE}_LIBRARY})
-            set(HDF5_CXX_LIBRARIES ${HDF5_CXX_${LIB_TYPE}_LIBRARY)
+            set(HDF5_CXX_LIBRARIES ${HDF5_CXX_${LIB_TYPE}_LIBRARY})
         endif()
     endif()
 


### PR DESCRIPTION
Could not find a contribution guide, apologies if this PR doesn't follow your normal practices.

This is a really self explanatory PR. I came across a missing curly bracket, while writing a Conan recipe for Project Chrono such that it can be installed with the C++ package manager Conan, see: https://github.com/conan-io/conan-center-index/issues/18561 and https://github.com/projectchrono/chrono/issues/270