### PR TITLE
Include ChSystem header in ChVehicleCosimBaseNode.h

### DIFF
--- a/src/chrono_vehicle/cosim/ChVehicleCosimBaseNode.h
+++ b/src/chrono_vehicle/cosim/ChVehicleCosimBaseNode.h
@@ -30,6 +30,8 @@
 #include "chrono/core/ChVector3.h"
 #include "chrono/core/ChQuaternion.h"
 
+#include "chrono/physics/ChSystem.h"
+
 #include "chrono/utils/ChBodyGeometry.h"
 
 #include "chrono_vehicle/ChApiVehicle.h"


### PR DESCRIPTION
Added an include for ChSystem.h, since there was no context for the ChSystem pointer on line 238 when building.