### PR TITLE
fea linear elements refactor

### DIFF
--- a/src/chrono/fea/ChBuilderBeam.cpp
+++ b/src/chrono/fea/ChBuilderBeam.cpp
@@ -94,12 +94,12 @@ void ChBuilderBeamEuler::BuildBeam(std::shared_ptr<ChMesh> mesh,              //
         element->SetNodes(beam_nodes[i - 1], beam_nodes[i]);
 
         ChQuaternion<> elrot = mrot.GetQuaternion();
-        element->SetNodeAreferenceRot(elrot.GetConjugate() * element->GetNodeA()->Frame().GetRot());
-        element->SetNodeBreferenceRot(elrot.GetConjugate() * element->GetNodeB()->Frame().GetRot());
+        element->SetRefRotation(elrot);
+        element->SetElemToNodeArefRot(elrot.GetConjugate() * element->GetNodeA()->Frame().GetRot());
+        element->SetElemToNodeBrefRot(elrot.GetConjugate() * element->GetNodeB()->Frame().GetRot());
 
         element->SetSection(sect);
 
-        element->SetRefRotation(mrot.GetQuaternion());
     }
 }
 
@@ -133,14 +133,12 @@ void ChBuilderBeamEuler::BuildBeam(std::shared_ptr<ChMesh> mesh,              //
         element->SetNodes(beam_nodes[i - 1], beam_nodes[i]);
 
         ChQuaternion<> elrot = mrot.GetQuaternion();
-        element->SetNodeAreferenceRot(elrot.GetConjugate() * element->GetNodeA()->Frame().GetRot());
-        element->SetNodeBreferenceRot(elrot.GetConjugate() * element->GetNodeB()->Frame().GetRot());
-        // std::cout << "Element n." << i << " with rotations:" << std::endl;
-        // std::cout << "   Qa=" << element->GetNodeAreferenceRot() << std::endl;
-        // std::cout << "   Qb=" << element->GetNodeBreferenceRot() << std::endl << std::endl;
+        element->SetRefRotation(elrot);
+        element->SetElemToNodeArefRot(elrot.GetConjugate() * element->GetNodeA()->Frame().GetRot());
+        element->SetElemToNodeBrefRot(elrot.GetConjugate() * element->GetNodeB()->Frame().GetRot());
+
         element->SetSection(sect);
 
-        element->SetRefRotation(mrot.GetQuaternion());
     }
 }
 

--- a/src/chrono/fea/ChBuilderBeam.cpp
+++ b/src/chrono/fea/ChBuilderBeam.cpp
@@ -54,6 +54,8 @@ void ChBuilderBeamEuler::BuildBeam(std::shared_ptr<ChMesh> mesh,              //
         element->SetNodes(beam_nodes[i - 1], beam_nodes[i]);
 
         element->SetSection(sect);
+
+        element->SetRefRotation(mrot.GetQuaternion());
     }
 }
 
@@ -96,6 +98,8 @@ void ChBuilderBeamEuler::BuildBeam(std::shared_ptr<ChMesh> mesh,              //
         element->SetNodeBreferenceRot(elrot.GetConjugate() * element->GetNodeB()->Frame().GetRot());
 
         element->SetSection(sect);
+
+        element->SetRefRotation(mrot.GetQuaternion());
     }
 }
 
@@ -135,6 +139,8 @@ void ChBuilderBeamEuler::BuildBeam(std::shared_ptr<ChMesh> mesh,              //
         // std::cout << "   Qa=" << element->GetNodeAreferenceRot() << std::endl;
         // std::cout << "   Qb=" << element->GetNodeBreferenceRot() << std::endl << std::endl;
         element->SetSection(sect);
+
+        element->SetRefRotation(mrot.GetQuaternion());
     }
 }
 

