### PR TITLE
Fix redefinition warning when using omp without CUDA

### DIFF
--- a/src/chrono/ChConfig.h.in
+++ b/src/chrono/ChConfig.h.in
@@ -194,7 +194,9 @@
 
 // If CUDA is not available, force Thrust to always use the OMP backend
 #ifndef CHRONO_HAS_CUDA
-  #define THRUST_DEVICE_SYSTEM THRUST_DEVICE_SYSTEM_OMP
+  #ifndef THRUST_DEVICE_SYSTEM
+    #define THRUST_DEVICE_SYSTEM THRUST_DEVICE_SYSTEM_OMP
+  #endif
 #endif
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Compiling with Thrust and omp without CUDA results in redefinition warning of `THRUST_DEVICE_SYSTEM` this PR add an extra check such that it is defined once