### PR TITLE
Add CXX to CSharp demos Cmakelists (not inherited from core cmake)

### DIFF
--- a/src/demos/csharp/CMakeLists.txt
+++ b/src/demos/csharp/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(ChronoDemos CSharp)
+# We're using Csharp here, but adding the CXX language lets CMake know that a C++ compiler is
+# available for configuration checks - openmp and mpi require it (others may also)
+project(ChronoDemos CSharp CXX)
 
 if(NOT Chrono_DIR)
   set(Chrono_DIR "" CACHE PATH "The directory containing a CMake configuration file for Chrono.")

--- a/src/demos/csharp/README.md
+++ b/src/demos/csharp/README.md
@@ -13,3 +13,5 @@ The demos in this directory are meant for illustration only, as well as a mechan
 
 To prevent mixing different languages (C++ and C#) in the same build, these demos can not be enabled, configured, and built simultaneously with the rest of the Chrono libraries, C++ demos, and tests.  Instead, we provide a separate CMakeLists.txt hierarchy to generate a C# CMake project that includes all C# demos in the various sub-directories.  These C# demos assume an existing Chrono installation (with the Chrono::Csharp module enabled) and are configured as external projects depending on Chrono.  This setup is very similar to the simpler example provided in `template_project_csharp`, except that the CMake scripts here account for multiple sub-projects. 
 
+As DLL dependencies are no longer copied over, the user will need to copy Irrlicht library and Chrono dll's into the build folder, or set them in PATH environment.
+


### PR DESCRIPTION
For the demo builds for csharp (if chrono was built with openmp or mpi) their find macros require the CXX language tag

Also noted in readme for the demos that user needs to bring irrlicht.dll into build folder manually