### PR TITLE
Fixed synchrono unit test to couple with latest synchrono api (updated clean PR)

### DIFF
--- a/src/chrono_synchrono/SynChronoManager.h
+++ b/src/chrono_synchrono/SynChronoManager.h
@@ -74,6 +74,10 @@ class SYN_API SynChronoManager {
     ///
     std::map<AgentKey, std::shared_ptr<SynAgent>>& GetAgents() { return m_agents; }
 
+    ///@brief Get the zombies list
+    ///
+    std::map<AgentKey, std::shared_ptr<SynAgent>>& GetZombies() { return m_zombies; }
+
     ///@brief Set the heartbeat for the rate at which SynChrono synchronization
     /// occurs
     ///

--- a/src/tests/unit_tests/synchrono/utest_SYN_agent_initialization.cpp
+++ b/src/tests/unit_tests/synchrono/utest_SYN_agent_initialization.cpp
@@ -119,17 +119,19 @@ int main(int argc, char* argv[]) {
 TEST(SynChrono, SynChronoInit) {
     // Retrieve mpi_manager after sync
     auto check_agent_list = syn_manager_ptr->GetAgents();
+    auto check_zombie_list = syn_manager_ptr->GetZombies();
 
     // Agent list size after sync
     int check_agent_size = static_cast<int>(check_agent_list.size());
+    int check_zombie_size = static_cast<int>(check_zombie_list.size());
 
     // Var to store msg on the current rank after mpi sync
     SynMessageList messages;
-    check_agent_list[AgentKey(rank, 0)]->GatherMessages(messages);
+    check_agent_list[AgentKey(rank, 1)]->GatherMessages(messages);
     auto msg_recvd = messages[0];
 
     // Check whether agent size is num_ranks
-    EXPECT_EQ(check_agent_size, num_ranks);
+    EXPECT_EQ(check_agent_size + check_zombie_size, num_ranks);
 
     // Check whether the msg in the agent on the curr rank is intact
     EXPECT_EQ(msg_recvd, msg_sent);


### PR DESCRIPTION
- added zombie list retrieval helper in synchrono manager class
- coupled utest_SYN_agent_initialization to latest apis

SYN utests need to be run with 3 ranks.