### PR TITLE
Add Viper Direct Control Driver

### DIFF
--- a/src/chrono_models/robot/viper/Viper.cpp
+++ b/src/chrono_models/robot/viper/Viper.cpp
@@ -726,5 +726,11 @@ void ViperSpeedDriver::Update(double time) {
     drive_speeds = {speed, speed, speed, speed};
 }
 
+void ViperDirectControl::SetDirectControl(std::array<double, 4> m_drive_speeds, std::array<double, 4> m_steer_angles, std::array<double, 4> m_lift_angles){
+    drive_speeds = m_drive_speeds;
+    steer_angles = m_steer_angles;
+    lift_angles = m_lift_angles;
+}
+
 }  // namespace viper
 }  // namespace chrono

--- a/src/chrono_models/robot/viper/Viper.h
+++ b/src/chrono_models/robot/viper/Viper.h
@@ -427,6 +427,25 @@ class CH_MODELS_API ViperSpeedDriver : public ViperDriver {
     double m_speed;
 };
 
+/// Viper Direct Control Driver.
+/// This driver allows direct control of the drive speeds, steer angles, and lift angles for all wheels individually.
+class CH_MODELS_API ViperDirectControl : public ViperDriver {
+  public:
+    ViperDirectControl() {}
+
+    ~ViperDirectControl() {}
+
+    /// Set Direct control of drive speeds, steer angles, and lift angles
+    void SetDirectControl(
+      std::array<double, 4> m_drive_speeds, 
+      std::array<double, 4> m_steer_angles,
+      std::array<double, 4> m_lift_angles
+    );
+  private:
+    virtual DriveMotorType GetDriveMotorType() const override { return DriveMotorType::SPEED; }
+    virtual void Update(double time){}
+};
+
 /// @} robot_models_viper
 
 }  // namespace viper

--- a/src/chrono_swig/interface/robot/ChModuleRobot.i
+++ b/src/chrono_swig/interface/robot/ChModuleRobot.i
@@ -176,6 +176,7 @@ using namespace chrono::industrial;
 %shared_ptr(chrono::viper::ViperDriver)
 %shared_ptr(chrono::viper::ViperDCMotorControl)
 %shared_ptr(chrono::viper::ViperSpeedDriver)
+%shared_ptr(chrono::viper::ViperDirectControl)
 
 %shared_ptr(chrono::curiosity::CuriosityPart)
 %shared_ptr(chrono::curiosity::CuriosityChassis)


### PR DESCRIPTION
In my own research I have found it very useful to have individual unrestricted control of all four wheel speeds, steering angles, and suspension angles for the Viper rover.

For instance there is not currently a way to move individual wheels in opposite directions in the current two drivers.

Happy to make changes to the way this is implemented if required!

