### PR TITLE
Implement Zombie Domains for FSI Simulations

### DIFF
--- a/src/chrono_fsi/sph/ChFluidSystemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFluidSystemSPH.cpp
@@ -163,6 +163,7 @@ void ChFluidSystemSPH::InitParams() {
     m_paramsH->Cs = 10 * m_paramsH->v_Max;
 
     m_paramsH->use_default_limits = true;
+    m_paramsH->match_zombie_periodic = true;
     m_paramsH->use_init_pressure = false;
 
     m_paramsH->num_proximity_search_steps = 4;

--- a/src/chrono_fsi/sph/ChFluidSystemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFluidSystemSPH.cpp
@@ -587,6 +587,11 @@ void ChFluidSystemSPH::SetBoundaries(const ChVector3d& cMin, const ChVector3d& c
     m_paramsH->use_default_limits = false;
 }
 
+void ChFluidSystemSPH::SetZombieDomain(const ChVector3d& zombieMin, const ChVector3d& zombieMax) {
+    m_paramsH->zombieMin = ToReal3(zombieMin);
+    m_paramsH->zombieMax = ToReal3(zombieMax);
+    m_paramsH->match_zombie_periodic = false;
+}
 void ChFluidSystemSPH::SetActiveDomain(const ChVector3d& boxHalfDim) {
     m_paramsH->bodyActiveDomain = ToReal3(boxHalfDim);
 }
@@ -1143,6 +1148,11 @@ void ChFluidSystemSPH::Initialize(unsigned int num_fsi_bodies,
             mR3(+2 * m_paramsH->boxDimX, +2 * m_paramsH->boxDimY, +2 * m_paramsH->boxDimZ) + 10 * mR3(m_paramsH->h);
     }
 
+    if (m_paramsH->match_zombie_periodic) {
+        m_paramsH->zombieMin = m_paramsH->cMin - make_Real3(1, 1, 1);
+        m_paramsH->zombieMax = m_paramsH->cMax + make_Real3(1, 1, 1);
+    }
+
     if (m_paramsH->use_init_pressure) {
         size_t numParticles = m_data_mgr->sphMarkers_H->rhoPresMuH.size();
         for (int i = 0; i < numParticles; i++) {
@@ -1176,6 +1186,10 @@ void ChFluidSystemSPH::Initialize(unsigned int num_fsi_bodies,
     m_paramsH->gridSize = SIDE;
     m_paramsH->worldOrigin = m_paramsH->cMin;
     m_paramsH->cellSize = mR3(mBinSize, mBinSize, mBinSize);
+
+    // Set up stuff for the zombie domain
+    m_paramsH->zombieBoxDims = m_paramsH->zombieMax - m_paramsH->zombieMin;
+    m_paramsH->zombieOrigin = m_paramsH->zombieMin;
 
     // Initialize the underlying FSU system: set reference arrays, set counters, and resize simulation arrays
     m_data_mgr->Initialize(num_fsi_bodies, num_fsi_nodes1D, num_fsi_elements1D, num_fsi_nodes2D, num_fsi_elements2D);

--- a/src/chrono_fsi/sph/ChFluidSystemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFluidSystemSPH.cpp
@@ -1186,6 +1186,14 @@ void ChFluidSystemSPH::Initialize(unsigned int num_fsi_bodies,
     m_paramsH->worldOrigin = m_paramsH->cMin;
     m_paramsH->cellSize = mR3(mBinSize, mBinSize, mBinSize);
 
+    // Precompute grid min and max bounds considering whether we have periodic boundaries or not
+    m_paramsH->minBounds = make_int3(m_paramsH->x_periodic ? INT_MIN : 0, m_paramsH->y_periodic ? INT_MIN : 0,
+                                     m_paramsH->z_periodic ? INT_MIN : 0);
+
+    m_paramsH->maxBounds = make_int3(m_paramsH->x_periodic ? INT_MAX : m_paramsH->gridSize.x - 1,
+                                     m_paramsH->y_periodic ? INT_MAX : m_paramsH->gridSize.y - 1,
+                                     m_paramsH->z_periodic ? INT_MAX : m_paramsH->gridSize.z - 1);
+
     // Initialize the underlying FSU system: set reference arrays, set counters, and resize simulation arrays
     m_data_mgr->Initialize(num_fsi_bodies, num_fsi_nodes1D, num_fsi_elements1D, num_fsi_nodes2D, num_fsi_elements2D);
 

--- a/src/chrono_fsi/sph/ChFluidSystemSPH.h
+++ b/src/chrono_fsi/sph/ChFluidSystemSPH.h
@@ -128,10 +128,7 @@ class CH_FSI_API ChFluidSystemSPH : public ChFluidSystem {
     void SetContainerDim(const ChVector3d& boxDim);
 
     /// Set periodic boundary condition for fluid.
-    void SetBoundaries(const ChVector3d& cMin, const ChVector3d& cMax);
-
-    /// Set zombie domain for fluid.
-    void SetZombieDomain(const ChVector3d& zombieMin, const ChVector3d& zombieMax);
+    void SetComputationalBoundaries(const ChVector3d& cMin, const ChVector3d& cMax, int sides);
 
     /// Set half-dimensions of the active domain.
     /// This value activates only those SPH particles that are within an AABB of the specified size from an object

--- a/src/chrono_fsi/sph/ChFluidSystemSPH.h
+++ b/src/chrono_fsi/sph/ChFluidSystemSPH.h
@@ -130,6 +130,9 @@ class CH_FSI_API ChFluidSystemSPH : public ChFluidSystem {
     /// Set periodic boundary condition for fluid.
     void SetBoundaries(const ChVector3d& cMin, const ChVector3d& cMax);
 
+    /// Set zombie domain for fluid.
+    void SetZombieDomain(const ChVector3d& zombieMin, const ChVector3d& zombieMax);
+
     /// Set half-dimensions of the active domain.
     /// This value activates only those SPH particles that are within an AABB of the specified size from an object
     /// interacting with the "fluid" phase. Note that this setting should *not* be used for actual (CFD) simulations,

--- a/src/chrono_fsi/sph/ChFsiDefinitionsSPH.h
+++ b/src/chrono_fsi/sph/ChFsiDefinitionsSPH.h
@@ -38,7 +38,7 @@ enum class SPHMethod {
 };
 
 /// Shifting Methods
-enum class ShiftingMethod { NONE, PPST, XSPH, PPST_XSPH, DIFFUSION, DIFFUSION_XSPH};
+enum class ShiftingMethod { NONE, PPST, XSPH, PPST_XSPH, DIFFUSION, DIFFUSION_XSPH };
 
 /// Equation of State type.
 /// see https://pysph.readthedocs.io/en/latest/reference/equations.html#basic-wcsph-equations
@@ -62,7 +62,18 @@ enum class FrictionLaw { CONSTANT, LINEAR, NONLINEAR };
 /// Linear solver type.
 enum class SolverType { JACOBI, BICGSTAB, GMRES, CR, CG, SAP };
 
-// -----------------------------------------------------------------------------
+/// -----------------------------------------------------------------------------
+/// Enumeration for specifying whether the sides of a computational domain are
+/// periodic or not. Sides can be combined using binary OR operations.
+namespace PeriodicSide {
+enum Enum {
+    NONE = 0x0000,
+    X = 1 << 0,   ///< X direction (both positive and negative) is periodic
+    Y = 1 << 1,   ///< Y direction (both positive and negative) is periodic
+    Z = 1 << 2,   ///< Z direction (both positive and negative) is periodic
+    ALL = 0xFFFF  ///< All directions (X, Y, Z) are periodic
+};
+}
 
 /// Enumeration for box sides.
 /// These flags are used to identify sides of a box container and can be combined using unary boolean operations.

--- a/src/chrono_fsi/sph/ChFsiProblemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFsiProblemSPH.cpp
@@ -300,20 +300,12 @@ void ChFsiProblemSPH::Initialize() {
     // Set computational domain
     if (!m_domain_aabb.IsInverted()) {
         // Use provided computational domain
-        m_sysSPH.SetBoundaries(m_domain_aabb.min, m_domain_aabb.max);
+        m_sysSPH.SetComputationalBoundaries(m_domain_aabb.min, m_domain_aabb.max, m_periodic_sides);
     } else {
         // Set computational domain based on actual AABB of all markers
         int bce_layers = m_sysSPH.GetNumBCELayers();
         m_domain_aabb = ChAABB(aabb.min - bce_layers * m_spacing, aabb.max + bce_layers * m_spacing);
-        m_sysSPH.SetBoundaries(m_domain_aabb.min, m_domain_aabb.max);
-    }
-
-    // Set the zombie domain if provided
-    if (!m_zombie_aabb.IsInverted()) {
-        m_sysSPH.SetZombieDomain(m_zombie_aabb.min, m_zombie_aabb.max);
-    } else {
-        // Set zombie domain to be 1 m bigger than the Periodic BC domain
-        m_sysSPH.SetZombieDomain(m_domain_aabb.min - ChVector3d(1, 1, 1), m_domain_aabb.max + ChVector3d(1, 1, 1));
+        m_sysSPH.SetComputationalBoundaries(m_domain_aabb.min, m_domain_aabb.max, static_cast<int>(PeriodicSide::NONE));
     }
 
     // Initialize the underlying FSI system
@@ -1043,9 +1035,8 @@ std::shared_ptr<ChBody> ChFsiProblemCartesian::ConstructWaveTank(
 
     if (end_wall) {
         ChVector3d size(thickness, width, height - Iz0 * m_spacing);
-        ChVector3d loc(box_size.x() / 2 + thickness / 2 + m_spacing, 0, Iz0 * m_spacing / 2 + box_size.z() / 2 + m_spacing);
-        auto shape = chrono_types::make_shared<ChVisualShapeBox>(size);
-        shape->SetColor(color);
+        ChVector3d loc(box_size.x() / 2 + thickness / 2 + m_spacing, 0, Iz0 * m_spacing / 2 + box_size.z() / 2 +
+    m_spacing); auto shape = chrono_types::make_shared<ChVisualShapeBox>(size); shape->SetColor(color);
         m_ground->AddVisualShape(shape, ChFramed(pos + loc, QUNIT));
     }
     */

--- a/src/chrono_fsi/sph/ChFsiProblemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFsiProblemSPH.cpp
@@ -308,6 +308,14 @@ void ChFsiProblemSPH::Initialize() {
         m_sysSPH.SetBoundaries(m_domain_aabb.min, m_domain_aabb.max);
     }
 
+    // Set the zombie domain if provided
+    if (!m_zombie_aabb.IsInverted()) {
+        m_sysSPH.SetZombieDomain(m_zombie_aabb.min, m_zombie_aabb.max);
+    } else {
+        // Set zombie domain to be 1 m bigger than the Periodic BC domain
+        m_sysSPH.SetZombieDomain(m_domain_aabb.min - ChVector3d(1, 1, 1), m_domain_aabb.max + ChVector3d(1, 1, 1));
+    }
+
     // Initialize the underlying FSI system
     m_sysFSI.Initialize();
     m_initialized = true;

--- a/src/chrono_fsi/sph/ChFsiProblemSPH.h
+++ b/src/chrono_fsi/sph/ChFsiProblemSPH.h
@@ -157,6 +157,12 @@ class CH_FSI_API ChFsiProblemSPH {
     /// By default, this is set so that it encompasses all SPH particles and BCE markers.
     void SetComputationalDomainSize(ChAABB aabb) { m_domain_aabb = aabb; }
 
+    /// Explicitly set the zombie domain limits.
+    /// By default this is the bigger than the periodic BC domain by 1 m on each side
+    /// TODO: Develop a way to combine both the periodic BC and the zombie domain
+    /// TODO: Think of a better default than just hardcoded 1 m on each side
+    void SetZombieDomainSize(ChAABB aabb) { m_zombie_aabb = aabb; }
+
     /// Complete construction of the FSI problem and initialize the FSI system.
     /// After this call, no additional solid bodies should be added to the FSI problem.
     void Initialize();
@@ -271,6 +277,7 @@ class CH_FSI_API ChFsiProblemSPH {
     ChVector3d m_offset_sph;           ///< SPH particles offset
     ChVector3d m_offset_bce;           ///< boundary BCE particles offset
     ChAABB m_domain_aabb;              ///< computational domain bounding box
+    ChAABB m_zombie_aabb;              ///< zombie domain bounding box
     ChAABB m_sph_aabb;                 ///< SPH volume bounding box
     std::vector<RigidBody> m_bodies;   ///< list of FSI rigid bodies
     std::vector<FeaMesh> m_meshes;     ///< list of FSI FEA meshes

--- a/src/chrono_fsi/sph/ChFsiProblemSPH.h
+++ b/src/chrono_fsi/sph/ChFsiProblemSPH.h
@@ -155,13 +155,10 @@ class CH_FSI_API ChFsiProblemSPH {
 
     /// Explicitly set the computational domain limits.
     /// By default, this is set so that it encompasses all SPH particles and BCE markers.
-    void SetComputationalDomainSize(ChAABB aabb) { m_domain_aabb = aabb; }
-
-    /// Explicitly set the zombie domain limits.
-    /// By default this is the bigger than the periodic BC domain by 1 m on each side
-    /// TODO: Develop a way to combine both the periodic BC and the zombie domain
-    /// TODO: Think of a better default than just hardcoded 1 m on each side
-    void SetZombieDomainSize(ChAABB aabb) { m_zombie_aabb = aabb; }
+    void SetComputationalDomain(ChAABB aabb, int periodic_sides) {
+        m_domain_aabb = aabb;
+        m_periodic_sides = periodic_sides;
+    }
 
     /// Complete construction of the FSI problem and initialize the FSI system.
     /// After this call, no additional solid bodies should be added to the FSI problem.
@@ -180,7 +177,10 @@ class CH_FSI_API ChFsiProblemSPH {
     size_t GetNumBoundaryBCEMarkers() const { return m_bce.size(); }
 
     /// Get limits of computational domain.
-    const ChAABB& GetComputationalDomainSize() const { return m_domain_aabb; }
+    const ChAABB& GetComputationalDomain() const { return m_domain_aabb; }
+
+    /// Get periodic sides of computational domain.
+    int GetPeriodicSides() const { return m_periodic_sides; }
 
     /// Get limits of SPH volume.
     const ChAABB& GetSPHBoundingBox() const { return m_sph_aabb; }
@@ -277,7 +277,7 @@ class CH_FSI_API ChFsiProblemSPH {
     ChVector3d m_offset_sph;           ///< SPH particles offset
     ChVector3d m_offset_bce;           ///< boundary BCE particles offset
     ChAABB m_domain_aabb;              ///< computational domain bounding box
-    ChAABB m_zombie_aabb;              ///< zombie domain bounding box
+    int m_periodic_sides;              ///< periodic sides
     ChAABB m_sph_aabb;                 ///< SPH volume bounding box
     std::vector<RigidBody> m_bodies;   ///< list of FSI rigid bodies
     std::vector<FeaMesh> m_meshes;     ///< list of FSI FEA meshes
@@ -421,9 +421,7 @@ class CH_FSI_API ChFsiProblemCylindrical : public ChFsiProblemSPH {
 /// Predefined SPH particle initial properties callback (depth-based pressure).
 class CH_FSI_API DepthPressurePropertiesCallback : public ChFsiProblemSPH::ParticlePropertiesCallback {
   public:
-    DepthPressurePropertiesCallback(double zero_height)
-        : ParticlePropertiesCallback(), zero_height(zero_height) {
-    }
+    DepthPressurePropertiesCallback(double zero_height) : ParticlePropertiesCallback(), zero_height(zero_height) {}
 
     virtual void set(const ChFluidSystemSPH& sysSPH, const ChVector3d& pos) override {
         double gz = std::abs(sysSPH.GetGravitationalAcceleration().z());

--- a/src/chrono_fsi/sph/physics/ChCollisionSystemFsi.cu
+++ b/src/chrono_fsi/sph/physics/ChCollisionSystemFsi.cu
@@ -197,8 +197,7 @@ __global__ void OriginalToSortedD(uint* mapOriginalToSorted, uint* gridMarkerInd
     mapOriginalToSorted[index] = id;
 }
 // ------------------------------------------------------------------------------
-ChCollisionSystemFsi::ChCollisionSystemFsi(FsiDataManager& data_mgr)
-    : m_data_mgr(data_mgr), m_sphMarkersD(nullptr) {}
+ChCollisionSystemFsi::ChCollisionSystemFsi(FsiDataManager& data_mgr) : m_data_mgr(data_mgr), m_sphMarkersD(nullptr) {}
 
 ChCollisionSystemFsi::~ChCollisionSystemFsi() {}
 // ------------------------------------------------------------------------------
@@ -228,10 +227,10 @@ void ChCollisionSystemFsi::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarker
     // copy the last element of prefixSumD to host and since we used exclusive scan, need to add the last flag
     uint lastPrefixVal = m_data_mgr.prefixSumExtendedActivityIdD[m_data_mgr.countersH->numAllMarkers - 1];
     uint32_t lastFlagInt32;
-    cudaMemcpy(
-        &lastFlagInt32,
-        thrust::raw_pointer_cast(&m_data_mgr.extendedActivityIdentifierOriginalD[m_data_mgr.countersH->numAllMarkers - 1]),
-        sizeof(uint32_t), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&lastFlagInt32,
+               thrust::raw_pointer_cast(
+                   &m_data_mgr.extendedActivityIdentifierOriginalD[m_data_mgr.countersH->numAllMarkers - 1]),
+               sizeof(uint32_t), cudaMemcpyDeviceToHost);
     uint lastFlag = (lastFlagInt32 > 0) ? 1 : 0;  // Convert to uint pr operly
 
     uint numExtended = lastPrefixVal + lastFlag;
@@ -302,18 +301,15 @@ void ChCollisionSystemFsi::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarker
         U1CAST(m_data_mgr.markersProximity_D->gridMarkerIndexD), mR4CAST(m_data_mgr.sortedSphMarkers2_D->posRadD),
         mR3CAST(m_data_mgr.sortedSphMarkers2_D->velMasD), mR4CAST(m_data_mgr.sortedSphMarkers2_D->rhoPresMuD),
         mR3CAST(m_data_mgr.sortedSphMarkers2_D->tauXxYyZzD), mR3CAST(m_data_mgr.sortedSphMarkers2_D->tauXyXzYzD),
-        UINT_32CAST(m_data_mgr.activityIdentifierSortedD),
-        mR4CAST(m_sphMarkersD->posRadD), mR3CAST(m_sphMarkersD->velMasD), mR4CAST(m_sphMarkersD->rhoPresMuD),
-        mR3CAST(m_sphMarkersD->tauXxYyZzD), mR3CAST(m_sphMarkersD->tauXyXzYzD), UINT_32CAST(m_data_mgr.activityIdentifierOriginalD),
-        numExtended);
+        UINT_32CAST(m_data_mgr.activityIdentifierSortedD), mR4CAST(m_sphMarkersD->posRadD),
+        mR3CAST(m_sphMarkersD->velMasD), mR4CAST(m_sphMarkersD->rhoPresMuD), mR3CAST(m_sphMarkersD->tauXxYyZzD),
+        mR3CAST(m_sphMarkersD->tauXyXzYzD), UINT_32CAST(m_data_mgr.activityIdentifierOriginalD), numExtended);
 
     cudaDeviceSynchronize();
     cudaCheckError();
 
-
     cudaFreeErrorFlag(error_flagD);
 }
-
 
 }  // namespace sph
 }  // end namespace fsi

--- a/src/chrono_fsi/sph/physics/ChCollisionSystemFsi.cu
+++ b/src/chrono_fsi/sph/physics/ChCollisionSystemFsi.cu
@@ -30,7 +30,7 @@ namespace sph {
 // The index's are the index of the original particle arrangement
 // After the active particles, random values that weere initialized are stored
 __global__ void fillActiveListD(const uint* __restrict__ prefixSum,
-                                const uint32_t* __restrict__ extendedActivityIdD,
+                                const int32_t* __restrict__ extendedActivityIdD,
                                 uint* __restrict__ activeListD,
                                 uint numAllMarkers) {
     uint tid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -142,13 +142,13 @@ __global__ void reorderDataD(const uint* __restrict__ gridMarkerIndexD,
                              Real4* __restrict__ sortedRhoPreMuD,
                              Real3* __restrict__ sortedTauXxYyZzD,
                              Real3* __restrict__ sortedTauXyXzYzD,
-                             uint32_t* __restrict__ activityIdentifierSortedD,
+                             int32_t* __restrict__ activityIdentifierSortedD,
                              const Real4* __restrict__ posRadD,
                              const Real3* __restrict__ velMasD,
                              const Real4* __restrict__ rhoPresMuD,
                              const Real3* __restrict__ tauXxYyZzD,
                              const Real3* __restrict__ tauXyXzYzD,
-                             const uint32_t* __restrict__ activityIdentifierOriginalD,
+                             const int32_t* __restrict__ activityIdentifierOriginalD,
                              const uint numActive) {
     uint tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid >= numActive)
@@ -160,7 +160,7 @@ __global__ void reorderDataD(const uint* __restrict__ gridMarkerIndexD,
     Real4 posRadVal = posRadD[originalIndex];
     Real3 velMasVal = velMasD[originalIndex];
     Real4 rhoPreMuVal = rhoPresMuD[originalIndex];
-    uint32_t activityIdentifierVal = activityIdentifierOriginalD[originalIndex];
+    int32_t activityIdentifierVal = activityIdentifierOriginalD[originalIndex];
 
     if (!IsFinite(mR3(posRadVal))) {
         printf("Error! reorderDataD_ActiveOnly: posRad is NAN at original index %u\n", originalIndex);
@@ -197,6 +197,16 @@ __global__ void OriginalToSortedD(uint* mapOriginalToSorted, uint* gridMarkerInd
     mapOriginalToSorted[index] = id;
 }
 // ------------------------------------------------------------------------------
+
+// Custom functor for exclusive scan that treats -1 (zombie particles) the same as 0 (sleep particles)
+struct ActivityScanOp {
+    __host__ __device__ int operator()(const int& a, const int& b) const {
+        // Treat -1 the same as 0 (only add positive values)
+        int b_value = (b <= 0) ? 0 : b;
+        return a + b_value;
+    }
+};
+
 ChCollisionSystemFsi::ChCollisionSystemFsi(FsiDataManager& data_mgr) : m_data_mgr(data_mgr), m_sphMarkersD(nullptr) {}
 
 ChCollisionSystemFsi::~ChCollisionSystemFsi() {}
@@ -219,19 +229,21 @@ void ChCollisionSystemFsi::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarker
     // Create active list where all active particles are at the front of the array
     //=========================================================================================================
 
-    // Exclusive scan for extended activity identifier
+    // Exclusive scan for extended activity identifier using custom functor to handle -1 values
     thrust::exclusive_scan(thrust::device, m_data_mgr.extendedActivityIdentifierOriginalD.begin(),
                            m_data_mgr.extendedActivityIdentifierOriginalD.end(),
-                           m_data_mgr.prefixSumExtendedActivityIdD.begin());
+                           m_data_mgr.prefixSumExtendedActivityIdD.begin(),
+                           0,  // Initial value
+                           ActivityScanOp());
 
     // copy the last element of prefixSumD to host and since we used exclusive scan, need to add the last flag
     uint lastPrefixVal = m_data_mgr.prefixSumExtendedActivityIdD[m_data_mgr.countersH->numAllMarkers - 1];
-    uint32_t lastFlagInt32;
+    int32_t lastFlagInt32;
     cudaMemcpy(&lastFlagInt32,
                thrust::raw_pointer_cast(
                    &m_data_mgr.extendedActivityIdentifierOriginalD[m_data_mgr.countersH->numAllMarkers - 1]),
-               sizeof(uint32_t), cudaMemcpyDeviceToHost);
-    uint lastFlag = (lastFlagInt32 > 0) ? 1 : 0;  // Convert to uint pr operly
+               sizeof(int32_t), cudaMemcpyDeviceToHost);
+    uint lastFlag = (lastFlagInt32 > 0) ? 1 : 0;  // Only count positive values
 
     uint numExtended = lastPrefixVal + lastFlag;
 
@@ -241,7 +253,7 @@ void ChCollisionSystemFsi::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarker
     computeGridSize((uint)m_data_mgr.countersH->numAllMarkers, 1024, numBlocks, numThreads);
 
     fillActiveListD<<<numBlocks, numThreads>>>(U1CAST(m_data_mgr.prefixSumExtendedActivityIdD),
-                                               UINT_32CAST(m_data_mgr.extendedActivityIdentifierOriginalD),
+                                               INT_32CAST(m_data_mgr.extendedActivityIdentifierOriginalD),
                                                U1CAST(m_data_mgr.activeListD), m_data_mgr.countersH->numAllMarkers);
     cudaDeviceSynchronize();
     cudaCheckErrorFlag(error_flagD, "fillActiveListD");
@@ -301,9 +313,9 @@ void ChCollisionSystemFsi::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarker
         U1CAST(m_data_mgr.markersProximity_D->gridMarkerIndexD), mR4CAST(m_data_mgr.sortedSphMarkers2_D->posRadD),
         mR3CAST(m_data_mgr.sortedSphMarkers2_D->velMasD), mR4CAST(m_data_mgr.sortedSphMarkers2_D->rhoPresMuD),
         mR3CAST(m_data_mgr.sortedSphMarkers2_D->tauXxYyZzD), mR3CAST(m_data_mgr.sortedSphMarkers2_D->tauXyXzYzD),
-        UINT_32CAST(m_data_mgr.activityIdentifierSortedD), mR4CAST(m_sphMarkersD->posRadD),
+        INT_32CAST(m_data_mgr.activityIdentifierSortedD), mR4CAST(m_sphMarkersD->posRadD),
         mR3CAST(m_sphMarkersD->velMasD), mR4CAST(m_sphMarkersD->rhoPresMuD), mR3CAST(m_sphMarkersD->tauXxYyZzD),
-        mR3CAST(m_sphMarkersD->tauXyXzYzD), UINT_32CAST(m_data_mgr.activityIdentifierOriginalD), numExtended);
+        mR3CAST(m_sphMarkersD->tauXyXzYzD), INT_32CAST(m_data_mgr.activityIdentifierOriginalD), numExtended);
 
     cudaDeviceSynchronize();
     cudaCheckError();

--- a/src/chrono_fsi/sph/physics/ChCollisionSystemFsi.cu
+++ b/src/chrono_fsi/sph/physics/ChCollisionSystemFsi.cu
@@ -237,7 +237,6 @@ void ChCollisionSystemFsi::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarker
     uint numExtended = lastPrefixVal + lastFlag;
 
     m_data_mgr.countersH->numExtendedParticles = numExtended;
-    std::cout << "numExtended: " << numExtended << std::endl;
 
     uint numThreads, numBlocks;
     computeGridSize((uint)m_data_mgr.countersH->numAllMarkers, 1024, numBlocks, numThreads);

--- a/src/chrono_fsi/sph/physics/ChFluidDynamics.cu
+++ b/src/chrono_fsi/sph/physics/ChFluidDynamics.cu
@@ -200,7 +200,7 @@ __global__ void UpdateFluidD(Real4* posRadD,
                              Real3* derivTauXyXzYzD,
                              Real4* sr_tau_I_mu_iD,
                              uint* freeSurfaceIdD,
-                             uint* activityIdentifierSortedD,
+                             uint32_t* activityIdentifierSortedD,
                              const uint numActive,
                              Real dT,
                              volatile bool* error_flag) {
@@ -415,8 +415,8 @@ __global__ void UpdateActivityD(const Real4* posRadD,
                                 const Real3* pos_bodies_D,
                                 const Real3* pos_nodes1D_D,
                                 const Real3* pos_nodes2D_D,
-                                uint* activityIdentifierD,
-                                uint* extendedActivityIdD,
+                                uint32_t* activityIdentifierD,
+                                uint32_t* extendedActivityIdD,
                                 const Real4* rhoPreMuD,
                                 volatile bool* error_flag) {
     uint index = blockIdx.x * blockDim.x + threadIdx.x;
@@ -436,7 +436,6 @@ __global__ void UpdateActivityD(const Real4* posRadD,
     // Check the activity of this particle
     uint isNotActive = 0;
     uint isNotExtended = 0;
-    // Real3 Acdomain = paramsD.bodyActiveDomain + mR3(2 * paramsD.h_multiplier * paramsD.h);
     Real3 Acdomain = paramsD.bodyActiveDomain;
     Real3 ExAcdomain = paramsD.bodyActiveDomain + mR3(2 * paramsD.h_multiplier * paramsD.h);
 
@@ -575,7 +574,7 @@ void ChFluidDynamics::UpdateActivity(std::shared_ptr<SphMarkerDataD> sphMarkersD
     UpdateActivityD<<<numBlocks, numThreads>>>(
         mR4CAST(sphMarkersD->posRadD), mR3CAST(sphMarkersD->velMasD), mR3CAST(m_data_mgr.fsiBodyState_D->pos),
         mR3CAST(m_data_mgr.fsiMesh1DState_D->pos_fsi_fea_D), mR3CAST(m_data_mgr.fsiMesh2DState_D->pos_fsi_fea_D),
-        U1CAST(m_data_mgr.activityIdentifierOriginalD), U1CAST(m_data_mgr.extendedActivityIdentifierOriginalD),
+        UINT_32CAST(m_data_mgr.activityIdentifierOriginalD), UINT_32CAST(m_data_mgr.extendedActivityIdentifierOriginalD),
         mR4CAST(sphMarkersD->rhoPresMuD), error_flagD);
     cudaCheckErrorFlag(error_flagD, "UpdateActivityD");
 
@@ -598,7 +597,7 @@ void ChFluidDynamics::UpdateFluid(std::shared_ptr<SphMarkerDataD> sortedSphMarke
         mR4CAST(sortedSphMarkersD->rhoPresMuD), mR3CAST(sortedSphMarkersD->tauXxYyZzD),
         mR3CAST(sortedSphMarkersD->tauXyXzYzD), mR3CAST(m_data_mgr.vel_XSPH_D), mR4CAST(m_data_mgr.derivVelRhoD),
         mR3CAST(m_data_mgr.derivTauXxYyZzD), mR3CAST(m_data_mgr.derivTauXyXzYzD), mR4CAST(m_data_mgr.sr_tau_I_mu_i),
-        U1CAST(m_data_mgr.freeSurfaceIdD), U1CAST(m_data_mgr.activityIdentifierSortedD), numActive, dT, error_flagD);
+        U1CAST(m_data_mgr.freeSurfaceIdD), UINT_32CAST(m_data_mgr.activityIdentifierSortedD), numActive, dT, error_flagD);
     cudaCheckErrorFlag(error_flagD, "UpdateFluidD");
 
     cudaFreeErrorFlag(error_flagD);

--- a/src/chrono_fsi/sph/physics/ChFluidDynamics.cu
+++ b/src/chrono_fsi/sph/physics/ChFluidDynamics.cu
@@ -438,6 +438,8 @@ __global__ void UpdateActivityD(const Real4* posRadD,
     uint isNotExtended = 0;
     Real3 Acdomain = paramsD.bodyActiveDomain;
     Real3 ExAcdomain = paramsD.bodyActiveDomain + mR3(2 * paramsD.h_multiplier * paramsD.h);
+    Real3 zombieBoxDims = paramsD.zombieBoxDims;
+    Real3 zombieOrigin = paramsD.zombieOrigin;
 
     Real3 posRadA = mR3(posRadD[index]);
 
@@ -473,6 +475,15 @@ __global__ void UpdateActivityD(const Real4* posRadD,
     if (isNotExtended == numTotal && numTotal > 0)
         extendedActivityIdD[index] = 0;
 
+    // Check if the particle is outside the zombie domain
+    if (posRadA.x < zombieOrigin.x || posRadA.x > zombieOrigin.x + zombieBoxDims.x ||
+        posRadA.y < zombieOrigin.y || posRadA.y > zombieOrigin.y + zombieBoxDims.y ||
+        posRadA.z < zombieOrigin.z || posRadA.z > zombieOrigin.z + zombieBoxDims.z) {
+        activityIdentifierD[index] = 0;
+        extendedActivityIdD[index] = 0;
+        velMasD[index] = mR3(0.0);
+    }
+    
     return;
 }
 

--- a/src/chrono_fsi/sph/physics/ChFluidDynamics.cu
+++ b/src/chrono_fsi/sph/physics/ChFluidDynamics.cu
@@ -476,9 +476,9 @@ __global__ void UpdateActivityD(const Real4* posRadD,
         extendedActivityIdD[index] = 0;
 
     // Check if the particle is outside the zombie domain
-    if (posRadA.x < zombieOrigin.x || posRadA.x > zombieOrigin.x + zombieBoxDims.x ||
+    if (IsFluidParticle(rhoPreMuD[index].w) && (posRadA.x < zombieOrigin.x || posRadA.x > zombieOrigin.x + zombieBoxDims.x ||
         posRadA.y < zombieOrigin.y || posRadA.y > zombieOrigin.y + zombieBoxDims.y ||
-        posRadA.z < zombieOrigin.z || posRadA.z > zombieOrigin.z + zombieBoxDims.z) {
+        posRadA.z < zombieOrigin.z || posRadA.z > zombieOrigin.z + zombieBoxDims.z)) {
         activityIdentifierD[index] = 0;
         extendedActivityIdD[index] = 0;
         velMasD[index] = mR3(0.0);

--- a/src/chrono_fsi/sph/physics/ChFluidDynamics.cu
+++ b/src/chrono_fsi/sph/physics/ChFluidDynamics.cu
@@ -210,7 +210,7 @@ __global__ void UpdateFluidD(Real4* posRadD,
     }
 
     // Only update active particles not extended active particles
-    if(activityIdentifierSortedD[index] == 0){
+    if (activityIdentifierSortedD[index] == 0) {
         return;
     }
 
@@ -438,8 +438,11 @@ __global__ void UpdateActivityD(const Real4* posRadD,
     uint isNotExtended = 0;
     Real3 Acdomain = paramsD.bodyActiveDomain;
     Real3 ExAcdomain = paramsD.bodyActiveDomain + mR3(2 * paramsD.h_multiplier * paramsD.h);
-    Real3 zombieBoxDims = paramsD.zombieBoxDims;
-    Real3 zombieOrigin = paramsD.zombieOrigin;
+    Real3 domainDims = paramsD.boxDims;
+    Real3 domainOrigin = paramsD.worldOrigin;
+    bool x_periodic = paramsD.x_periodic;
+    bool y_periodic = paramsD.y_periodic;
+    bool z_periodic = paramsD.z_periodic;
 
     Real3 posRadA = mR3(posRadD[index]);
 
@@ -476,14 +479,31 @@ __global__ void UpdateActivityD(const Real4* posRadD,
         extendedActivityIdD[index] = 0;
 
     // Check if the particle is outside the zombie domain
-    if (IsFluidParticle(rhoPreMuD[index].w) && (posRadA.x < zombieOrigin.x || posRadA.x > zombieOrigin.x + zombieBoxDims.x ||
-        posRadA.y < zombieOrigin.y || posRadA.y > zombieOrigin.y + zombieBoxDims.y ||
-        posRadA.z < zombieOrigin.z || posRadA.z > zombieOrigin.z + zombieBoxDims.z)) {
-        activityIdentifierD[index] = 0;
-        extendedActivityIdD[index] = 0;
-        velMasD[index] = mR3(0.0);
+    if (IsFluidParticle(rhoPreMuD[index].w)) {
+        bool outside_domain = false;
+
+        // Check X boundaries - only inactivate if not periodic
+        if (!x_periodic && (posRadA.x < domainOrigin.x || posRadA.x > domainOrigin.x + domainDims.x)) {
+            outside_domain = true;
+        }
+
+        // Check Y boundaries - only inactivate if not periodic
+        if (!y_periodic && (posRadA.y < domainOrigin.y || posRadA.y > domainOrigin.y + domainDims.y)) {
+            outside_domain = true;
+        }
+
+        // Check Z boundaries - only inactivate if not periodic
+        if (!z_periodic && (posRadA.z < domainOrigin.z || posRadA.z > domainOrigin.z + domainDims.z)) {
+            outside_domain = true;
+        }
+
+        if (outside_domain) {
+            activityIdentifierD[index] = 0;
+            extendedActivityIdD[index] = 0;
+            velMasD[index] = mR3(0.0);
+        }
     }
-    
+
     return;
 }
 
@@ -585,8 +605,8 @@ void ChFluidDynamics::UpdateActivity(std::shared_ptr<SphMarkerDataD> sphMarkersD
     UpdateActivityD<<<numBlocks, numThreads>>>(
         mR4CAST(sphMarkersD->posRadD), mR3CAST(sphMarkersD->velMasD), mR3CAST(m_data_mgr.fsiBodyState_D->pos),
         mR3CAST(m_data_mgr.fsiMesh1DState_D->pos_fsi_fea_D), mR3CAST(m_data_mgr.fsiMesh2DState_D->pos_fsi_fea_D),
-        UINT_32CAST(m_data_mgr.activityIdentifierOriginalD), UINT_32CAST(m_data_mgr.extendedActivityIdentifierOriginalD),
-        mR4CAST(sphMarkersD->rhoPresMuD), error_flagD);
+        UINT_32CAST(m_data_mgr.activityIdentifierOriginalD),
+        UINT_32CAST(m_data_mgr.extendedActivityIdentifierOriginalD), mR4CAST(sphMarkersD->rhoPresMuD), error_flagD);
     cudaCheckErrorFlag(error_flagD, "UpdateActivityD");
 
     cudaFreeErrorFlag(error_flagD);
@@ -608,7 +628,8 @@ void ChFluidDynamics::UpdateFluid(std::shared_ptr<SphMarkerDataD> sortedSphMarke
         mR4CAST(sortedSphMarkersD->rhoPresMuD), mR3CAST(sortedSphMarkersD->tauXxYyZzD),
         mR3CAST(sortedSphMarkersD->tauXyXzYzD), mR3CAST(m_data_mgr.vel_XSPH_D), mR4CAST(m_data_mgr.derivVelRhoD),
         mR3CAST(m_data_mgr.derivTauXxYyZzD), mR3CAST(m_data_mgr.derivTauXyXzYzD), mR4CAST(m_data_mgr.sr_tau_I_mu_i),
-        U1CAST(m_data_mgr.freeSurfaceIdD), UINT_32CAST(m_data_mgr.activityIdentifierSortedD), numActive, dT, error_flagD);
+        U1CAST(m_data_mgr.freeSurfaceIdD), UINT_32CAST(m_data_mgr.activityIdentifierSortedD), numActive, dT,
+        error_flagD);
     cudaCheckErrorFlag(error_flagD, "UpdateFluidD");
 
     cudaFreeErrorFlag(error_flagD);
@@ -647,20 +668,24 @@ void ChFluidDynamics::ApplyBoundarySPH_Markers(std::shared_ptr<SphMarkerDataD> s
     uint numBlocks, numThreads;
     uint numActive = m_data_mgr.countersH->numExtendedParticles;
     computeGridSize(numActive, 1024, numBlocks, numThreads);
-    ApplyPeriodicBoundaryXKernel<<<numBlocks, numThreads>>>(mR4CAST(sortedSphMarkersD->posRadD),
-                                                            mR4CAST(sortedSphMarkersD->rhoPresMuD), numActive);
-    cudaDeviceSynchronize();
-    cudaCheckError();
-
-    ApplyPeriodicBoundaryYKernel<<<numBlocks, numThreads>>>(mR4CAST(sortedSphMarkersD->posRadD),
-                                                            mR4CAST(sortedSphMarkersD->rhoPresMuD), numActive);
-    cudaDeviceSynchronize();
-    cudaCheckError();
-
-    ApplyPeriodicBoundaryZKernel<<<numBlocks, numThreads>>>(mR4CAST(sortedSphMarkersD->posRadD),
-                                                            mR4CAST(sortedSphMarkersD->rhoPresMuD), numActive);
-    cudaDeviceSynchronize();
-    cudaCheckError();
+    if (m_data_mgr.paramsH->x_periodic) {
+        ApplyPeriodicBoundaryXKernel<<<numBlocks, numThreads>>>(mR4CAST(sortedSphMarkersD->posRadD),
+                                                                mR4CAST(sortedSphMarkersD->rhoPresMuD), numActive);
+        cudaDeviceSynchronize();
+        cudaCheckError();
+    }
+    if (m_data_mgr.paramsH->y_periodic) {
+        ApplyPeriodicBoundaryYKernel<<<numBlocks, numThreads>>>(mR4CAST(sortedSphMarkersD->posRadD),
+                                                                mR4CAST(sortedSphMarkersD->rhoPresMuD), numActive);
+        cudaDeviceSynchronize();
+        cudaCheckError();
+    }
+    if (m_data_mgr.paramsH->z_periodic) {
+        ApplyPeriodicBoundaryZKernel<<<numBlocks, numThreads>>>(mR4CAST(sortedSphMarkersD->posRadD),
+                                                                mR4CAST(sortedSphMarkersD->rhoPresMuD), numActive);
+        cudaDeviceSynchronize();
+        cudaCheckError();
+    }
 }
 
 // -----------------------------------------------------------------------------

--- a/src/chrono_fsi/sph/physics/ChParams.h
+++ b/src/chrono_fsi/sph/physics/ChParams.h
@@ -181,8 +181,11 @@ struct SimParams {
     bool y_periodic;
     bool z_periodic;
 
-    Real3 cMin;  ///< Lower limit point
-    Real3 cMax;  ///< Upper limit point
+    int3 minBounds;  ///< Lower limit point of the grid (in grid index)
+    int3 maxBounds;  ///< Upper limit point of the grid (in grid index)
+
+    Real3 cMin;  ///< Lower limit point (in world coordinates)
+    Real3 cMax;  ///< Upper limit point (in world coordinates)
 
     Real3 zombieMin;  ///< Lower limit point of the zombie domain -> All particles outside this will be frozen
     Real3 zombieMax;  ///< Upper limit point of the zombie domain -> All particles outside this will be frozen

--- a/src/chrono_fsi/sph/physics/ChParams.h
+++ b/src/chrono_fsi/sph/physics/ChParams.h
@@ -53,6 +53,8 @@ struct SimParams {
     Real3 cellSize;         ///< Cell size for the neighbor particle search
     uint numBodies;         ///< Number of FSI bodies.
     Real3 boxDims;          ///< Dimensions (AABB) of the domain
+    Real3 zombieBoxDims;    ///< Dimensions (AABB) of the zombie domain
+    Real3 zombieOrigin;     ///< Origin point of the zombie domain
     Real d0;                ///< Initial separation of SPH particles
     Real ood0;              ///< 1 / d0
     Real d0_multiplier;     ///< Multiplier to obtain the interaction length, h = d0_multiplier * d0
@@ -99,6 +101,7 @@ struct SimParams {
     Real gammaBB;  ///< Equation of state parameter
 
     bool use_default_limits;  ///< true if cMin and cMax are not user-provided (default: true)
+    bool match_zombie_periodic;  ///< true if zombie domain is not user-provided (default: true)
     bool use_init_pressure;   ///< true if pressure set based on height (default: false)
 
     Real3 cMinInit;  ///< Minimum point of the fluid domain.
@@ -174,6 +177,9 @@ struct SimParams {
 
     Real3 cMin;  ///< Lower limit point
     Real3 cMax;  ///< Upper limit point
+
+    Real3 zombieMin;  ///< Lower limit point of the zombie domain -> All particles outside this will be frozen
+    Real3 zombieMax;  ///< Upper limit point of the zombie domain -> All particles outside this will be frozen
 
     Real3 bodyActiveDomain;  ///< Size of the active domain that influenced by an FSI body
     Real settlingTime;       ///< Time for the granular to settle down

--- a/src/chrono_fsi/sph/physics/ChParams.h
+++ b/src/chrono_fsi/sph/physics/ChParams.h
@@ -100,8 +100,9 @@ struct SimParams {
     Real kdT;      ///< Implicit integration parameter
     Real gammaBB;  ///< Equation of state parameter
 
+    int periodic_sides;  ///< Periodic boundary condition sides for the defined computational domain - Takes values
+                         ///< NONE, X, Y, Z, All (can also be combined using binary OR and bitwise AND). (default: NONE)
     bool use_default_limits;  ///< true if cMin and cMax are not user-provided (default: true)
-    bool match_zombie_periodic;  ///< true if zombie domain is not user-provided (default: true)
     bool use_init_pressure;   ///< true if pressure set based on height (default: false)
 
     Real3 cMinInit;  ///< Minimum point of the fluid domain.
@@ -166,7 +167,7 @@ struct SimParams {
     Real G_shear;       ///< Shear modulus
     Real INV_G_shear;   ///< 1.0 / G_shear
     Real K_bulk;        ///< Bulk modulus
-    Real Nu_poisson;    ///< Poisson’s ratio
+    Real Nu_poisson;    ///< Poisson's ratio
     Real Ar_vis_alpha;  ///< Artifical viscosity coefficient
     Real Coh_coeff;     ///< Cohesion coefficient
     Real C_Wi;          ///< Threshold of the integration of the kernel function
@@ -174,6 +175,11 @@ struct SimParams {
     Real boxDimX;  ///< Dimension of the space domain - X
     Real boxDimY;  ///< Dimension of the space domain - Y
     Real boxDimZ;  ///< Dimension of the space domain - Z
+
+    // Bools for whether a side is a periodic side or not
+    bool x_periodic;
+    bool y_periodic;
+    bool z_periodic;
 
     Real3 cMin;  ///< Lower limit point
     Real3 cMax;  ///< Upper limit point

--- a/src/chrono_fsi/sph/physics/ChSphGeneral.cu
+++ b/src/chrono_fsi/sph/physics/ChSphGeneral.cu
@@ -716,6 +716,12 @@ __global__ void neighborSearchNum(const Real4* sortedPosRad,
         for (int y = -1; y <= 1; y++) {
             for (int z = -1; z <= 1; z++) {
                 int3 neighborPos = gridPos + mI3(x, y, z);
+                // Check if we need to skip this neighbor position (out of bounds for non-periodic dimensions)
+                if (neighborPos.x < paramsD.minBounds.x || neighborPos.x > paramsD.maxBounds.x ||
+                    neighborPos.y < paramsD.minBounds.y || neighborPos.y > paramsD.maxBounds.y ||
+                    neighborPos.z < paramsD.minBounds.z || neighborPos.z > paramsD.maxBounds.z) {
+                    continue;
+                }
                 uint gridHash = calcGridHash(neighborPos);
                 uint startIndex = cellStart[gridHash];
                 uint endIndex = cellEnd[gridHash];
@@ -756,6 +762,12 @@ __global__ void neighborSearchID(const Real4* sortedPosRad,
         for (int y = -1; y <= 1; y++) {
             for (int z = -1; z <= 1; z++) {
                 int3 neighborPos = gridPos + mI3(x, y, z);
+                // Check if we need to skip this neighbor position (out of bounds for non-periodic dimensions)
+                if (neighborPos.x < paramsD.minBounds.x || neighborPos.x > paramsD.maxBounds.x ||
+                    neighborPos.y < paramsD.minBounds.y || neighborPos.y > paramsD.maxBounds.y ||
+                    neighborPos.z < paramsD.minBounds.z || neighborPos.z > paramsD.maxBounds.z) {
+                    continue;
+                }
                 uint gridHash = calcGridHash(neighborPos);
                 uint startIndex = cellStart[gridHash];
                 uint endIndex = cellEnd[gridHash];

--- a/src/chrono_fsi/sph/physics/ChSphGeneral.cuh
+++ b/src/chrono_fsi/sph/physics/ChSphGeneral.cuh
@@ -310,13 +310,13 @@ __device__ inline int3 calcGridPos(Real3 p) {
 }
 //--------------------------------------------------------------------------------------------------------------------------------
 __device__ inline uint calcGridHash(int3 gridPos) {
-    gridPos.x -= ((gridPos.x >= paramsD.gridSize.x) ? paramsD.gridSize.x : 0);
-    gridPos.y -= ((gridPos.y >= paramsD.gridSize.y) ? paramsD.gridSize.y : 0);
-    gridPos.z -= ((gridPos.z >= paramsD.gridSize.z) ? paramsD.gridSize.z : 0);
+    gridPos.x -= ((gridPos.x >= paramsD.gridSize.x && paramsD.x_periodic) ? paramsD.gridSize.x : 0);
+    gridPos.y -= ((gridPos.y >= paramsD.gridSize.y && paramsD.y_periodic) ? paramsD.gridSize.y : 0);
+    gridPos.z -= ((gridPos.z >= paramsD.gridSize.z && paramsD.z_periodic) ? paramsD.gridSize.z : 0);
 
-    gridPos.x += ((gridPos.x < 0) ? paramsD.gridSize.x : 0);
-    gridPos.y += ((gridPos.y < 0) ? paramsD.gridSize.y : 0);
-    gridPos.z += ((gridPos.z < 0) ? paramsD.gridSize.z : 0);
+    gridPos.x += ((gridPos.x < 0 && paramsD.x_periodic) ? paramsD.gridSize.x : 0);
+    gridPos.y += ((gridPos.y < 0 && paramsD.y_periodic) ? paramsD.gridSize.y : 0);
+    gridPos.z += ((gridPos.z < 0 && paramsD.z_periodic) ? paramsD.gridSize.z : 0);
 
     return gridPos.z * paramsD.gridSize.y * paramsD.gridSize.x + gridPos.y * paramsD.gridSize.x + gridPos.x;
 }

--- a/src/chrono_fsi/sph/physics/FsiDataManager.cuh
+++ b/src/chrono_fsi/sph/physics/FsiDataManager.cuh
@@ -319,11 +319,11 @@ class FsiDataManager {
         sr_tau_I_mu_i_Original;  ///< I2SPH strain-rate, stress, inertia number, friction - unsorted for writing
     thrust::device_vector<Real3> bceAcc;  ///< Acceleration for boundary/rigid/flex body particles
 
-    thrust::device_vector<uint>
+    thrust::device_vector<uint32_t>
         activityIdentifierOriginalD;  ///< Identifies if a particle is an active particle or not - unsorted
-    thrust::device_vector<uint>
+    thrust::device_vector<uint32_t>
         activityIdentifierSortedD;  ///< Identifies if a particle is an active particle or not - sorted
-    thrust::device_vector<uint>
+    thrust::device_vector<uint32_t>
         extendedActivityIdentifierOriginalD;  ///< Identifies if a particle is an active particle or not - unsorted
     thrust::device_vector<uint> prefixSumExtendedActivityIdD;  ///< Prefix sum of extended particles
     thrust::device_vector<uint> activeListD;         ///< Active list of particles

--- a/src/chrono_fsi/sph/physics/FsiDataManager.cuh
+++ b/src/chrono_fsi/sph/physics/FsiDataManager.cuh
@@ -199,10 +199,10 @@ struct Counters {
     size_t numBceMarkers;       ///< total number of BCE markers
     size_t numAllMarkers;       ///< total number of particles in the simulation
 
-    size_t startRigidMarkers;   ///< index of first BCE marker on first rigid body
-    size_t startFlexMarkers1D;  ///< index of first BCE marker on first flex segment
-    size_t startFlexMarkers2D;  ///< index of first BCE marker on first flex face
-    size_t numActiveParticles;  ///< number of active particles
+    size_t startRigidMarkers;     ///< index of first BCE marker on first rigid body
+    size_t startFlexMarkers1D;    ///< index of first BCE marker on first flex segment
+    size_t startFlexMarkers2D;    ///< index of first BCE marker on first flex face
+    size_t numActiveParticles;    ///< number of active particles
     size_t numExtendedParticles;  ///< number of extended particles
 };
 
@@ -319,14 +319,14 @@ class FsiDataManager {
         sr_tau_I_mu_i_Original;  ///< I2SPH strain-rate, stress, inertia number, friction - unsorted for writing
     thrust::device_vector<Real3> bceAcc;  ///< Acceleration for boundary/rigid/flex body particles
 
-    thrust::device_vector<uint32_t>
+    thrust::device_vector<int32_t>
         activityIdentifierOriginalD;  ///< Identifies if a particle is an active particle or not - unsorted
-    thrust::device_vector<uint32_t>
+    thrust::device_vector<int32_t>
         activityIdentifierSortedD;  ///< Identifies if a particle is an active particle or not - sorted
-    thrust::device_vector<uint32_t>
+    thrust::device_vector<int32_t>
         extendedActivityIdentifierOriginalD;  ///< Identifies if a particle is an active particle or not - unsorted
     thrust::device_vector<uint> prefixSumExtendedActivityIdD;  ///< Prefix sum of extended particles
-    thrust::device_vector<uint> activeListD;         ///< Active list of particles
+    thrust::device_vector<uint> activeListD;                   ///< Active list of particles
     thrust::device_vector<uint>
         numNeighborsPerPart;                   ///< Stores the number of neighbors the particle, given by the index, has
     thrust::device_vector<uint> neighborList;  ///< Stores the neighbor list - all neighbors are just stored one by one

--- a/src/chrono_fsi/sph/utils/ChUtilsDevice.cuh
+++ b/src/chrono_fsi/sph/utils/ChUtilsDevice.cuh
@@ -59,6 +59,8 @@ typedef unsigned int uint;
 #define I1CAST(x) (int*)thrust::raw_pointer_cast(&x[0])
 // This is not 32 uints but rather a single uint32_t
 #define UINT_32CAST(x) (uint32_t*)thrust::raw_pointer_cast(&x[0])
+// This is not 32 ints but rather a single int32_t
+#define INT_32CAST(x) (int32_t*)thrust::raw_pointer_cast(&x[0])
 #define mI2CAST(x) (int2*)thrust::raw_pointer_cast(&x[0])
 #define mI4CAST(x) (int4*)thrust::raw_pointer_cast(&x[0])
 #define U1CAST(x) (uint*)thrust::raw_pointer_cast(&x[0])
@@ -101,11 +103,15 @@ typedef unsigned int uint;
 
 // ----------------------------------------------------------------------------
 
-#define cudaMallocErrorFlag(error_flag_D) \
-    { cudaMalloc((void**)&error_flag_D, sizeof(bool)); }
+#define cudaMallocErrorFlag(error_flag_D)                \
+    {                                                    \
+        cudaMalloc((void**)&error_flag_D, sizeof(bool)); \
+    }
 
 #define cudaFreeErrorFlag(error_flag_D) \
-    { cudaFree(error_flag_D); }
+    {                                   \
+        cudaFree(error_flag_D);         \
+    }
 
 #define cudaResetErrorFlag(error_flag_D)                                               \
     {                                                                                  \

--- a/src/chrono_fsi/sph/utils/ChUtilsDevice.cuh
+++ b/src/chrono_fsi/sph/utils/ChUtilsDevice.cuh
@@ -57,6 +57,8 @@ typedef unsigned int uint;
 #define BCAST(x) (bool*)thrust::raw_pointer_cast(&x[0])
 
 #define I1CAST(x) (int*)thrust::raw_pointer_cast(&x[0])
+// This is not 32 uints but rather a single uint32_t
+#define UINT_32CAST(x) (uint32_t*)thrust::raw_pointer_cast(&x[0])
 #define mI2CAST(x) (int2*)thrust::raw_pointer_cast(&x[0])
 #define mI4CAST(x) (int4*)thrust::raw_pointer_cast(&x[0])
 #define U1CAST(x) (uint*)thrust::raw_pointer_cast(&x[0])

--- a/src/demos/fsi/demo_FSI_AngleRepose.cpp
+++ b/src/demos/fsi/demo_FSI_AngleRepose.cpp
@@ -146,11 +146,10 @@ int main(int argc, char* argv[]) {
 
     // Set the periodic boundary condition
     auto initSpace0 = sysSPH.GetInitialSpacing();
-    ChVector3d cMin(-bxDim / 2 - 10.0 * initSpace0 / 2.0, -byDim / 2 - 1.0 * initSpace0 / 2.0,
-                    -1.0 * bzDim - 5 * initSpace0);
-    ChVector3d cMax(bxDim / 2 + 10.0 * initSpace0 / 2.0, byDim / 2 + 1.0 * initSpace0 / 2.0,
-                    2.0 * bzDim + 5 * initSpace0);
-    sysSPH.SetBoundaries(cMin, cMax);
+    ChVector3d cMin(-bxDim / 2 - 3 * initSpace0 / 2.0, -byDim / 2 - 3 * initSpace0 / 2.0,
+                    -1.0 * bzDim - 3 * initSpace0);
+    ChVector3d cMax(bxDim / 2 + 3 * initSpace0 / 2.0, byDim / 2 + 3 * initSpace0 / 2.0, 2.0 * bzDim + 3 * initSpace0);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::NONE);
     sysSPH.SetOutputLevel(OutputLevel::CRM_FULL);
 
     // Create SPH particle locations using a sampler

--- a/src/demos/fsi/demo_FSI_BaffleFlow.cpp
+++ b/src/demos/fsi/demo_FSI_BaffleFlow.cpp
@@ -270,7 +270,7 @@ int main(int argc, char* argv[]) {
     CreateBaffles(fsi);
 
     // Enable depth-based initial pressure for SPH particles
-    ChVector3d v0(4, 0, 0);
+    ChVector3d v0(1, 0, 0);
     fsi.RegisterParticlePropertiesCallback(chrono_types::make_shared<SPHPropertiesCallback>(fsize.z(), v0));
 
     // Create SPH material (do not create boundary BCEs)
@@ -288,8 +288,7 @@ int main(int argc, char* argv[]) {
     // Explicitly set computational domain (necessary if no side walls)
     ChAABB aabb(ChVector3d(-csize.x() / 2, -csize.y() / 2, -0.1),
                 ChVector3d(+csize.x() / 2, +csize.y() / 2, +0.1 + csize.z()));
-    fsi.SetComputationalDomainSize(aabb);
-    fsi.SetZombieDomainSize(aabb);
+    fsi.SetComputationalDomain(aabb, PeriodicSide::NONE);
 
     if (show_rigid) {
         ChVector3d ground_box_size(csize.x(), csize.y(), 0.02);

--- a/src/demos/fsi/demo_FSI_BaffleFlow.cpp
+++ b/src/demos/fsi/demo_FSI_BaffleFlow.cpp
@@ -270,7 +270,7 @@ int main(int argc, char* argv[]) {
     CreateBaffles(fsi);
 
     // Enable depth-based initial pressure for SPH particles
-    ChVector3d v0(1.5, 0, 0);
+    ChVector3d v0(4, 0, 0);
     fsi.RegisterParticlePropertiesCallback(chrono_types::make_shared<SPHPropertiesCallback>(fsize.z(), v0));
 
     // Create SPH material (do not create boundary BCEs)
@@ -289,6 +289,7 @@ int main(int argc, char* argv[]) {
     ChAABB aabb(ChVector3d(-csize.x() / 2, -csize.y() / 2, -0.1),
                 ChVector3d(+csize.x() / 2, +csize.y() / 2, +0.1 + csize.z()));
     fsi.SetComputationalDomainSize(aabb);
+    fsi.SetZombieDomainSize(aabb);
 
     if (show_rigid) {
         ChVector3d ground_box_size(csize.x(), csize.y(), 0.02);

--- a/src/demos/fsi/demo_FSI_Compressibility.cpp
+++ b/src/demos/fsi/demo_FSI_Compressibility.cpp
@@ -107,7 +107,7 @@ int main(int argc, char* argv[]) {
     auto initSpace0 = sysSPH.GetInitialSpacing();
     ChVector3d cMin = ChVector3d(-bxDim / 2, -byDim / 2, -bzDim / 2) - ChVector3d(initSpace0 * 20);
     ChVector3d cMax = ChVector3d(bxDim / 2, byDim / 2, bzDim) + ChVector3d(initSpace0 * 10);
-    sysSPH.SetBoundaries(cMin, cMax);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::ALL);
 
     // Create an initial box for the terrain patch
     chrono::utils::ChGridSampler<> sampler(initSpace0);

--- a/src/demos/fsi/demo_FSI_CouetteFlow.cpp
+++ b/src/demos/fsi/demo_FSI_CouetteFlow.cpp
@@ -168,7 +168,7 @@ int main(int argc, char* argv[]) {
     sysSPH.SetContainerDim(ChVector3<>(bxDim, byDim, bzDim));
     ChVector3<> cMin(-bxDim / 2 * 1.2, -byDim * 1.2, -bzDim / 2 * 1.2);
     ChVector3<> cMax(bxDim / 2 * 1.2, byDim * 1.2, bzDim / 2 * 1.2);
-    sysSPH.SetBoundaries(cMin, cMax);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::ALL);
 
     bool use_polar_coords = true;
 

--- a/src/demos/fsi/demo_FSI_Cratering.cpp
+++ b/src/demos/fsi/demo_FSI_Cratering.cpp
@@ -180,10 +180,11 @@ int main(int argc, char* argv[]) {
     double bzDim = fzDim;
 
     // Set the periodic boundary condition
-    ChVector3d cMin(-bxDim / 2 * 1.2, -byDim / 2 * 1.2, -bzDim * 1.2);
+    ChVector3d cMin(-bxDim / 2 - 3 * init_spacing, -byDim / 2 - 3 * init_spacing, -bzDim * 1.2);
     ////ChVector3d cMax(bxDim / 2 * 1.2, byDim / 2 * 1.2, (bzDim + Hdrop + sphere_radius + init_spacing) * 1.2);
-    ChVector3d cMax(bxDim / 2 * 1.2, byDim / 2 * 1.2, (bzDim + sphere_radius + init_spacing) * 1.2);
-    sysSPH.SetBoundaries(cMin, cMax);
+    ChVector3d cMax(bxDim / 2 + 3 * init_spacing, byDim / 2 + 3 * init_spacing,
+                    (bzDim + sphere_radius + init_spacing) * 1.2);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::NONE);
 
     // Create SPH particle locations using a regular grid sampler
     chrono::utils::ChGridSampler<> sampler(init_spacing);

--- a/src/demos/fsi/demo_FSI_DamBreak.cpp
+++ b/src/demos/fsi/demo_FSI_DamBreak.cpp
@@ -140,7 +140,7 @@ int main(int argc, char* argv[]) {
     auto initSpace0 = sysSPH.GetInitialSpacing();
     ChVector3d cMin = ChVector3d(-bxDim / 2 - 10.0 * initSpace0, -byDim / 2 - 1.0 * initSpace0 / 2.0, -2.0 * bzDim);
     ChVector3d cMax = ChVector3d(bxDim / 2 + 10.0 * initSpace0, byDim / 2 + 1.0 * initSpace0 / 2.0, 2.0 * bzDim);
-    sysSPH.SetBoundaries(cMin, cMax);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::Y);
 
     // Create Fluid region and discretize with SPH particles
     ChVector3d boxCenter(-bxDim / 2 + fxDim / 2, 0.0, fzDim / 2);

--- a/src/demos/fsi/demo_FSI_Flexible_Cable.cpp
+++ b/src/demos/fsi/demo_FSI_Flexible_Cable.cpp
@@ -252,7 +252,7 @@ int main(int argc, char* argv[]) {
     // Explicitly set computational domain (necessary if no side walls)
     ChVector3d cMin = ChVector3d(-5 * cxDim, -cyDim / 2 - initial_spacing / 2, -5 * czDim);
     ChVector3d cMax = ChVector3d(+5 * cxDim, +cyDim / 2 + initial_spacing / 2, +5 * czDim);
-    fsi.SetComputationalDomainSize(ChAABB(cMin, cMax));
+    fsi.SetComputationalDomain(ChAABB(cMin, cMax), PeriodicSide::Y);
 
     // Initialize FSI problem
     fsi.Initialize();

--- a/src/demos/fsi/demo_FSI_Flexible_Plate.cpp
+++ b/src/demos/fsi/demo_FSI_Flexible_Plate.cpp
@@ -240,7 +240,7 @@ int main(int argc, char* argv[]) {
 
     ChVector3d cMin = ChVector3d(-5 * cxDim, -cyDim / 2 - initial_spacing / 2, -5 * czDim);
     ChVector3d cMax = ChVector3d(+5 * cxDim, +cyDim / 2 + initial_spacing / 2, +5 * czDim);
-    fsi.SetComputationalDomainSize(ChAABB(cMin, cMax));
+    fsi.SetComputationalDomain(ChAABB(cMin, cMax), PeriodicSide::Y);
 
     // Initialize FSI problem
     fsi.Initialize();

--- a/src/demos/fsi/demo_FSI_Flexible_Toroidal_Tire.cpp
+++ b/src/demos/fsi/demo_FSI_Flexible_Toroidal_Tire.cpp
@@ -134,7 +134,7 @@ int main(int argc, char* argv[]) {
     auto initSpace0 = sysSPH.GetInitialSpacing();
     ChVector3d cMin = ChVector3d(-5 * bxDim, -byDim / 2.0 - initSpace0 / 2.0, -5 * bzDim);
     ChVector3d cMax = ChVector3d(5 * bxDim, byDim / 2.0 + initSpace0 / 2.0, 10 * bzDim);
-    sysSPH.SetBoundaries(cMin, cMax);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::NONE);
 
     // Set SPH discretization type, consistent or inconsistent
     sysSPH.SetConsistentDerivativeDiscretization(false, false);

--- a/src/demos/fsi/demo_FSI_ObjectDrop.cpp
+++ b/src/demos/fsi/demo_FSI_ObjectDrop.cpp
@@ -63,8 +63,8 @@ ObjectType object_type = ObjectType::CYLINDER;
 double density = 500;
 
 // Object initial height above floor (as a ratio of fluid height)
-double initial_height = 1.05;
-
+double initial_height = 2.00;
+double hdrop = 2;
 // Visibility flags
 bool show_rigid = true;
 bool show_rigid_bce = false;
@@ -229,7 +229,7 @@ int main(int argc, char* argv[]) {
     body->SetName("object");
     body->SetFixed(false);
     body->EnableCollision(false);
-
+    double impact_vel = std::sqrt(2 * hdrop * -gravity.z());
     switch (object_type) {
         case ObjectType::SPHERE: {
             double radius = 0.12;
@@ -237,6 +237,7 @@ int main(int argc, char* argv[]) {
             auto inertia = mass * ChSphere::GetGyration(radius);
 
             body->SetPos(ChVector3d(0, 0, initial_height * fsize.z() + radius));
+            body->SetPosDt(ChVector3d(0, 0, -impact_vel));
             body->SetRot(QUNIT);
             body->SetMass(mass);
             body->SetInertia(inertia);
@@ -253,6 +254,7 @@ int main(int argc, char* argv[]) {
             auto inertia = mass * ChCylinder::GetGyration(radius, length / 2);
 
             body->SetPos(ChVector3d(0, 0, initial_height * fsize.z() + radius));
+            body->SetPosDt(ChVector3d(0, 0, -impact_vel));
             body->SetRot(QUNIT);
             body->SetMass(mass);
             body->SetInertia(inertia);
@@ -278,6 +280,10 @@ int main(int argc, char* argv[]) {
                   ChVector3d(0, 0, 0),            // position of bottom origin
                   BoxSide::ALL & ~BoxSide::Z_POS  // all boundaries except top
     );
+
+    ChVector3d cMin(-csize.x() / 2 - 3 * initial_spacing, -csize.y() / 2 - 3 * initial_spacing, -0.1);
+    ChVector3d cMax(csize.x() / 2 + 3 * initial_spacing, csize.y() / 2 + 3 * initial_spacing, csize.z() + 2.0);
+    fsi.SetComputationalDomain(ChAABB(cMin, cMax), PeriodicSide::NONE);
 
     // Initialize FSI problem
     fsi.Initialize();

--- a/src/demos/fsi/demo_FSI_Poiseuille_flow.cpp
+++ b/src/demos/fsi/demo_FSI_Poiseuille_flow.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[]) {
     auto initSpace0 = sysSPH.GetInitialSpacing();
     ChVector3d cMin = ChVector3d(-bxDim / 2 - initSpace0 / 2, -byDim / 2 - initSpace0 / 2, -5.0 * initSpace0);
     ChVector3d cMax = ChVector3d(bxDim / 2 + initSpace0 / 2, byDim / 2 + initSpace0 / 2, bzDim + 5.0 * initSpace0);
-    sysSPH.SetBoundaries(cMin, cMax);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::ALL);
 
     // Create Fluid region and discretize with SPH particles
     ChVector3d boxCenter(0.0, 0.0, bzDim / 2);

--- a/src/demos/fsi/demo_FSI_SingleWheelTest.cpp
+++ b/src/demos/fsi/demo_FSI_SingleWheelTest.cpp
@@ -330,7 +330,7 @@ int main(int argc, char* argv[]) {
     // Set up the periodic boundary condition (if not, set relative larger values)
     ChVector3d cMin(-bxDim / 2 * 10, -byDim / 2 - 0.5 * initSpacing, -bzDim * 10);
     ChVector3d cMax(bxDim / 2 * 10, byDim / 2 + 0.5 * initSpacing, bzDim * 10);
-    sysSPH.SetBoundaries(cMin, cMax);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::NONE);
 
     // Initialize the SPH particles
     auto initSpace0 = sysSPH.GetInitialSpacing();

--- a/src/demos/robot/demo_ROBOT_Viper_SPH.cpp
+++ b/src/demos/robot/demo_ROBOT_Viper_SPH.cpp
@@ -186,7 +186,7 @@ int main(int argc, char* argv[]) {
     double initSpace0 = sysSPH.GetInitialSpacing();
     ChVector3d cMin(-bxDim / 2 * 2, -byDim / 2 - 0.5 * initSpacing, -bzDim * 10);
     ChVector3d cMax(bxDim / 2 * 2, byDim / 2 + 0.5 * initSpacing, bzDim * 20);
-    sysSPH.SetBoundaries(cMin, cMax);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::NONE);
 
     // Set simulation data output level
     sysSPH.SetOutputLevel(OutputLevel::STATE);

--- a/src/demos/vehicle/fsi/demo_VEH_FSI_FloatingBlock.cpp
+++ b/src/demos/vehicle/fsi/demo_VEH_FSI_FloatingBlock.cpp
@@ -103,7 +103,7 @@ int main(int argc, char* argv[]) {
         ChVector3d(-bxDim / 2 - bxDim - 20.0 * initSpace0, -byDim / 2 - 1.0 * initSpace0 / 2.0, -2.0 * bzDim);
     ChVector3d cMax =
         ChVector3d(bxDim / 2 + bxDim + 20.0 * initSpace0, byDim / 2 + 1.0 * initSpace0 / 2.0, 2.0 * bzDim);
-    sysSPH.SetBoundaries(cMin, cMax);
+    sysSPH.SetComputationalBoundaries(cMin, cMax, PeriodicSide::NONE);
 
     // Create Fluid region and discretize with SPH particles
     ChVector3d boxCenter(-bxDim / 2 + fxDim / 2, 0.0, fzDim / 2);

--- a/src/tests/benchmark_tests/fsi/btest_FSI_RigidBCE_Scaling.cpp
+++ b/src/tests/benchmark_tests/fsi/btest_FSI_RigidBCE_Scaling.cpp
@@ -141,7 +141,7 @@ FsiRigidBceScalingTest<num_boxes>::FsiRigidBceScalingTest() {
                     -(box_multiplier * m_box_size.z()) * (m_num_boxes / m_boxes_per_layer + 1));
     ChVector3d cMax(m_box_size.x() / 2, m_box_size.y() / 2,
                     (box_multiplier * m_box_size.z()) * (m_num_boxes / m_boxes_per_layer + 1));
-    m_sysSPH->SetBoundaries(cMin, cMax);
+    m_sysSPH->SetComputationalBoundaries(cMin, cMax, PeriodicSide::ALL);
 
     chrono::utils::ChGridSampler<> sampler(sph_params.initial_spacing);
     ChVector3d boxCenter(0.0, 0.0, 0.0);

--- a/src/tests/unit_tests/fsi/utest_FSI_Poiseuille_flow.cpp
+++ b/src/tests/unit_tests/fsi/utest_FSI_Poiseuille_flow.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[]) {
     ChVector3d c_min(-bxDim / 2 - initial_spacing / 2, -byDim / 2 - initial_spacing / 2, -10.0 * initial_spacing);
     ChVector3d c_max(+bxDim / 2 + initial_spacing / 2, +byDim / 2 + initial_spacing / 2,
                      bzDim + 10.0 * initial_spacing);
-    fsi.SetComputationalDomainSize(ChAABB(c_min, c_max));
+    fsi.SetComputationalDomain(ChAABB(c_min, c_max), PeriodicSide::ALL);
 
     // Set particle initial velocity
     fsi.RegisterParticlePropertiesCallback(chrono_types::make_shared<InitialVelocityCallback>(bzDim, t_start));


### PR DESCRIPTION
# Implement Zombie Domains for FSI Simulations

This PR introduces the concept of "Zombie Domains" to the FSI module, which improves robustness by efficiently handling particles that leave the computational domain. Particles that are flying out of the computational domain will be frozen and not allowed to re-enter and impact the fluid domain.

## Key Features

1. **Zombie Domains**: Particles that leave the computational domain through non-periodic walls are marked as "zombie" particles (-1) rather than inactive (0), preventing them from being confused with particles that are merely asleep in the active box.

2. **Improved Computational Domain Control**: Users can now specify which sides of the computational domain behave as periodic boundaries. Particles leaving through non-periodic walls are "frozen" and no longer considered in the simulation.

## Affected Components

The changes primarily affect the FSI module's computational domain handling and particle management, with updates to several demos to showcase the new functionality.
