### PR TITLE
Reduced time_step for sim stability in demo_SYN_scm

### DIFF
--- a/src/demos/synchrono/mpi/demo_SYN_scm.cpp
+++ b/src/demos/synchrono/mpi/demo_SYN_scm.cpp
@@ -365,7 +365,7 @@ int main(int argc, char* argv[]) {
 
 void AddCommandLineOptions(ChCLI& cli) {
     // Standard demo options
-    cli.AddOption<double>("Simulation", "s,step_size", "Step size", "3e-3");
+    cli.AddOption<double>("Simulation", "s,step_size", "Step size", "1e-3");
     cli.AddOption<double>("Simulation", "e,end_time", "End time", "1000");
     cli.AddOption<double>("Simulation", "b,heartbeat", "Heartbeat", "1e-2");
     cli.AddOption<std::string>("Simulation", "c,contact_method", "Contact Method", "SMC", "NSC/SMC");


### PR DESCRIPTION
The default step_size is not stable for demo_SYN_scm demo. This PR reduces the default step_size for the sim demo to 1e-3 for stability.

Attached is a screenshot with original 3e-3 step size, the vehicle dynamics and path following behaviors are strange:
![image](https://github.com/user-attachments/assets/e9669a58-e665-4789-b987-5115811d6c6f)

This might be due to a change on the solver and vehicle dynamics side which I was not participated in.


Platform:
System: ubuntu 22.04
CPU: AMD Ryzen 7 2700X
GPU: NVIDIA GTX1080