### PR TITLE
Add support for custom JSON constructors for vehicle sub-systems

### DIFF
--- a/src/chrono_vehicle/tracked_vehicle/vehicle/TrackedVehicle.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/vehicle/TrackedVehicle.cpp
@@ -28,18 +28,23 @@ namespace vehicle {
 
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-TrackedVehicle::TrackedVehicle(const std::string& filename, ChContactMethod contact_method)
+TrackedVehicle::TrackedVehicle(const std::string& filename,
+                               ChContactMethod contact_method,
+                               CustomConstructorsTV custom_constructors)
     : ChTrackedVehicle("", contact_method) {
-    Create(filename);
+    Create(filename, custom_constructors);
 }
 
-TrackedVehicle::TrackedVehicle(ChSystem* system, const std::string& filename) : ChTrackedVehicle("", system) {
-    Create(filename);
+TrackedVehicle::TrackedVehicle(ChSystem* system,
+                               const std::string& filename,
+                               CustomConstructorsTV custom_constructors)
+    : ChTrackedVehicle("", system) {
+    Create(filename, custom_constructors);
 }
 
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
-void TrackedVehicle::Create(const std::string& filename) {
+void TrackedVehicle::Create(const std::string& filename, CustomConstructorsTV custom_constructors) {
     // -------------------------------------------
     // Open and parse the input file
     // -------------------------------------------
@@ -67,7 +72,10 @@ void TrackedVehicle::Create(const std::string& filename) {
 
     {
         std::string file_name = d["Chassis"]["Input File"].GetString();
-        m_chassis = ReadChassisJSON(vehicle::GetDataFile(file_name));
+        m_chassis = ReadChassisJSON(
+            vehicle::GetDataFile(file_name),
+            custom_constructors.chassis_constructor
+        );
         if (d["Chassis"].HasMember("Output")) {
             m_chassis->SetOutput(d["Chassis"]["Output"].GetBool());
         }
@@ -83,7 +91,10 @@ void TrackedVehicle::Create(const std::string& filename) {
 
     {
         std::string file_name = d["Track Assemblies"][0u]["Input File"].GetString();
-        m_tracks[VehicleSide::LEFT] = ReadTrackAssemblyJSON(vehicle::GetDataFile(file_name));
+        m_tracks[VehicleSide::LEFT] = ReadTrackAssemblyJSON(
+            vehicle::GetDataFile(file_name),
+            custom_constructors.track_assembly_constructor
+        );
         if (d["Track Assemblies"][0u].HasMember("Output")) {
             m_tracks[VehicleSide::LEFT]->SetOutput(d["Track Assemblies"][0u]["Output"].GetBool());
         }
@@ -91,7 +102,10 @@ void TrackedVehicle::Create(const std::string& filename) {
     }
     {
         std::string file_name = d["Track Assemblies"][1u]["Input File"].GetString();
-        m_tracks[VehicleSide::RIGHT] = ReadTrackAssemblyJSON(vehicle::GetDataFile(file_name));
+        m_tracks[VehicleSide::RIGHT] = ReadTrackAssemblyJSON(
+            vehicle::GetDataFile(file_name),
+            custom_constructors.track_assembly_constructor
+        );
         if (d["Track Assemblies"][1u].HasMember("Output")) {
             m_tracks[VehicleSide::RIGHT]->SetOutput(d["Track Assemblies"][1u]["Output"].GetBool());
         }
@@ -106,7 +120,10 @@ void TrackedVehicle::Create(const std::string& filename) {
 
     {
         std::string file_name = d["Driveline"]["Input File"].GetString();
-        m_driveline = ReadDrivelineTVJSON(vehicle::GetDataFile(file_name));
+        m_driveline = ReadDrivelineTVJSON(
+            vehicle::GetDataFile(file_name),
+            custom_constructors.driveline_tv_constructor
+        );
         if (d["Driveline"].HasMember("Output")) {
             m_driveline->SetOutput(d["Driveline"]["Output"].GetBool());
         }

--- a/src/chrono_vehicle/tracked_vehicle/vehicle/TrackedVehicle.h
+++ b/src/chrono_vehicle/tracked_vehicle/vehicle/TrackedVehicle.h
@@ -27,19 +27,40 @@ namespace vehicle {
 /// @addtogroup vehicle_tracked
 /// @{
 
+/// Constructors for different vehicle subsystems. Used to construct custom
+/// instances of the subsystems from a JSON document.
+struct CH_VEHICLE_API CustomConstructorsTV {
+
+    /// A constructor for creating a vehicle subsystem from a JSON document.
+    template<typename T>
+    using CustomConstructor =
+        std::function<std::shared_ptr<T>(
+            const std::string&,         /// The name of the template to create an instance of
+            const rapidjson::Document&  /// The JSON document
+        )>;
+
+    CustomConstructor<ChChassis> chassis_constructor;
+    CustomConstructor<ChTrackAssembly> track_assembly_constructor;
+    CustomConstructor<ChDrivelineTV> driveline_tv_constructor;
+};
+
 /// Tracked vehicle model constructed from a JSON specification file.
 class CH_VEHICLE_API TrackedVehicle : public ChTrackedVehicle {
   public:
-    TrackedVehicle(const std::string& filename, ChContactMethod contact_method = ChContactMethod::NSC);
+    TrackedVehicle(const std::string& filename,
+                   ChContactMethod contact_method = ChContactMethod::NSC,
+                   CustomConstructorsTV custom_constructors = {});
 
-    TrackedVehicle(ChSystem* system, const std::string& filename);
+    TrackedVehicle(ChSystem* system,
+                   const std::string& filename,
+                   CustomConstructorsTV custom_constructors = {});
 
     ~TrackedVehicle() {}
 
     virtual void Initialize(const ChCoordsys<>& chassisPos, double chassisFwdVel = 0) override;
 
   private:
-    void Create(const std::string& filename);
+    void Create(const std::string& filename, CustomConstructorsTV custom_constructors);
 
   private:
     double m_track_offset[2];  ///< offsets for the left and right track assemblies

--- a/src/chrono_vehicle/utils/ChUtilsJSON.cpp
+++ b/src/chrono_vehicle/utils/ChUtilsJSON.cpp
@@ -630,7 +630,7 @@ std::shared_ptr<ChLinkRSDA::TorqueFunctor> ReadRSDAFunctorJSON(const rapidjson::
 
 // -----------------------------------------------------------------------------
 
-std::shared_ptr<ChChassis> ReadChassisJSON(const std::string& filename) {
+std::shared_ptr<ChChassis> ReadChassisJSON(const std::string& filename, JSONConstructorFn<ChChassis> custom_constructor) {
     std::shared_ptr<ChChassis> chassis;
 
     Document d;
@@ -650,14 +650,17 @@ std::shared_ptr<ChChassis> ReadChassisJSON(const std::string& filename) {
     // Create the chassis using the appropriate template.
     if (subtype.compare("RigidChassis") == 0) {
         chassis = chrono_types::make_shared<RigidChassis>(d);
-    } else {
-        throw ChException("Chassis type not supported in ReadChassisJSON.");
+    } else if (custom_constructor) {
+        chassis = custom_constructor(subtype, d);
     }
+
+    if (!chassis)
+        throw ChException("Chassis type not supported in ReadChassisJSON.");
 
     return chassis;
 }
 
-std::shared_ptr<ChChassisRear> ReadChassisRearJSON(const std::string& filename) {
+std::shared_ptr<ChChassisRear> ReadChassisRearJSON(const std::string& filename, JSONConstructorFn<ChChassisRear> custom_constructor) {
     std::shared_ptr<ChChassisRear> chassis;
 
     Document d;
@@ -677,14 +680,17 @@ std::shared_ptr<ChChassisRear> ReadChassisRearJSON(const std::string& filename) 
     // Create the chassis using the appropriate template.
     if (subtype.compare("RigidChassisRear") == 0) {
         chassis = chrono_types::make_shared<RigidChassisRear>(d);
-    } else {
-        throw ChException("Chassis type not supported in ReadChassisRearJSON.");
+    } else if (custom_constructor){
+        chassis = custom_constructor(subtype, d);
     }
+
+    if (!chassis)
+        throw ChException("Chassis type not supported in ReadChassisRearJSON.");
 
     return chassis;
 }
 
-std::shared_ptr<ChChassisConnector> ReadChassisConnectorJSON(const std::string& filename) {
+std::shared_ptr<ChChassisConnector> ReadChassisConnectorJSON(const std::string& filename, JSONConstructorFn<ChChassisConnector> custom_constructor) {
     std::shared_ptr<ChChassisConnector> connector;
 
     Document d;
@@ -708,14 +714,17 @@ std::shared_ptr<ChChassisConnector> ReadChassisConnectorJSON(const std::string& 
         connector = chrono_types::make_shared<ChassisConnectorArticulated>(d);
     } else if (subtype.compare("ChassisConnectorTorsion") == 0) {
         connector = chrono_types::make_shared<ChassisConnectorTorsion>(d);
-    } else {
-        throw ChException("Chassis type not supported in ReadChassisConnectorJSON.");
+    } else if (custom_constructor) {
+        connector = custom_constructor(subtype, d);
     }
+
+    if (!connector)
+        throw ChException("Chassis type not supported in ReadChassisConnectorJSON.");
 
     return connector;
 }
 
-std::shared_ptr<ChEngine> ReadEngineJSON(const std::string& filename) {
+std::shared_ptr<ChEngine> ReadEngineJSON(const std::string& filename, JSONConstructorFn<ChEngine> custom_constructor) {
     std::shared_ptr<ChEngine> engine;
 
     Document d;
@@ -739,14 +748,17 @@ std::shared_ptr<ChEngine> ReadEngineJSON(const std::string& filename) {
         engine = chrono_types::make_shared<EngineSimpleMap>(d);
     } else if (subtype.compare("EngineShafts") == 0) {
         engine = chrono_types::make_shared<EngineShafts>(d);
-    } else {
-        throw ChException("Engine type not supported in ReadEngineJSON.");
+    } else if (custom_constructor) {
+        engine = custom_constructor(subtype, d);
     }
+
+    if (!engine)
+        throw ChException("Engine type not supported in ReadEngineJSON.");
 
     return engine;
 }
 
-std::shared_ptr<ChTransmission> ReadTransmissionJSON(const std::string& filename) {
+std::shared_ptr<ChTransmission> ReadTransmissionJSON(const std::string& filename, JSONConstructorFn<ChTransmission> custom_constructor) {
     std::shared_ptr<ChTransmission> transmission;
 
     Document d;
@@ -770,16 +782,19 @@ std::shared_ptr<ChTransmission> ReadTransmissionJSON(const std::string& filename
         transmission = chrono_types::make_shared<AutomaticTransmissionShafts>(d);
     } else if (subtype.compare("ManualTransmissionShafts") == 0) {
         transmission = chrono_types::make_shared<ManualTransmissionShafts>(d);
-    } else {
-        throw ChException("Transmission type not supported in ReadTransmissionJSON.");
+    } else if (custom_constructor) {
+        transmission = custom_constructor(subtype, d);
     }
+
+    if (!transmission)
+        throw ChException("Transmission type not supported in ReadTransmissionJSON.");
 
     return transmission;
 }
 
 // -----------------------------------------------------------------------------
 
-std::shared_ptr<ChSuspension> ReadSuspensionJSON(const std::string& filename) {
+std::shared_ptr<ChSuspension> ReadSuspensionJSON(const std::string& filename, JSONConstructorFn<ChSuspension> custom_constructor) {
     std::shared_ptr<ChSuspension> suspension;
 
     Document d;
@@ -839,14 +854,17 @@ std::shared_ptr<ChSuspension> ReadSuspensionJSON(const std::string& filename) {
         suspension = chrono_types::make_shared<HendricksonPRIMAXX>(d);
     } else if (subtype.compare("GenericWheeledSuspension") == 0) {
         suspension = chrono_types::make_shared<GenericWheeledSuspension>(d);
-    } else {
-        throw ChException("Suspension type not supported in ReadSuspensionJSON.");
+    } else if (custom_constructor) {
+        suspension = custom_constructor(subtype, d);
     }
+
+    if (!suspension)
+        throw ChException("Suspension type not supported in ReadSuspensionJSON.");
 
     return suspension;
 }
 
-std::shared_ptr<ChSteering> ReadSteeringJSON(const std::string& filename) {
+std::shared_ptr<ChSteering> ReadSteeringJSON(const std::string& filename, JSONConstructorFn<ChSteering> custom_constructor) {
     std::shared_ptr<ChSteering> steering;
 
     Document d;
@@ -870,14 +888,17 @@ std::shared_ptr<ChSteering> ReadSteeringJSON(const std::string& filename) {
         steering = chrono_types::make_shared<RackPinion>(d);
     } else if (subtype.compare("RotaryArm") == 0) {
         steering = chrono_types::make_shared<RotaryArm>(d);
-    } else {
-        throw ChException("Steering type not supported in ReadSteeringJSON.");
+    } else if (custom_constructor) {
+        steering = custom_constructor(subtype, d);
     }
+
+    if (!steering)
+        throw ChException("Steering type not supported in ReadSteeringJSON.");
 
     return steering;
 }
 
-std::shared_ptr<ChDrivelineWV> ReadDrivelineWVJSON(const std::string& filename) {
+std::shared_ptr<ChDrivelineWV> ReadDrivelineWVJSON(const std::string& filename, JSONConstructorFn<ChDrivelineWV> custom_constructor) {
     std::shared_ptr<ChDrivelineWV> driveline;
 
     Document d;
@@ -903,14 +924,17 @@ std::shared_ptr<ChDrivelineWV> ReadDrivelineWVJSON(const std::string& filename) 
         driveline = chrono_types::make_shared<SimpleDriveline>(d);
     } else if (subtype.compare("SimpleDrivelineXWD") == 0) {
         driveline = chrono_types::make_shared<SimpleDrivelineXWD>(d);
-    } else {
-        throw ChException("Driveline type not supported in ReadDrivelineWVJSON.");
+    } else if (custom_constructor) {
+        driveline = custom_constructor(subtype, d);
     }
+
+    if (!driveline)
+        throw ChException("Driveline type not supported in ReadDrivelineWVJSON.");
 
     return driveline;
 }
 
-std::shared_ptr<ChAntirollBar> ReadAntirollbarJSON(const std::string& filename) {
+std::shared_ptr<ChAntirollBar> ReadAntirollbarJSON(const std::string& filename, JSONConstructorFn<ChAntirollBar> custom_constructor) {
     std::shared_ptr<ChAntirollBar> antirollbar;
 
     Document d;
@@ -930,14 +954,17 @@ std::shared_ptr<ChAntirollBar> ReadAntirollbarJSON(const std::string& filename) 
     // Create the antirollbar using the appropriate template.
     if (subtype.compare("AntirollBarRSD") == 0) {
         antirollbar = chrono_types::make_shared<AntirollBarRSD>(d);
-    } else {
-        throw ChException("AntirollBar type not supported in ReadAntirollbarJSON.");
+    } else if (antirollbar) {
+        antirollbar = custom_constructor(subtype, d);
     }
+
+    if (!antirollbar)
+        throw ChException("AntirollBar type not supported in ReadAntirollbarJSON.");
 
     return antirollbar;
 }
 
-std::shared_ptr<ChWheel> ReadWheelJSON(const std::string& filename) {
+std::shared_ptr<ChWheel> ReadWheelJSON(const std::string& filename, JSONConstructorFn<ChWheel> custom_constructor) {
     std::shared_ptr<ChWheel> wheel;
 
     Document d;
@@ -957,14 +984,17 @@ std::shared_ptr<ChWheel> ReadWheelJSON(const std::string& filename) {
     // Create the wheel using the appropriate template.
     if (subtype.compare("Wheel") == 0) {
         wheel = chrono_types::make_shared<Wheel>(d);
-    } else {
-        throw ChException("Wheel type not supported in ReadWheelJSON.");
+    } else if (custom_constructor) {
+        wheel = custom_constructor(subtype, d);
     }
+
+    if (!wheel)
+        throw ChException("Wheel type not supported in ReadWheelJSON.");
 
     return wheel;
 }
 
-std::shared_ptr<ChSubchassis> ReadSubchassisJSON(const std::string& filename) {
+std::shared_ptr<ChSubchassis> ReadSubchassisJSON(const std::string& filename, JSONConstructorFn<ChSubchassis> custom_constructor) {
     std::shared_ptr<ChSubchassis> chassis;
 
     Document d;
@@ -984,14 +1014,17 @@ std::shared_ptr<ChSubchassis> ReadSubchassisJSON(const std::string& filename) {
     // Create the wheel using the appropriate template.
     if (subtype.compare("Balancer") == 0) {
         chassis = chrono_types::make_shared<Balancer>(d);
-    } else {
-        throw ChException("Subchassis type not supported in ReadSubchassisJSON.");
+    } else if (custom_constructor) {
+        chassis = custom_constructor(subtype, d);
     }
+
+    if (!chassis)
+        throw ChException("Subchassis type not supported in ReadSubchassisJSON.");
 
     return chassis;
 }
 
-std::shared_ptr<ChBrake> ReadBrakeJSON(const std::string& filename) {
+std::shared_ptr<ChBrake> ReadBrakeJSON(const std::string& filename, JSONConstructorFn<ChBrake> custom_constructor) {
     std::shared_ptr<ChBrake> brake;
 
     Document d;
@@ -1013,14 +1046,17 @@ std::shared_ptr<ChBrake> ReadBrakeJSON(const std::string& filename) {
         brake = chrono_types::make_shared<BrakeSimple>(d);
     } else if (subtype.compare("BrakeShafts") == 0) {
         brake = chrono_types::make_shared<BrakeShafts>(d);
-    } else {
-        throw ChException("Brake type not supported in ReadBrakeJSON.");
+    } else if (custom_constructor) {
+        brake = custom_constructor(subtype, d);
     }
+
+    if (!brake)
+        throw ChException("Brake type not supported in ReadBrakeJSON.");
 
     return brake;
 }
 
-std::shared_ptr<ChTire> ReadTireJSON(const std::string& filename) {
+std::shared_ptr<ChTire> ReadTireJSON(const std::string& filename, JSONConstructorFn<ChTire> custom_constructor) {
     std::shared_ptr<ChTire> tire;
 
     Document d;
@@ -1056,16 +1092,19 @@ std::shared_ptr<ChTire> ReadTireJSON(const std::string& filename) {
         tire = chrono_types::make_shared<ReissnerTire>(d);
     } else if (subtype.compare("FEATire") == 0) {
         tire = chrono_types::make_shared<FEATire>(d);
-    } else {
-        throw ChException("Tire type not supported in ReadTireJSON.");
+    } else if (custom_constructor) {
+        tire = custom_constructor(subtype, d);
     }
+
+    if (!tire)
+        throw ChException("Tire type not supported in ReadTireJSON.");
 
     return tire;
 }
 
 // -----------------------------------------------------------------------------
 
-std::shared_ptr<ChTrackAssembly> ReadTrackAssemblyJSON(const std::string& filename) {
+std::shared_ptr<ChTrackAssembly> ReadTrackAssemblyJSON(const std::string& filename, JSONConstructorFn<ChTrackAssembly> custom_constructor) {
     std::shared_ptr<ChTrackAssembly> track;
 
     Document d;
@@ -1091,14 +1130,17 @@ std::shared_ptr<ChTrackAssembly> ReadTrackAssemblyJSON(const std::string& filena
         track = chrono_types::make_shared<TrackAssemblyBandBushing>(d);
     } else if (subtype.compare("TrackAssemblyBandANCF") == 0) {
         track = chrono_types::make_shared<TrackAssemblyBandANCF>(d);
-    } else {
-        throw ChException("TrackAssembly type not supported in ReadTrackAssemblyJSON.");
+    } else if (custom_constructor) {
+        track = custom_constructor(subtype, d);
     }
+
+    if (!track)
+        throw ChException("TrackAssembly type not supported in ReadTrackAssemblyJSON.");
 
     return track;
 }
 
-std::shared_ptr<ChDrivelineTV> ReadDrivelineTVJSON(const std::string& filename) {
+std::shared_ptr<ChDrivelineTV> ReadDrivelineTVJSON(const std::string& filename, JSONConstructorFn<ChDrivelineTV> custom_constructor) {
     std::shared_ptr<ChDrivelineTV> driveline;
 
     Document d;
@@ -1120,14 +1162,17 @@ std::shared_ptr<ChDrivelineTV> ReadDrivelineTVJSON(const std::string& filename) 
         driveline = chrono_types::make_shared<SimpleTrackDriveline>(d);
     } else if (subtype.compare("TrackDrivelineBDS") == 0) {
         driveline = chrono_types::make_shared<TrackDrivelineBDS>(d);
-    } else {
-        throw ChException("Driveline type not supported in ReadTrackDrivelineJSON.");
+    } else if (custom_constructor) {
+        driveline = custom_constructor(subtype, d);
     }
+
+    if (!driveline)
+        throw ChException("Driveline type not supported in ReadTrackDrivelineJSON.");
 
     return driveline;
 }
 
-std::shared_ptr<ChTrackBrake> ReadTrackBrakeJSON(const std::string& filename) {
+std::shared_ptr<ChTrackBrake> ReadTrackBrakeJSON(const std::string& filename, JSONConstructorFn<ChTrackBrake> custom_constructor) {
     std::shared_ptr<ChTrackBrake> brake;
 
     Document d;
@@ -1149,14 +1194,17 @@ std::shared_ptr<ChTrackBrake> ReadTrackBrakeJSON(const std::string& filename) {
         brake = chrono_types::make_shared<TrackBrakeSimple>(d);
     } else if (subtype.compare("TrackBrakeShafts") == 0) {
         brake = chrono_types::make_shared<TrackBrakeShafts>(d);
-    } else {
-        throw ChException("Brake type not supported in ReadTrackBrakeJSON.");
+    } else if (custom_constructor) {
+        brake = custom_constructor(subtype, d);
     }
+
+    if (!brake)
+        throw ChException("Brake type not supported in ReadTrackBrakeJSON.");
 
     return brake;
 }
 
-std::shared_ptr<ChIdler> ReadIdlerJSON(const std::string& filename) {
+std::shared_ptr<ChIdler> ReadIdlerJSON(const std::string& filename, JSONConstructorFn<ChIdler> custom_constructor) {
     std::shared_ptr<ChIdler> idler;
 
     Document d;
@@ -1178,14 +1226,17 @@ std::shared_ptr<ChIdler> ReadIdlerJSON(const std::string& filename) {
         idler = chrono_types::make_shared<TranslationalIdler>(d);
     } else if (subtype.compare("DistanceIdler") == 0) {
         idler = chrono_types::make_shared<DistanceIdler>(d);
-    } else {
-        throw ChException("Idler type not supported in ReadIdlerJSON.");
+    } else if (custom_constructor) {
+        idler = custom_constructor(subtype, d);
     }
+
+    if (!idler)
+        throw ChException("Idler type not supported in ReadIdlerJSON.");
 
     return idler;
 }
 
-std::shared_ptr<ChTrackSuspension> ReadTrackSuspensionJSON(const std::string& filename, bool has_shock, bool lock_arm) {
+std::shared_ptr<ChTrackSuspension> ReadTrackSuspensionJSON(const std::string& filename, bool has_shock, bool lock_arm, JSONConstructorFn<ChTrackSuspension> custom_constructor) {
     std::shared_ptr<ChTrackSuspension> suspension;
 
     Document d;
@@ -1207,14 +1258,17 @@ std::shared_ptr<ChTrackSuspension> ReadTrackSuspensionJSON(const std::string& fi
         suspension = chrono_types::make_shared<TranslationalDamperSuspension>(d, has_shock, lock_arm);
     } else if (subtype.compare("RotationalDamperSuspension") == 0) {
         suspension = chrono_types::make_shared<RotationalDamperSuspension>(d, has_shock, lock_arm);
-    } else {
-        throw ChException("Suspension type not supported in ReadTrackSuspensionJSON.");
+    } else if (custom_constructor) {
+        suspension = custom_constructor(subtype, d);
     }
+
+    if (!suspension)
+        throw ChException("Suspension type not supported in ReadTrackSuspensionJSON.");
 
     return suspension;
 }
 
-std::shared_ptr<ChTrackWheel> ReadTrackWheelJSON(const std::string& filename) {
+std::shared_ptr<ChTrackWheel> ReadTrackWheelJSON(const std::string& filename, JSONConstructorFn<ChTrackWheel> custom_constructor) {
     std::shared_ptr<ChTrackWheel> wheel;
 
     Document d;
@@ -1236,9 +1290,12 @@ std::shared_ptr<ChTrackWheel> ReadTrackWheelJSON(const std::string& filename) {
         wheel = chrono_types::make_shared<SingleTrackWheel>(d);
     } else if (subtype.compare("DoubleTrackWheel") == 0) {
         wheel = chrono_types::make_shared<DoubleTrackWheel>(d);
-    } else {
-        throw ChException("Road-wheel type not supported in ReadTrackWheelJSON.");
+    } else if (custom_constructor) {
+        wheel = custom_constructor(subtype, d);
     }
+
+    if (!wheel)
+        throw ChException("Road-wheel type not supported in ReadTrackWheelJSON.");
 
     return wheel;
 }

--- a/src/chrono_vehicle/utils/ChUtilsJSON.h
+++ b/src/chrono_vehicle/utils/ChUtilsJSON.h
@@ -51,6 +51,15 @@ namespace vehicle {
 
 // -----------------------------------------------------------------------------
 
+/// A constructor for creating a vehicle subsystem from a JSON document.
+template<typename T>
+using JSONConstructorFn = std::function<std::shared_ptr<T>(
+        const std::string&,         /// The name of the template to create an instance of
+        const rapidjson::Document&  /// The JSON document
+    )>;
+
+// -----------------------------------------------------------------------------
+
 /// Load and return a RapidJSON document from the specified file.
 /// A Null document is returned if the file cannot be opened.
 CH_VEHICLE_API void ReadFileJSON(const std::string& filename, rapidjson::Document& d);
@@ -98,67 +107,68 @@ CH_VEHICLE_API std::shared_ptr<ChLinkRSDA::TorqueFunctor> ReadRSDAFunctorJSON(co
 // -----------------------------------------------------------------------------
 
 /// Load and return a chassis subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChChassis> ReadChassisJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChChassis> ReadChassisJSON(const std::string& filename, JSONConstructorFn<ChChassis> = {});
 
 /// Load and return a rear chassis subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChChassisRear> ReadChassisRearJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChChassisRear> ReadChassisRearJSON(const std::string& filename, JSONConstructorFn<ChChassisRear> = {});
 
 /// Load and return a chassis connector subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChChassisConnector> ReadChassisConnectorJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChChassisConnector> ReadChassisConnectorJSON(const std::string& filename, JSONConstructorFn<ChChassisConnector> = {});
 
 /// Load and return an engine subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChEngine> ReadEngineJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChEngine> ReadEngineJSON(const std::string& filename, JSONConstructorFn<ChEngine> = {});
 
 /// Load and return a transmission subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChTransmission> ReadTransmissionJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChTransmission> ReadTransmissionJSON(const std::string& filename, JSONConstructorFn<ChTransmission> = {});
 
 // -----------------------------------------------------------------------------
 
 ///  Load and return a suspension subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChSuspension> ReadSuspensionJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChSuspension> ReadSuspensionJSON(const std::string& filename, JSONConstructorFn<ChSuspension> = {});
 
 ///  Load and return a steering subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChSteering> ReadSteeringJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChSteering> ReadSteeringJSON(const std::string& filename, JSONConstructorFn<ChSteering> = {});
 
 ///  Load and return a driveline subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChDrivelineWV> ReadDrivelineWVJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChDrivelineWV> ReadDrivelineWVJSON(const std::string& filename, JSONConstructorFn<ChDrivelineWV> = {});
 
 ///  Load and return a steering subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChAntirollBar> ReadAntirollbarJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChAntirollBar> ReadAntirollbarJSON(const std::string& filename, JSONConstructorFn<ChAntirollBar> = {});
 
 ///  Load and return a steering subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChWheel> ReadWheelJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChWheel> ReadWheelJSON(const std::string& filename, JSONConstructorFn<ChWheel> = {});
 
 /// Load and return a subchassis subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChSubchassis> ReadSubchassisJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChSubchassis> ReadSubchassisJSON(const std::string& filename, JSONConstructorFn<ChSubchassis> = {});
 
 ///  Load and return a steering subsystem from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChBrake> ReadBrakeJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChBrake> ReadBrakeJSON(const std::string& filename, JSONConstructorFn<ChBrake> = {});
 
 /// Load and return a tire from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChTire> ReadTireJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChTire> ReadTireJSON(const std::string& filename, JSONConstructorFn<ChTire> = {});
 
 // -----------------------------------------------------------------------------
 
 /// Load and return a track assembly from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChTrackAssembly> ReadTrackAssemblyJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChTrackAssembly> ReadTrackAssemblyJSON(const std::string& filename, JSONConstructorFn<ChTrackAssembly> = {});
 
 /// Load and return a track driveline from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChDrivelineTV> ReadDrivelineTVJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChDrivelineTV> ReadDrivelineTVJSON(const std::string& filename, JSONConstructorFn<ChDrivelineTV> = {});
 
 /// Load and return a track brake from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChTrackBrake> ReadTrackBrakeJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChTrackBrake> ReadTrackBrakeJSON(const std::string& filename, JSONConstructorFn<ChTrackBrake> = {});
 
 /// Load and return an idler from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChIdler> ReadIdlerJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChIdler> ReadIdlerJSON(const std::string& filename, JSONConstructorFn<ChIdler> = {});
 
 /// Load and return a track suspension from the specified JSON file.
 CH_VEHICLE_API std::shared_ptr<ChTrackSuspension> ReadTrackSuspensionJSON(const std::string& filename,
                                                                           bool has_shock,
-                                                                          bool lock_arm);
+                                                                          bool lock_arm,
+                                                                          JSONConstructorFn<ChTrackSuspension> = {});
 
 /// Load and return a road-wheel from the specified JSON file.
-CH_VEHICLE_API std::shared_ptr<ChTrackWheel> ReadTrackWheelJSON(const std::string& filename);
+CH_VEHICLE_API std::shared_ptr<ChTrackWheel> ReadTrackWheelJSON(const std::string& filename, JSONConstructorFn<ChTrackWheel> = {});
 
 // -----------------------------------------------------------------------------
 

--- a/src/chrono_vehicle/wheeled_vehicle/vehicle/WheeledVehicle.h
+++ b/src/chrono_vehicle/wheeled_vehicle/vehicle/WheeledVehicle.h
@@ -27,6 +27,34 @@ namespace vehicle {
 /// @addtogroup vehicle_wheeled
 /// @{
 
+
+/// Constructors for different vehicle subsystems. Used to construct custom
+/// instances of the subsystems from a JSON document.
+struct CH_VEHICLE_API CustomConstructorsWV {
+
+    /// A constructor for creating a vehicle subsystem from a JSON document.
+    template<typename T>
+    using CustomConstructor =
+        std::function<std::shared_ptr<T>(
+            const std::string&,         /// The name of the template to create an instance of
+            const rapidjson::Document&  /// The JSON document
+        )>;
+
+    CustomConstructor<ChChassis> chassis_constructor;
+    CustomConstructor<ChChassisRear> chassis_rear_constructor;
+    CustomConstructor<ChChassisConnector> chassis_connector_constructor;
+    CustomConstructor<ChEngine> engine_constructor;
+    CustomConstructor<ChTransmission> transmission_constructor;
+    CustomConstructor<ChSuspension> suspension_constructor;
+    CustomConstructor<ChSteering> steering_constructor;
+    CustomConstructor<ChDrivelineWV> driveline_constructor;
+    CustomConstructor<ChAntirollBar> antirollbar_constructor;
+    CustomConstructor<ChWheel> wheel_constructor;
+    CustomConstructor<ChSubchassis> subchassis_constructor;
+    CustomConstructor<ChBrake> brake_constructor;
+    CustomConstructor<ChTire> tire_constructor;
+};
+
 /// Wheeled vehicle model constructed from a JSON specification file.
 class CH_VEHICLE_API WheeledVehicle : public ChWheeledVehicle {
   public:
@@ -36,7 +64,8 @@ class CH_VEHICLE_API WheeledVehicle : public ChWheeledVehicle {
     WheeledVehicle(const std::string& filename,
                    ChContactMethod contact_method = ChContactMethod::NSC,
                    bool create_powertrain = true,
-                   bool create_tires = true);
+                   bool create_tires = true,
+                   CustomConstructorsWV custom_constructors = {});
 
     /// Create a wheeled vehicle from the provided JSON specification file.
     /// The vehicle is added to the given Chrono system. If indicated, an associated powertrain and tires are created
@@ -44,7 +73,8 @@ class CH_VEHICLE_API WheeledVehicle : public ChWheeledVehicle {
     WheeledVehicle(ChSystem* system,
                    const std::string& filename,
                    bool create_powertrain = true,
-                   bool create_tires = true);
+                   bool create_tires = true,
+                   CustomConstructorsWV custom_constructors = {});
 
     ~WheeledVehicle() {}
 
@@ -57,7 +87,10 @@ class CH_VEHICLE_API WheeledVehicle : public ChWheeledVehicle {
     virtual void Initialize(const ChCoordsys<>& chassisPos, double chassisFwdVel = 0) override;
 
   private:
-    void Create(const std::string& filename, bool create_powertrain, bool create_tires);
+    void Create(const std::string& filename,
+                bool create_powertrain,
+                bool create_tires,
+                CustomConstructorsWV custom_constructors);
 
   private:
     int m_num_rear_chassis;                   // number of rear chassis subsystems for this vehicle


### PR DESCRIPTION
Currently vehicles can be constructed from JSON files, but only using the predefined templates. This pull request adds the possibility to supply custom constructors when creating a vehicle from a JSON file.

This can be used like this:

(main.cpp)
```C++
// An example of a custom vehicle component
class ExampleDriveline : public ChDrivelineWV {
    // Implementation
};

// An example constructor for custom driveline implementations
std::shared_ptr<ChDrivelineWV> custom_driveline_constructor(
    const std::string& name,
    const rapidjson::Document&
) {
    if(name == "ExampleDriveline") {
        return std::make_shared<ExampleDriveline>();
    }
    else if(name == "ExampleDriveline2") {
        return std::make_shared<ExampleDriveline2>();
    }
    // etc...

    return nullptr;
}

int main() {
    // Set custom constructors
    CustomConstructorsWV custom_constructors = {};
    custom_constructors.driveline_constructor = custom_driveline_constructor;
    // custom_constructors.suspension_constructor = ....

    // Create vehicle
    WheeledVehicle vehicle(
        vehicle::GetDataFile("vehicle/Example.json"),
        ChContactMethod::NSC,
        false,
        true,
        custom_constructors
    );
}
```

(ExampleDriveline.json)
```json
{
  "Name":       "Example Driveline",
  "Type":         "Driveline",
  "Template":  "ExampleDriveline",

  "Stuff":
  {
    "Thing": 0.5
  }
}
```
