### PR TITLE
Fixed bug of being unable to find the vehicle scripts when collecting csharp module files and small update to C# demo readme

### DIFF
--- a/src/demos/csharp/CMakeLists.txt
+++ b/src/demos/csharp/CMakeLists.txt
@@ -89,7 +89,7 @@ function(CollectCSharpFiles out_list module_list)
   endif()
   
   # Vehicle module
-  list (FIND module_list "postprocess" index)
+  list (FIND module_list "vehicle" index)
   if (${index} GREATER -1)
     set(Chrono_CSHARP_VEHICLE_DIR "${PROJECT_BINARY_DIR}/chrono_csharp/vehicle")
     file(GLOB Chrono_CSHARP_VEHICLE_SOURCES

--- a/src/demos/csharp/README.md
+++ b/src/demos/csharp/README.md
@@ -8,3 +8,7 @@ Currently, these are:
 - the Chrono::Vehicle module
 
 To generate the necessary C# scripts and associated libraries, set `CH_ENABLE_MODULE_CSHARP` to `ON` and also enable any other desired Chrono module (Irrlicht and/or Vehicle). The resulting C# scripts and associated libraries can then be used in external C# programs that leverage the exposed Chrono functionality, or else embedded in a Unity project.
+
+When using MS Visual Studio, in order to build the C# demos included in the main Chrono solution, firstly build the core modules. When complete, attempt to build a C# demo to trigger Cmake GLOB update and a regeneration of all dependencies (i.e. the SIG generated .cs builds). Reload again and then proceed to build demos.
+
+NB. If using the irrlicht module, ensure you manually copy the Irrlicht.dll to the build folder (or point to it in the system PATH), otherwise the demos will present an "unhandled exception error" stating an inability to load the dll 'Chrono_csharp_vehicle' for example. This is somewhat misleading, as it is not an error with Chrono - check you have correctly placed the Irrlicht (or any other required component dll) where the program can find it.

--- a/src/demos/csharp/core/CMakeLists.txt
+++ b/src/demos/csharp/core/CMakeLists.txt
@@ -13,5 +13,8 @@ CollectCSharpFiles(CHRONO_CSHARP_SOURCES "${MODULE_LIST}")
 
 foreach(PROGRAM ${DEMOS})
   add_executable(${PROGRAM} "${PROGRAM}.cs" ${CHRONO_CSHARP_SOURCES})
-  add_dependencies(${PROGRAM} Chrono_csharp_core)
+  # set dependencies, so latest SWIG always builds first
+  foreach(module IN LISTS MODULE_LIST)
+    add_dependencies(${PROGRAM} "Chrono_csharp_${module}")
+  endforeach()
 endforeach()

--- a/src/demos/csharp/mbs/CMakeLists.txt
+++ b/src/demos/csharp/mbs/CMakeLists.txt
@@ -18,5 +18,8 @@ CollectCSharpFiles(CHRONO_CSHARP_SOURCES "${MODULE_LIST}")
 
 foreach(PROGRAM ${DEMOS})
   add_executable(${PROGRAM} "${PROGRAM}.cs" ${CHRONO_CSHARP_SOURCES})
-  add_dependencies(${PROGRAM} Chrono_csharp_core Chrono_csharp_irrlicht)
+  # set dependencies, so latest SWIG always builds first
+  foreach(module IN LISTS MODULE_LIST)
+    add_dependencies(${PROGRAM} "Chrono_csharp_${module}")
+  endforeach()
 endforeach()

--- a/src/demos/csharp/vehicle/CMakeLists.txt
+++ b/src/demos/csharp/vehicle/CMakeLists.txt
@@ -40,7 +40,6 @@ CollectCSharpFiles(CHRONO_CSHARP_SOURCES "${MODULE_LIST}")
 
 foreach(PROGRAM ${DEMOS})
   add_executable(${PROGRAM} "${PROGRAM}.cs" ${CHRONO_CSHARP_SOURCES})
-  add_dependencies(${PROGRAM} Chrono_csharp_core Chrono_csharp_irrlicht Chrono_csharp_vehicle Chrono_csharp_postprocess)
 
   # Applying specific reference dependencies for CRGTerrain demos (uses dynamic objects)
   if(HAVE_OPENCRG)
@@ -52,5 +51,8 @@ foreach(PROGRAM ${DEMOS})
       find_package(Mono REQUIRED)
     endif()
   endif()
-
+  # set dependencies, so latest SWIG always builds first
+  foreach(module IN LISTS MODULE_LIST)
+    add_dependencies(${PROGRAM} "Chrono_csharp_${module}")
+  endforeach()
 endforeach()


### PR DESCRIPTION
small error in cmake custom function (postprocess listed where vehicle string should be). And some instruction in the readme to explain a bit more the multi-step cmake generation required for building the demos.