### PR TITLE
remove clearkeyframes and enable the moving average in imu update filter

### DIFF
--- a/src/chrono_sensor/ChDynamicsManager.cpp
+++ b/src/chrono_sensor/ChDynamicsManager.cpp
@@ -45,7 +45,7 @@ CH_SENSOR_API void ChDynamicsManager::UpdateSensors() {
                 for (auto filter : pSen->GetFilterList()) {
                     filter->Apply();
                 }
-                pSen->ClearKeyFrames();
+                // pSen->ClearKeyFrames();
             }
         }
     }


### PR DESCRIPTION
Try to solve the IMU smoothing problem as suggested by @Nevindu . 

For some unknown reason, there's ` pSen->ClearKeyFrames();` in dynamcs manager in the code, which kinda disable the moving average function in the IMU update funtion ([imu moving average function](https://github.com/projectchrono/chrono/blob/f63fff51fd03f2b66a7e6550ffe6fda6a8b60929/src/chrono_sensor/filters/ChFilterIMUUpdate.cpp#L39)). 

I did a test before and after remove ` pSen->ClearKeyFrames();`. Test: attach IMU (with zero noise) to a gator vehicle, and 0-5 second, vehicle move forward with 0.5 throttle and after 5 second, apply full brake. here is the IMU data logging comparison (only change is add/remove the code ` pSen->ClearKeyFrames();`):

![Screenshot from 2024-11-21 10-03-33](https://github.com/user-attachments/assets/2da9388c-3604-4d30-8f18-42f21b195011)
