### PR TITLE
Up-rev FastDDS dependency to version 2.14 for Synchrono

### DIFF
--- a/doxygen/documentation/installation/module_synchrono_installation.md
+++ b/doxygen/documentation/installation/module_synchrono_installation.md
@@ -22,8 +22,7 @@ The **SynChrono module** allows users to parallelize the dynamics computations f
     - A version is included in chrono_thirdparty as a submodule, for general development either that version or an externally built one can be used.
 - The following are optional:
   * [FastDDS](https://fast-dds.docs.eprosima.com/en/latest/)
-    - Please use the [latest binaries](https://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-dds) for installation.
-    - Versions provided by package managers will likely work as well if they are reasonably up to date.
+    - Please use the [FastDDS Version 2.14](https://www.eprosima.com/product-download) for installation.
 
 ## Building instructions
 

--- a/src/chrono_synchrono/communication/dds/idl/SynDDSMessagePubSubTypes.cxx
+++ b/src/chrono_synchrono/communication/dds/idl/SynDDSMessagePubSubTypes.cxx
@@ -58,7 +58,7 @@ bool SynDDSMessagePubSubType::serialize(
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::DDS_CDR);
     payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
     // Serialize encapsulation
     ser.serialize_encapsulation();
@@ -74,7 +74,7 @@ bool SynDDSMessagePubSubType::serialize(
     }
 
     // Get the serialized length
-    payload->length = static_cast<uint32_t>(ser.getSerializedDataLength());
+    payload->length = static_cast<uint32_t>(ser.get_serialized_data_length());
     return true;
 }
 
@@ -89,7 +89,7 @@ bool SynDDSMessagePubSubType::deserialize(
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->length);
 
     // Object that deserializes the data.
-    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::DDS_CDR);
 
     // Deserialize encapsulation.
     deser.read_encapsulation();
@@ -151,7 +151,7 @@ bool SynDDSMessagePubSubType::getKey(
     if (force_md5 || SynDDSMessage::getKeyMaxCdrSerializedSize() > 16)
     {
         m_md5.init();
-        m_md5.update(m_keyBuffer, static_cast<unsigned int>(ser.getSerializedDataLength()));
+        m_md5.update(m_keyBuffer, static_cast<unsigned int>(ser.get_serialized_data_length()));
         m_md5.finalize();
         for (uint8_t i = 0; i < 16; ++i)
         {

--- a/src/chrono_synchrono/communication/dds/idl/SynDDSMessagePubSubTypes.h
+++ b/src/chrono_synchrono/communication/dds/idl/SynDDSMessagePubSubTypes.h
@@ -28,7 +28,7 @@
 
 #include "SynDDSMessage.h"
 
-#if !defined(GEN_API_VER) || (GEN_API_VER != 1)
+#if !defined(GEN_API_VER) || (GEN_API_VER != 2)
 #error Generated SynDDSMessage is not compatible with current installed Fast DDS. Please, regenerate it with fastddsgen.
 #endif  // GEN_API_VER
 


### PR DESCRIPTION
This PR aims to up-rev FastDDS dependency to version 2.14 [released 27 July 2024] with minor API changes. 

The link in installation guide has been old and broken, this PR also updated the documentation with correct web link to eProsima FastDDS download.

All related DDS demos with prefix ./demo_SYN_DDS* have been tested and they were running well.