--- a/src/chrono/fea/ChElementBar.h
+++ b/src/chrono/fea/ChElementBar.h
@@ -71,7 +71,7 @@ class ChApi ChElementBar : public ChElementGeneric {
     // Custom properties functions
     //
 
-    /// Set the cross sectional area of the bar (m^2) (also changes stiffness keeping same E modulus)
+    /// Set the cross sectional area of the bar (m^2)
     void SetArea(double ma) { this->area = ma; }
     double GetArea() { return this->area; }
 
@@ -79,7 +79,7 @@ class ChApi ChElementBar : public ChElementGeneric {
     void SetDensity(double md) { this->density = md; }
     double GetDensity() { return this->density; }
 
-    /// Set the Young elastic modulus (N/m^2) (also sets stiffness)
+    /// Set the Young elastic modulus (N/m^2)
     void SetYoungModulus(double mE) { this->E = mE; }
     double GetYoungModulus() { return this->E; }
 
@@ -111,7 +111,7 @@ class ChApi ChElementBar : public ChElementGeneric {
     //            (***not needed, thank to bookkeeping in parent class ChElementGeneric)
 
   private:
-    /// Initial setup. Precompute mass and matrices that do not change during the simulation, such as the local tangent
+    /// Initial setup. Precompute mass, rest length, axial stiffness and matrices that do not change during the simulation, such as the local tangent
     /// stiffness Kl of each element, if needed, etc.
     virtual void SetupInitial(ChSystem* system) override;
 
@@ -120,6 +120,7 @@ class ChApi ChElementBar : public ChElementGeneric {
     double density;
     double E;
     double rdamping;
+    double kstiff;
     double mass;
     double length;
 };

--- a/src/chrono/fea/ChElementBeamEuler.cpp
+++ b/src/chrono/fea/ChElementBeamEuler.cpp
@@ -115,8 +115,6 @@ void ChElementBeamEuler::UpdateRotation() {
 
         this->A.SetFromQuaternion(q_element_ref_rot_previous.GetConjugate() * q_element_abs_rot);
     }
-
-    this->A = A0.transpose() * Aabs;
 }
 
 void ChElementBeamEuler::GetStateBlock(ChVectorDynamic<>& mD) {

--- a/src/chrono/fea/ChElementBeamEuler.cpp
+++ b/src/chrono/fea/ChElementBeamEuler.cpp
@@ -97,24 +97,23 @@ void ChElementBeamEuler::Update() {
 }
 
 void ChElementBeamEuler::UpdateRotation() {
-    ChMatrix33<> A0(this->q_element_ref_rot);
+    if (!this->disable_corotate) {
+        ChMatrix33<> Aabs;
+        ChQuaternion<> q_element_ref_rot_previous(q_element_ref_rot);
 
-    ChMatrix33<> Aabs;
-    if (this->disable_corotate) {
-        Aabs = A0;
-        q_element_abs_rot = q_element_ref_rot;
-    } else {
         ChVector3d mXele_w = nodes[1]->Frame().GetPos() - nodes[0]->Frame().GetPos();
         // propose Y_w as absolute dir of the Y axis of A node, removing the effect of Aref-to-A rotation if any:
         //    Y_w = [R Aref->w ]*[R Aref->A ]'*{0,1,0}
-        ChVector3d myele_wA = nodes[0]->Frame().GetRot().Rotate(q_refrotA.RotateBack(ChVector3d(0, 1, 0)));
+        ChVector3d myele_wA = nodes[0]->Frame().GetRot().Rotate(q_refrotA.RotateBack(ChVector3d(0, 1, 0))); // TODO: q_refrotA.RotateBack(ChVector3d(0, 1, 0)) dodes not change through the sim and is expensive to compute: store it
         // propose Y_w as absolute dir of the Y axis of B node, removing the effect of Bref-to-B rotation if any:
         //    Y_w = [R Bref->w ]*[R Bref->B ]'*{0,1,0}
-        ChVector3d myele_wB = nodes[1]->Frame().GetRot().Rotate(q_refrotB.RotateBack(ChVector3d(0, 1, 0)));
+        ChVector3d myele_wB = nodes[1]->Frame().GetRot().Rotate(q_refrotB.RotateBack(ChVector3d(0, 1, 0))); // TODO: q_refrotB.RotateBack(ChVector3d(0, 1, 0)) dodes not change through the sim and is expensive to compute: store it
         // Average the two Y directions to have midpoint torsion (ex -30?torsion A and +30?torsion B= 0?
         ChVector3d myele_w = (myele_wA + myele_wB).GetNormalized();
         Aabs.SetFromAxisX(mXele_w, myele_w);
         q_element_abs_rot = Aabs.GetQuaternion();
+
+        this->A.SetFromQuaternion(q_element_ref_rot_previous.GetConjugate() * q_element_abs_rot);
     }
 
     this->A = A0.transpose() * Aabs;

--- a/src/chrono/fea/ChElementBeamEuler.cpp
+++ b/src/chrono/fea/ChElementBeamEuler.cpp
@@ -15,6 +15,10 @@
 // #define BEAM_VERBOSE
 
 #include <cmath>
+#include <memory>
+#include "chrono/core/ChQuaternion.h"
+#include "chrono/core/ChVector3.h"
+#include "chrono/fea/ChNodeFEAxyzrot.h"
 
 #include "chrono/fea/ChElementBeamEuler.h"
 
@@ -444,13 +448,8 @@ void ChElementBeamEuler::SetupInitial(ChSystem* system) {
     this->length = (nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos()).Length();
     this->mass = this->length * this->section->GetMassPerUnitLength();
 
-    // Compute initial rotation
-    ChMatrix33<> A0;
-    ChVector3d mXele = nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos();
-    ChVector3d myele =
-        (nodes[0]->GetX0().GetRotMat().GetAxisY() + nodes[1]->GetX0().GetRotMat().GetAxisY()).GetNormalized();
-    A0.SetFromAxisX(mXele, myele);
-    q_element_ref_rot = A0.GetQuaternion();
+    // Set initial rotation
+    q_element_abs_rot = q_element_ref_rot;
 
     // Compute local stiffness matrix:
     ComputeStiffnessMatrix();

--- a/src/chrono/fea/ChElementBeamEuler.h
+++ b/src/chrono/fea/ChElementBeamEuler.h
@@ -15,6 +15,7 @@
 #ifndef CHELEMENTBEAMEULER_H
 #define CHELEMENTBEAMEULER_H
 
+#include "chrono/core/ChQuaternion.h"
 #include "chrono/fea/ChBeamSectionEuler.h"
 #include "chrono/fea/ChElementBeam.h"
 #include "chrono/fea/ChElementCorotational.h"
@@ -83,6 +84,9 @@ class ChApi ChElementBeamEuler : public ChElementBeam,
     /// This is not the same of Rotation() , that expresses
     /// the accumulated rotation from starting point.
     ChQuaternion<> GetAbsoluteRotation() { return q_element_abs_rot; }
+
+    /// Set the original reference rotation of element in space
+    void SetRefRotation(ChQuaternion<> q_initial) { q_element_ref_rot = q_initial; }
 
     /// Get the original reference rotation of element in space
     ChQuaternion<> GetRefRotation() { return q_element_ref_rot; }

--- a/src/chrono/fea/ChElementBeamEuler.h
+++ b/src/chrono/fea/ChElementBeamEuler.h
@@ -72,13 +72,17 @@ class ChApi ChElementBeamEuler : public ChElementBeam,
     /// Get the second node (ending)
     std::shared_ptr<ChNodeFEAxyzrot> GetNodeB() { return nodes[1]; }
 
-    /// Set the reference rotation of nodeA respect to the element rotation.
-    void SetNodeAreferenceRot(ChQuaternion<> mrot) { q_refrotA = mrot; }
-    ChQuaternion<> GetNodeAreferenceRot() { return q_refrotA; }
+    /// Set the reference rotation of nodeA with respect to the element rotation.
+    void SetElemToNodeArefRot(ChQuaternion<> mrot) {
+      q_elemref_to_nodeAref_conj = mrot.GetConjugate();
+      yabs_in_elemref_to_nodeAref_frame = mrot.RotateBack(ChVector3d(0, 1, 0));
+    }
 
-    /// Set the reference rotation of nodeB respect to the element rotation.
-    void SetNodeBreferenceRot(ChQuaternion<> mrot) { q_refrotB = mrot; }
-    ChQuaternion<> GetNodeBreferenceRot() { return q_refrotB; }
+    /// Set the reference rotation of nodeB with respect to the element rotation.
+    void SetElemToNodeBrefRot(ChQuaternion<> mrot) {
+      q_elemref_to_nodeBref_conj = mrot.GetConjugate();
+      yabs_in_elemref_to_nodeBref_frame = mrot.RotateBack(ChVector3d(0, 1, 0));
+    }
 
     /// Get the absolute rotation of element in space
     /// This is not the same of Rotation() , that expresses
@@ -286,8 +290,10 @@ class ChApi ChElementBeamEuler : public ChElementBeam,
     ChMatrixDynamic<> Km;  ///< local material  stiffness matrix
     ChMatrixDynamic<> Kg;  ///< local geometric stiffness matrix NORMALIZED by P
 
-    ChQuaternion<> q_refrotA;
-    ChQuaternion<> q_refrotB;
+    ChQuaternion<> q_elemref_to_nodeAref_conj;
+    ChQuaternion<> q_elemref_to_nodeBref_conj;
+    ChVector3d yabs_in_elemref_to_nodeAref_frame;
+    ChVector3d yabs_in_elemref_to_nodeBref_frame;
 
     ChQuaternion<> q_element_abs_rot;
     ChQuaternion<> q_element_ref_rot;

--- a/src/chrono/fea/ChElementSpring.cpp
+++ b/src/chrono/fea/ChElementSpring.cpp
@@ -52,7 +52,7 @@ void ChElementSpring::ComputeKRMmatricesGlobal(ChMatrixRef H, double Kfactor, do
     ChVectorN<double, 3> dircolumn = dir.eigen();
 
     // note that stiffness and damping matrices are the same, so join stuff here
-    double commonfactor = this->spring_k * Kfactor + this->damper_r * Rfactor;
+    double commonfactor = this->spring_k * Kfactor + this->damper_r * Rfactor; // TODO: the damping part depends on velocity, is 1/dt passed to Rfactor ? Or should 1/dt be inside the damping matrix calculation here?
     ChMatrix33<> V = dircolumn * dircolumn.transpose();
     ChMatrix33<> keV = commonfactor * V;
 

--- a/src/chrono/fea/ChElementSpring.h
+++ b/src/chrono/fea/ChElementSpring.h
@@ -81,14 +81,15 @@ class ChApi ChElementSpring : public ChElementGeneric {
     //            (***not needed, thank to bookkeeping in parent class ChElementGeneric)
 
   private:
-    /// Initial setup.
+    /// Initial setup. Precompute rest length
     /// No override needed for the spring element because global K is computed on-the-fly in
     /// ComputeAddKRmatricesGlobal()
-    ////virtual void SetupInitial(ChSystem* system) override {}
+    virtual void SetupInitial(ChSystem* system) override;
 
     std::vector<std::shared_ptr<ChNodeFEAxyz> > nodes;
     double spring_k;
     double damper_r;
+    double length;
 };
 
 /// @} fea_elements


### PR DESCRIPTION
# This PR refactors the Spring, Bar, and some Beam elements.

This is ongoing work, we should decide when it is a good enough point to merge it

# Springs

### Modifications

- [X] precompute and store rest length as class attribute to avoid computation at each step (this length does not change during simulation)
- [X] refactor force calculation to limit number of length calculations and divisions

### possible issues / bugs to be discussed

- [ ] : the stiffness calculation for the damping does not take the timestep into account. if F = A * v, dF / dx = A / dt ?

# Bars

### Modifications

- [x] precompute and store axial stiffness k=EA/L to avoid computation at each step (this value does not change during simulation)
- [X] refactor force calculation to limit number of length calculations and divisions


### possible issues / bugs to be discussed

- [ ] : the stiffness calculation for the damping does not take the timestep into account. if F = A * v, dF / dx = A / dt ?


# Euler-Bernoulli beams

### Modifications

- [x] define the exact beam reference rotation using the end points and `YDir` vectors in the Builder, rather than using the average Y directions of the end nodes after the fact. This is more practical, but I also believe this was a bug since the average Y direction of the nodes after Gram-Schmidt has no guarantee to be colinear with user provided Y direction of the beams when the nodes pre-exist the beam.
- [x] Refactor the update rotation function: do nothing when corotation is disabled, replace rotation matrix operations with faster quaternion operations
- [x]  Do once and store expensive calculations of the rotation of nodes wrt reference configuration since these never change but were performed on it every step.
- [x] refactor GetStateBlock with lambdas to avoid code duplication
- [x] rename relative rotation quaternions for clarity.

