### PR TITLE
Implement matrix assembly and factorization persistent through entire simulation

### DIFF
--- a/src/chrono/timestepper/ChTimestepperHHT.cpp
+++ b/src/chrono/timestepper/ChTimestepperHHT.cpp
@@ -34,7 +34,8 @@ ChTimestepperHHT::ChTimestepperHHT(ChIntegrableIIorder* intgr)
       h_min(1e-10),
       h(1e6),
       num_successful_steps(0),
-      modified_Newton(true) {
+      modified_Newton(true),
+      persistent_Newton(false) {
     SetAlpha(-0.2);  // default: some dissipation
 }
 

--- a/src/chrono/timestepper/ChTimestepperHHT.h
+++ b/src/chrono/timestepper/ChTimestepperHHT.h
@@ -77,6 +77,13 @@ class ChApi ChTimestepperHHT : public ChTimestepperIIorder, public ChImplicitIte
     /// Default: true.
     void SetModifiedNewton(bool enable) { modified_Newton = enable; }
 
+    /// Enable/disable persistent Newton.
+    /// If enabled, the Newton matrix is evaluated, assembled, and factorized only once
+    /// at the beginning of the first step or if the Newton iteration does not converge with an out-of-date matrix.
+    /// If disabled, the Newton matrix is evaluated at every iteration of the nonlinear solver.
+    /// Default: false.
+    void SetPersistentNewton(bool enable) { persistent_Newton = enable; }
+
     /// Perform an integration timestep, by advancing the state by the specified time step.
     virtual void Advance(const double dt) override;
 
@@ -126,6 +133,7 @@ class ChApi ChTimestepperHHT : public ChTimestepperIIorder, public ChImplicitIte
     unsigned int num_successful_steps;  ///< number of successful steps
 
     bool modified_Newton;    ///< use modified Newton?
+    bool persistent_Newton;  ///< use persistent Newton?
     bool matrix_is_current;  ///< is the Newton matrix up-to-date?
     bool call_setup;         ///< should the solver's Setup function be called?
 

--- a/src/chrono/timestepper/ChTimestepperHHT.h
+++ b/src/chrono/timestepper/ChTimestepperHHT.h
@@ -70,19 +70,26 @@ class ChApi ChTimestepperHHT : public ChTimestepperIIorder, public ChImplicitIte
     /// Default: 0.5.
     void SetStepDecreaseFactor(double factor) { step_decrease_factor = factor; }
 
+    /// Available styles of modified Newton methods
+    enum ModifiedNewton : int {
+        UNMODIFIED, // Classical Newton. Jacobian updated at every iteration
+        EVERY_STEP, // Jacobian updated at every step
+        CONSTANT,   // Jacobian never updated
+        AUTOMATIC   // Jaobian updated when appropriate. TODO: implement
+    };
+
     /// Enable/disable modified Newton.
     /// If enabled, the Newton matrix is evaluated, assembled, and factorized only once
     /// per step or if the Newton iteration does not converge with an out-of-date matrix.
     /// If disabled, the Newton matrix is evaluated at every iteration of the nonlinear solver.
     /// Default: true.
-    void SetModifiedNewton(bool enable) { modified_Newton = enable; }
-
-    /// Enable/disable persistent Newton.
-    /// If enabled, the Newton matrix is evaluated, assembled, and factorized only once
-    /// at the beginning of the first step or if the Newton iteration does not converge with an out-of-date matrix.
-    /// If disabled, the Newton matrix is evaluated at every iteration of the nonlinear solver.
-    /// Default: false.
-    void SetPersistentNewton(bool enable) { persistent_Newton = enable; }
+    void SetModifiedNewton(ModifiedNewton style) { modified_Newton = style; }
+    void SetModifiedNewton(bool enable) { // Overload for backward compatibility with boolean implementation
+        if (enable)
+            modified_Newton = ModifiedNewton::EVERY_STEP;
+        else
+            modified_Newton = ModifiedNewton::UNMODIFIED;
+    }
 
     /// Perform an integration timestep, by advancing the state by the specified time step.
     virtual void Advance(const double dt) override;
@@ -103,6 +110,7 @@ class ChApi ChTimestepperHHT : public ChTimestepperIIorder, public ChImplicitIte
     void Increment(ChIntegrableIIorder* integrable2);
     bool CheckConvergence(int it);
     void CalcErrorWeights(const ChVectorDynamic<>& x, double rtol, double atol, ChVectorDynamic<>& ewt);
+    bool SetupRequiredForIteration(int iteration, bool previous_substep_converged);
 
   private:
     double alpha;  ///< HHT method parameter:  -1/3 <= alpha <= 0
@@ -132,9 +140,7 @@ class ChApi ChTimestepperHHT : public ChTimestepperIIorder, public ChImplicitIte
     double h;                           ///< internal stepsize
     unsigned int num_successful_steps;  ///< number of successful steps
 
-    bool modified_Newton;    ///< use modified Newton?
-    bool persistent_Newton;  ///< use persistent Newton?
-    bool persistent_matrix_computed; ///< persistent Newton matrix computed?
+    ModifiedNewton modified_Newton;    ///< style of modified Newton?
     bool matrix_is_current;  ///< is the Newton matrix up-to-date?
     bool call_setup;         ///< should the solver's Setup function be called?
 

--- a/src/chrono/timestepper/ChTimestepperHHT.h
+++ b/src/chrono/timestepper/ChTimestepperHHT.h
@@ -117,7 +117,7 @@ class ChApi ChTimestepperHHT : public ChTimestepperIIorder, public ChImplicitIte
     ChVectorDynamic<> Lnew;  ///< current estimate of Lagrange multipliers
     ChVectorDynamic<> R;     ///< residual of nonlinear system (dynamics portion)
     ChVectorDynamic<> Rold;  ///< residual terms depending on previous state
-    ChVectorDynamic<> Qc;    ///< residual of nonlinear system (constranints portion)
+    ChVectorDynamic<> Qc;    ///< residual of nonlinear system (constraints portion)
 
     std::array<double, 3> Da_nrm_hist;  ///< last 3 update norms
     std::array<double, 3> Dl_nrm_hist;  ///< last 3 update norms
@@ -134,6 +134,7 @@ class ChApi ChTimestepperHHT : public ChTimestepperIIorder, public ChImplicitIte
 
     bool modified_Newton;    ///< use modified Newton?
     bool persistent_Newton;  ///< use persistent Newton?
+    bool persistent_matrix_computed; ///< persistent Newton matrix computed?
     bool matrix_is_current;  ///< is the Newton matrix up-to-date?
     bool call_setup;         ///< should the solver's Setup function be called?
 


### PR DESCRIPTION
Assemble and factorize direct solver matrices only once at the beginning of the first step


corresponding issue: #566 