### PR TITLE
Kraz demo realism fixes (fifth wheel and COM changes)

### DIFF
--- a/src/chrono_models/vehicle/kraz/Kraz_tractor_Chassis.cpp
+++ b/src/chrono_models/vehicle/kraz/Kraz_tractor_Chassis.cpp
@@ -30,7 +30,7 @@ namespace kraz {
 const double Kraz_tractor_Chassis::m_body_mass = 10000.0;
 const ChVector3d Kraz_tractor_Chassis::m_body_inertiaXX(3441, 28485, 29395);
 const ChVector3d Kraz_tractor_Chassis::m_body_inertiaXY(0, 0, 0);
-const ChVector3d Kraz_tractor_Chassis::m_body_COM_loc(-2.0, 0, 0.6);
+const ChVector3d Kraz_tractor_Chassis::m_body_COM_loc(-2.0, 0, 0.8);
 const ChVector3d Kraz_tractor_Chassis::m_connector_loc(-4.64, 0, 0.82);
 const ChCoordsys<> Kraz_tractor_Chassis::m_driverCsys(ChVector3d(-1.5, 0.5, 1.2), ChQuaternion<>(1, 0, 0, 0));
 

--- a/src/chrono_models/vehicle/kraz/Kraz_trailer_Chassis.cpp
+++ b/src/chrono_models/vehicle/kraz/Kraz_trailer_Chassis.cpp
@@ -26,7 +26,7 @@ namespace kraz {
 const double Kraz_trailer_Chassis::m_body_mass = 20000.0;
 const ChVector3d Kraz_trailer_Chassis::m_body_inertiaXX(23904, 322240, 320011);
 const ChVector3d Kraz_trailer_Chassis::m_body_inertiaXY(0, 0, 0);
-const ChVector3d Kraz_trailer_Chassis::m_body_COM_loc(-6, 0, 0.8);
+const ChVector3d Kraz_trailer_Chassis::m_body_COM_loc(-6, 0, 2);
 const ChVector3d Kraz_trailer_Chassis::m_connector_loc(-0.04, 0, 0.82);
 
 Kraz_trailer_Chassis::Kraz_trailer_Chassis(const std::string& name, CollisionType chassis_collision_type)

--- a/src/chrono_models/vehicle/kraz/Kraz_trailer_Chassis.h
+++ b/src/chrono_models/vehicle/kraz/Kraz_trailer_Chassis.h
@@ -20,7 +20,7 @@
 #define KRAZ_TRAILER_CHASSIS_H
 
 #include "chrono_vehicle/chassis/ChRigidChassis.h"
-#include "chrono_vehicle/chassis/ChChassisConnectorHitch.h"
+#include "chrono_vehicle/chassis/ChChassisConnectorFifthWheel.h"
 
 #include "chrono_models/ChApiModels.h"
 #include "chrono_models/vehicle/ChVehicleModelDefs.h"
@@ -60,10 +60,10 @@ class CH_MODELS_API Kraz_trailer_Chassis : public ChRigidChassisRear {
 
 // -----------------------------------------------------------------------------
 
-/// Kraz tractor-trailer hitch connector subsystem.
-class CH_MODELS_API Kraz_trailer_Connector : public ChChassisConnectorHitch {
+/// Kraz tractor-trailer fifth wheel connector subsystem.
+class CH_MODELS_API Kraz_trailer_Connector : public ChChassisConnectorFifthWheel {
   public:
-    Kraz_trailer_Connector(const std::string& name) : ChChassisConnectorHitch(name) {}
+    Kraz_trailer_Connector(const std::string& name) : ChChassisConnectorFifthWheel(name) {}
     ~Kraz_trailer_Connector() {}
 };
 

--- a/src/chrono_vehicle/CMakeLists.txt
+++ b/src/chrono_vehicle/CMakeLists.txt
@@ -205,6 +205,8 @@ set(CV_CHASSIS_FILES
     chassis/ChChassisConnectorArticulated.cpp
     chassis/ChChassisConnectorHitch.h
     chassis/ChChassisConnectorHitch.cpp
+    chassis/ChChassisConnectorFifthWheel.h
+    chassis/ChChassisConnectorFifthWheel.cpp
     chassis/ChChassisConnectorTorsion.h
     chassis/ChChassisConnectorTorsion.cpp
 
@@ -213,6 +215,8 @@ set(CV_CHASSIS_FILES
 
     chassis/ChassisConnectorHitch.h
     chassis/ChassisConnectorHitch.cpp
+    chassis/ChassisConnectorFifthWheel.h
+    chassis/ChassisConnectorFifthWheel.cpp
     chassis/ChassisConnectorArticulated.h
     chassis/ChassisConnectorArticulated.cpp
     chassis/ChassisConnectorTorsion.h

--- a/src/chrono_vehicle/chassis/ChChassisConnectorFifthWheel.cpp
+++ b/src/chrono_vehicle/chassis/ChChassisConnectorFifthWheel.cpp
@@ -1,0 +1,64 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Ian Rust
+// =============================================================================
+//
+// Template for a fifth wheel chassis connector.  This is a passive connector,
+// modeled with a universal joint.
+//
+// =============================================================================
+
+#include "chrono_vehicle/chassis/ChChassisConnectorFifthWheel.h"
+
+namespace chrono {
+namespace vehicle {
+
+ChChassisConnectorFifthWheel::ChChassisConnectorFifthWheel(const std::string& name) : ChChassisConnectorHitch(name) {}
+
+ChChassisConnectorFifthWheel::~ChChassisConnectorFifthWheel() {
+    if (!m_initialized)
+        return;
+
+    auto sys = m_joint->GetSystem();
+    if (!sys)
+        return;
+
+    sys->Remove(m_joint);
+}
+
+void ChChassisConnectorFifthWheel::Initialize(std::shared_ptr<ChChassis> front, std::shared_ptr<ChChassisRear> rear) {
+    ChChassisConnector::Initialize(front, rear);
+
+    ChQuaternion<> x2z;
+    x2z.SetFromAngleY(90.0);
+
+    // Express the connector reference frames in the local coordinate system of the trailer and towing vehicle coordinate system
+    //
+    ChFrame<> rear_frame(rear->GetLocalPosFrontConnector());
+    rear_frame.ConcatenatePreTransformation(rear->GetBody()->GetFrameRefToCOM());
+    // rotate so that the fixed axis (z) is aligned with the body x direction
+    rear_frame.SetRot(x2z);
+
+    ChFrame<> front_frame(front->GetLocalPosRearConnector());
+    front_frame.ConcatenatePreTransformation(front->GetBody()->GetFrameRefToCOM());
+    // rotate so that the fixed axis (z) is aligned with the body x direction
+    front_frame.SetRot(x2z);
+
+    // Create the universal joint connection
+    m_joint = chrono_types::make_shared<ChLinkUniversal>();
+    m_joint->SetName(m_name + " joint");
+    m_joint->Initialize(front->GetBody(), rear->GetBody(), true, front_frame, rear_frame);
+    rear->GetBody()->GetSystem()->AddLink(m_joint);
+}
+
+}  // end namespace vehicle
+}  // end namespace chrono

--- a/src/chrono_vehicle/chassis/ChChassisConnectorFifthWheel.h
+++ b/src/chrono_vehicle/chassis/ChChassisConnectorFifthWheel.h
@@ -1,0 +1,59 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Ian Rust
+// =============================================================================
+//
+// Template for a fifth wheel chassis connector.  This is a passive connector,
+// modeled with a universal joint.
+//
+// =============================================================================
+
+#ifndef CH_CHASSIS_CONNECTOR_FIFTH_WHEEL_H
+#define CH_CHASSIS_CONNECTOR_FIFTH_WHEEL_H
+
+#include "chrono_vehicle/ChChassis.h"
+#include "chrono/physics/ChLinkUniversal.h"
+#include "chrono_vehicle/chassis/ChassisConnectorHitch.h"
+
+namespace chrono {
+namespace vehicle {
+
+/// @addtogroup vehicle
+/// @{
+
+/// Template for a hitch chassis connector.  This is a passive connector, modeled with a spherical joint.
+class CH_VEHICLE_API ChChassisConnectorFifthWheel : public ChChassisConnectorHitch {
+  public:
+    ChChassisConnectorFifthWheel(const std::string& name);
+    ~ChChassisConnectorFifthWheel();
+
+    /// Get the name of the vehicle subsystem template.
+    virtual std::string GetTemplateName() const override { return "ChassisConnectorFifthWheel"; }
+
+    /// Initialize this chassis connector subsystem.
+    /// The subsystem is initialized by attaching it to the specified front and rear
+    /// chassis bodies at the specified location (with respect to and expressed in
+    /// the reference frame of the front chassis).
+    virtual void Initialize(std::shared_ptr<ChChassis> front,    ///< [in] front chassis
+                            std::shared_ptr<ChChassisRear> rear  ///< [in] rear chassis
+                            ) override;
+
+  protected:
+    std::shared_ptr<ChLinkUniversal> m_joint;  ///< spherical joint of the connector
+};
+
+/// @} vehicle
+
+}  // end namespace vehicle
+}  // end namespace chrono
+
+#endif

--- a/src/chrono_vehicle/chassis/ChassisConnectorFifthWheel.cpp
+++ b/src/chrono_vehicle/chassis/ChassisConnectorFifthWheel.cpp
@@ -1,0 +1,49 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Radu Serban
+// =============================================================================
+//
+// FifthWheel chassis connector model constructed with data from file (JSON format).
+//
+// =============================================================================
+
+#include "chrono_vehicle/ChVehicleModelData.h"
+#include "chrono_vehicle/chassis/ChassisConnectorFifthWheel.h"
+#include "chrono_vehicle/utils/ChUtilsJSON.h"
+
+using namespace rapidjson;
+
+namespace chrono {
+namespace vehicle {
+
+ChassisConnectorFifthWheel::ChassisConnectorFifthWheel(const std::string& filename) : ChChassisConnectorFifthWheel("") {
+    Document d;
+    ReadFileJSON(filename, d);
+    if (d.IsNull())
+        return;
+
+    Create(d);
+
+    std::cout << "Loaded JSON " << filename << std::endl;
+}
+
+ChassisConnectorFifthWheel::ChassisConnectorFifthWheel(const rapidjson::Document& d) : ChChassisConnectorFifthWheel("") {
+    Create(d);
+}
+
+void ChassisConnectorFifthWheel::Create(const rapidjson::Document& d) {
+    // Invoke base class method.
+    ChPart::Create(d);
+}
+
+}  // end namespace vehicle
+}  // end namespace chrono

--- a/src/chrono_vehicle/chassis/ChassisConnectorFifthWheel.h
+++ b/src/chrono_vehicle/chassis/ChassisConnectorFifthWheel.h
@@ -1,0 +1,48 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Ian Rust
+// =============================================================================
+//
+// FifthWheel chassis connector model constructed with data from file (JSON format).
+//
+// =============================================================================
+#ifndef CHASSIS_CONNECTOR_FIFTH_WHEEL_H
+#define CHASSIS_CONNECTOR_FIFTH_WHEEL_H
+
+#include "chrono_vehicle/ChApiVehicle.h"
+#include "chrono_vehicle/chassis/ChChassisConnectorFifthWheel.h"
+
+#include "chrono_thirdparty/rapidjson/document.h"
+
+namespace chrono {
+namespace vehicle {
+
+/// @addtogroup vehicle
+/// @{
+
+/// Fifth wheel chassis connector model constructed with data from file (JSON format).
+class CH_VEHICLE_API ChassisConnectorFifthWheel : public ChChassisConnectorFifthWheel {
+  public:
+    ChassisConnectorFifthWheel(const std::string& filename);
+    ChassisConnectorFifthWheel(const rapidjson::Document& d);
+    ~ChassisConnectorFifthWheel() {}
+
+  private:
+    virtual void Create(const rapidjson::Document& d) override;
+};
+
+/// @} vehicle
+
+}  // end namespace vehicle
+}  // end namespace chrono
+
+#endif


### PR DESCRIPTION
In the Kraz Demo, the Hitch being a Spherical joint is incorrect because a tractor trailer uses a "fifth wheel" hitch that only has 2 rotary degrees of freedom. The hitch can rotate in the Z direction, and can rock in the y direction, but cannot rotate in the x direction: 
![image](https://github.com/user-attachments/assets/fa6ff41e-df3f-42d1-b050-1bf727175076)

As such, the spherical joint is not appropriate. This is however consistent with a Universal joint rotated 90 degrees such that the z axis of the joint is coincident with the x axis of the tractor. This PR creates a subclass of `ChChassisConnectorHitch` called `ChChassisConnectorFifthWheel` and replaces the standard hitch (spherical joint) with a Fifth Wheel hitch (universal joint).

In addition, the centers of mass of both the tractor and the trailer are unrealistically low, so I changed these to be more consistent with where they are in reality