### PR TITLE
Recouple chrono::synchrono to latest api

### DIFF
--- a/src/demos/synchrono/dds/demo_SYN_DDS_distributed.cpp
+++ b/src/demos/synchrono/dds/demo_SYN_DDS_distributed.cpp
@@ -26,7 +26,6 @@
 
 #include "chrono_vehicle/wheeled_vehicle/vehicle/WheeledVehicle.h"
 
-
 #include "chrono_synchrono/SynConfig.h"
 #include "chrono_synchrono/SynChronoManager.h"
 #include "chrono_synchrono/agent/SynWheeledVehicleAgent.h"
@@ -44,7 +43,7 @@
 
 using namespace chrono;
 #ifdef CHRONO_IRRLICHT
-    using namespace chrono::irrlicht;
+using namespace chrono::irrlicht;
 #endif
 using namespace chrono::synchrono;
 using namespace chrono::vehicle;
@@ -247,7 +246,8 @@ int main(int argc, char* argv[]) {
     // Get the vehicle JSON filenames
     const std::string vehicle_filename = vehicle::GetDataFile("sedan/vehicle/Sedan_Vehicle.json");
     const std::string engine_filename = vehicle::GetDataFile("sedan/powertrain/Sedan_EngineSimpleMap.json");
-    const std::string transmission_filename = vehicle::GetDataFile("sedan/powertrain/Sedan_AutomaticTransmissionSimpleMap.json");
+    const std::string transmission_filename =
+        vehicle::GetDataFile("sedan/powertrain/Sedan_AutomaticTransmissionSimpleMap.json");
     const std::string tire_filename = vehicle::GetDataFile("sedan/tire/Sedan_TMeasyTire.json");
     const std::string zombie_filename = synchrono::GetDataFile("vehicle/Sedan.json");
 
@@ -261,8 +261,8 @@ int main(int argc, char* argv[]) {
     vehicle.SetWheelVisualizationType(wheel_vis_type);
 
     // Create and initialize the powertrain system
-    auto engine = ReadEngineJSON(vehicle::GetDataFile(engine_filename));
-    auto transmission = ReadTransmissionJSON(vehicle::GetDataFile(transmission_filename));
+    auto engine = ReadEngineJSON((engine_filename));
+    auto transmission = ReadTransmissionJSON((transmission_filename));
     auto powertrain = chrono_types::make_shared<ChPowertrainAssembly>(engine, transmission);
     vehicle.InitializePowertrain(powertrain);
 
@@ -355,7 +355,7 @@ int main(int argc, char* argv[]) {
         if (time >= end_time)
             break;
 
-        // Render scene
+            // Render scene
 #ifdef CHRONO_IRRLICHT
         if (step_number % render_steps == 0)
             app.Render();
@@ -365,7 +365,7 @@ int main(int argc, char* argv[]) {
         DriverInputs driver_inputs = driver.GetInputs();
 
         // Update modules (process inputs from other modules)
-        //std::async(&syn_manager.Synchronize, time);  // Synchronize between nodes
+        // std::async(&syn_manager.Synchronize, time);  // Synchronize between nodes
         std::async(std::launch::async, &SynChronoManager::Synchronize, &syn_manager, time);
         terrain.Synchronize(time);
         vehicle.Synchronize(time, driver_inputs, terrain);
@@ -384,7 +384,7 @@ int main(int argc, char* argv[]) {
         step_number++;
 
         // Log clock time
-        if (step_number % 100 == 0 ) {
+        if (step_number % 100 == 0) {
             std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
             auto time_span = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
@@ -392,11 +392,11 @@ int main(int argc, char* argv[]) {
             std::cout << std::flush;
         }
 
-        #ifdef CHRONO_IRRLICHT
+#ifdef CHRONO_IRRLICHT
         appok = app.IsOk();
-        #else
+#else
         appok = true;
-        #endif
+#endif
     }
 
     return 0;

--- a/src/demos/synchrono/dds/demo_SYN_DDS_tracked.cpp
+++ b/src/demos/synchrono/dds/demo_SYN_DDS_tracked.cpp
@@ -206,8 +206,8 @@ int main(int argc, char* argv[]) {
     vehicle.SetSuspensionVisualizationType(road_wheel_assembly_vis_type);
 
     // Create and initialize the powertrain system
-    auto engine = ReadEngineJSON(vehicle::GetDataFile(engine_file));
-    auto transmission = ReadTransmissionJSON(vehicle::GetDataFile(transmission_file));
+    auto engine = ReadEngineJSON(engine_file);
+    auto transmission = ReadTransmissionJSON(transmission_file);
     auto powertrain = chrono_types::make_shared<ChPowertrainAssembly>(engine, transmission);
     vehicle.InitializePowertrain(powertrain);
 
@@ -341,7 +341,7 @@ void GetVehicleModelFiles(VehicleType type,
         case VehicleType::M113:
             vehicle = vehicle::GetDataFile("M113/vehicle/M113_Vehicle_SinglePin.json");
             engine = vehicle::GetDataFile("M113/powertrain/M113_EngineSimple.json");
-            transmission = vehicle::GetDataFile("M113/powertrain/M113_AutomaticTransmissionSimple.json");
+            transmission = vehicle::GetDataFile("M113/powertrain/M113_AutomaticTransmissionSimpleMap.json");
             zombie = synchrono::GetDataFile("vehicle/M113.json");
             cam_distance = 8.0;
             break;

--- a/src/demos/synchrono/dds/demo_SYN_DDS_wheeled.cpp
+++ b/src/demos/synchrono/dds/demo_SYN_DDS_wheeled.cpp
@@ -206,8 +206,8 @@ int main(int argc, char* argv[]) {
     vehicle.SetWheelVisualizationType(wheel_vis_type);
 
     // Create and initialize the powertrain system
-    auto engine = ReadEngineJSON(vehicle::GetDataFile(engine_filename));
-    auto transmission = ReadTransmissionJSON(vehicle::GetDataFile(transmission_filename));
+    auto engine = ReadEngineJSON(engine_filename);
+    auto transmission = ReadTransmissionJSON(transmission_filename);
     auto powertrain = chrono_types::make_shared<ChPowertrainAssembly>(engine, transmission);
     vehicle.InitializePowertrain(powertrain);
 

--- a/src/demos/synchrono/mpi/demo_SYN_highway.cpp
+++ b/src/demos/synchrono/mpi/demo_SYN_highway.cpp
@@ -9,7 +9,7 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 // =============================================================================
-// Authors: Yan Xiao
+// Authors: Yan Xiao, Jason Zhou
 // =============================================================================
 //
 // Demo of several vehicles driving on a highway, vehicles follow paths to stay
@@ -36,11 +36,11 @@
 #include "chrono_synchrono/utils/SynLog.h"
 
 #ifdef CHRONO_SENSOR
-#include "chrono_sensor/ChSensorManager.h"
-#include "chrono_sensor/sensors/ChCameraSensor.h"
-#include "chrono_sensor/filters/ChFilterAccess.h"
-#include "chrono_sensor/filters/ChFilterSave.h"
-#include "chrono_sensor/filters/ChFilterVisualize.h"
+    #include "chrono_sensor/ChSensorManager.h"
+    #include "chrono_sensor/sensors/ChCameraSensor.h"
+    #include "chrono_sensor/filters/ChFilterAccess.h"
+    #include "chrono_sensor/filters/ChFilterSave.h"
+    #include "chrono_sensor/filters/ChFilterVisualize.h"
 using namespace chrono::sensor;
 #endif
 
@@ -67,7 +67,7 @@ ChContactMethod contact_method = ChContactMethod::SMC;
 ChVector<> trackPoint(0.0, 0.0, 1.75);
 
 // Simulation step sizes
-double step_size = 3e-3;
+double step_size = 5e-4;
 
 // Simulation end time
 double end_time = 1000;
@@ -148,8 +148,8 @@ int main(int argc, char* argv[]) {
     vehicle.SetWheelVisualizationType(wheel_vis_type);
 
     // Create and initialize the powertrain system
-    auto engine = ReadEngineJSON(vehicle::GetDataFile(engine_filename));
-    auto transmission = ReadTransmissionJSON(vehicle::GetDataFile(transmission_filename));
+    auto engine = ReadEngineJSON(engine_filename);
+    auto transmission = ReadTransmissionJSON(transmission_filename);
     auto powertrain = chrono_types::make_shared<ChPowertrainAssembly>(engine, transmission);
     vehicle.InitializePowertrain(powertrain);
 
@@ -274,7 +274,7 @@ int main(int argc, char* argv[]) {
             cam_res_height,                                 // image height
             (float)CH_C_PI / 3,                             // FOV
             1,                                              // samples per pixel for antialiasing
-            CameraLensModelType::PINHOLE);                                       // camera type
+            CameraLensModelType::PINHOLE);                  // camera type
 
         intersection_camera->SetName("Intersection Cam");
         intersection_camera->PushFilter(chrono_types::make_shared<ChFilterRGBA8Access>());

--- a/src/demos/synchrono/mpi/demo_SYN_scm_tracked.cpp
+++ b/src/demos/synchrono/mpi/demo_SYN_scm_tracked.cpp
@@ -9,7 +9,7 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 // =============================================================================
-// Authors: Jay Taves
+// Authors: Jay Taves, Jason Zhou
 // =============================================================================
 //
 // Demo code illustrating synchronization of the SCM semi-empirical model for

--- a/src/demos/synchrono/mpi/demo_SYN_tracked.cpp
+++ b/src/demos/synchrono/mpi/demo_SYN_tracked.cpp
@@ -9,7 +9,7 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 // =============================================================================
-// Authors: Aaron Young
+// Authors: Aaron Young, Jason Zhou
 // =============================================================================
 //
 // Basic demonstration of multiple tracked vehicles in a single simulation using
@@ -200,8 +200,8 @@ int main(int argc, char* argv[]) {
     vehicle.SetSuspensionVisualizationType(road_wheel_assembly_vis_type);
 
     // Create and initialize the powertrain system
-    auto engine = ReadEngineJSON(vehicle::GetDataFile(engine_file));
-    auto transmission = ReadTransmissionJSON(vehicle::GetDataFile(transmission_file));
+    auto engine = ReadEngineJSON(engine_file);
+    auto transmission = ReadTransmissionJSON(transmission_file);
     auto powertrain = chrono_types::make_shared<ChPowertrainAssembly>(engine, transmission);
     vehicle.InitializePowertrain(powertrain);
 
@@ -331,7 +331,7 @@ void GetVehicleModelFiles(VehicleType type,
         case VehicleType::M113:
             vehicle = vehicle::GetDataFile("M113/vehicle/M113_Vehicle_SinglePin.json");
             engine = vehicle::GetDataFile("M113/powertrain/M113_EngineSimple.json");
-            transmission = vehicle::GetDataFile("M113/powertrain/M113_AutomaticTransmissionSimple.json");
+            transmission = vehicle::GetDataFile("M113/powertrain/M113_AutomaticTransmissionSimpleMap.json");
             zombie = synchrono::GetDataFile("vehicle/M113.json");
             cam_distance = 8.0;
             break;

--- a/src/demos/synchrono/mpi/demo_SYN_wheeled.cpp
+++ b/src/demos/synchrono/mpi/demo_SYN_wheeled.cpp
@@ -201,8 +201,8 @@ int main(int argc, char* argv[]) {
     vehicle.SetWheelVisualizationType(wheel_vis_type);
 
     // Create and initialize the powertrain system
-    auto engine = ReadEngineJSON(vehicle::GetDataFile(engine_filename));
-    auto transmission = ReadTransmissionJSON(vehicle::GetDataFile(transmission_filename));
+    auto engine = ReadEngineJSON(engine_filename);
+    auto transmission = ReadTransmissionJSON(transmission_filename);
     auto powertrain = chrono_types::make_shared<ChPowertrainAssembly>(engine, transmission);
     vehicle.InitializePowertrain(powertrain);
 


### PR DESCRIPTION
Synchrono demos were using ouf-of-date chrono::vehicle apis and no longer runable.

This pull request fixes all synchrono demos.