### PR TITLE
Optimized ChISO2631_Vibration_SeatCushionLogger absorbed power calculation

### DIFF
--- a/src/chrono/utils/ChFilters.cpp
+++ b/src/chrono/utils/ChFilters.cpp
@@ -841,6 +841,7 @@ void ChISO2631_Vibration_SeatCushionLogger::Config(double step) {
     m_filter_wk_z.Config(step);
 
     m_filter_abspow.Config(step);
+    m_filter_int_abspow.Config(step);
 
     m_filter_int_aw_x.Config(step);
     m_filter_int_aw_y.Config(step);
@@ -863,7 +864,12 @@ void ChISO2631_Vibration_SeatCushionLogger::AddData(double speed, double acc_x, 
     m_data_acc_y.push_back(startFactor * acc_y);
     m_data_acc_z.push_back(startFactor * acc_z);
 
-    m_data_acc_ap_z.push_back(startFactor * acc_z * meter_to_ft);
+    double next_ap = startFactor * acc_z * meter_to_ft;
+    m_data_acc_ap_z.push_back(next_ap);
+    double ap = m_filter_abspow.Filter(next_ap);
+    double ap_int = m_filter_int_abspow.Filter(ap * ap);
+    double time = m_step * m_data_acc_ap_z.size();
+    m_data_ap_avg = ap_int / time;
 
     m_data_acc_x_wd.push_back(m_filter_wd_x.Filter(m_data_acc_x.back()));
     m_data_acc_y_wd.push_back(m_filter_wd_y.Filter(m_data_acc_y.back()));
@@ -998,30 +1004,7 @@ double ChISO2631_Vibration_SeatCushionLogger::GetSeverityVDV() const {
 }
 
 double ChISO2631_Vibration_SeatCushionLogger::GetAbsorbedPowerVertical() {
-    double ap = 0.0;
-    ChFilterI m_filter_int_abspow(m_step);
-
-    std::vector<double> ap_buf, ap_buf_int, ap_buf_avg;
-    for (size_t i = 0; i < m_data_acc_ap_z.size(); i++) {
-        ap_buf.push_back(m_filter_abspow.Filter(m_data_acc_ap_z[i]));
-    }
-    for (size_t i = 0; i < m_data_acc_ap_z.size(); i++) {
-        ap_buf_int.push_back(m_filter_int_abspow.Filter(ap_buf[i] * ap_buf[i]));
-    }
-    for (size_t i = 0; i < m_data_acc_ap_z.size(); i++) {
-        double time = m_step * i;
-        if (i == 0) {
-            ap_buf_avg.push_back(0.0);
-        } else {
-            ap_buf_avg.push_back(ap_buf_int[i] / time);
-        }
-    }
-
-    if (ap_buf_avg.empty())
-        return 0;
-
-    ap = ap_buf_avg.back();
-    return ap;
+    return m_data_ap_avg;
 }
 
 void ChISO2631_Vibration_SeatCushionLogger::Reset() {
@@ -1063,7 +1046,8 @@ void ChISO2631_Vibration_SeatCushionLogger::Reset() {
     m_filter_wk_z.Reset();
 
     m_filter_abspow.Reset();
-
+	m_filter_int_abspow.Reset();
+	
     m_filter_int_aw_x.Reset();
     m_filter_int_aw_y.Reset();
     m_filter_int_aw_z.Reset();

--- a/src/chrono/utils/ChFilters.h
+++ b/src/chrono/utils/ChFilters.h
@@ -472,6 +472,7 @@ class ChApi ChISO2631_Vibration_SeatCushionLogger {
     std::vector<double> m_data_acc_z;
 
     std::vector<double> m_data_acc_ap_z;  // vertical acceleration in ft/s^2 for absorbed power calculation
+    double m_data_ap_avg;
 
     // freqency weighted data series
     std::vector<double> m_data_acc_x_wd;
@@ -504,6 +505,7 @@ class ChApi ChISO2631_Vibration_SeatCushionLogger {
     ChISO2631_1_Wk m_filter_wk_z;
 
     ChAbsorbed_Power_Vertical m_filter_abspow;
+    ChFilterI m_filter_int_abspow;
 
     // filter classes for time integral aw
     ChFilterI m_filter_int_aw_x;


### PR DESCRIPTION
The GetAbsorbedPowerVertical() function is using 15% of total compute (on my particular run).  This is for two reasons:

1. It's building a std::vector of intermediate results even though it only uses the final result. (easy fix)
2. It retreads the entire history every time making the compute requirements O(n^2) with time.

In this patch I change the filters so they only update once as the data comes in. 

This change will result in different results due to what I assume is a bug in the current version. The code doesn't reset m_filter_abspow each pass through the array so some residual from the previous calculation affects the current result. This patch also fixes this.
