### PR TITLE
New ChSpindle class to SWIG module (and fixed translate bug for __FILENAME__ macro)

### DIFF
--- a/src/chrono_swig/interface/core/ChModuleCore.i
+++ b/src/chrono_swig/interface/core/ChModuleCore.i
@@ -91,6 +91,20 @@ using namespace chrono::fea;
 #define EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 #define CH_DEPRECATED(msg)
 
+#ifdef SWIGCSHARP  // --------------------------------------------------------------------- CSHARP
+// I'm not certain if this is a python issue also, so wrap only for csharp for now
+// Stop SWIG from generating a baked literal for the __FILENAME__ macro
+%ignore __FILENAME__;
+%inline %{
+// if needed there can be a pinvoke func instead of a broken char constant that SWIG produces from the macro
+inline const char* ChUtils_GetFilename() {
+    return __FILE__ + SOURCE_PATH_SIZE;
+}
+%}
+// make the new function visible as a public static for c#
+%csmethodmodifiers ChUtils_GetFilename "public static"
+#endif             // --------------------------------------------------------------------- CSHARP
+
 %ignore CH_ENUM_MAPPER_BEGIN;
 %ignore CH_ENUM_VAL;
 %ignore CH_ENUM_MAPPER_END;

--- a/src/chrono_swig/interface/vehicle/ChModuleVehicle.i
+++ b/src/chrono_swig/interface/vehicle/ChModuleVehicle.i
@@ -90,6 +90,7 @@
 
 #include "chrono_vehicle/wheeled_vehicle/ChAxle.h"
 
+#include "chrono_vehicle/wheeled_vehicle/ChSpindle.h"
 #include "chrono_vehicle/wheeled_vehicle/ChBrake.h"
 #include "chrono_vehicle/wheeled_vehicle/brake/ChBrakeSimple.h"
 #include "chrono_vehicle/wheeled_vehicle/brake/ChBrakeShafts.h"
@@ -255,6 +256,7 @@ Before adding a shared_ptr, mark as shared ptr all its inheritance tree in the m
 %shared_ptr(chrono::vehicle::ChVehicleJoint)
 %shared_ptr(chrono::vehicle::ChVehicle)
 %shared_ptr(chrono::vehicle::ChAxle)
+%shared_ptr(chrono::vehicle::ChSpindle)
 %shared_ptr(chrono::vehicle::ChWheeledVehicle)
 %shared_ptr(chrono::vehicle::ChWheeledTrailer)
 %shared_ptr(chrono::vehicle::WheeledVehicle)
@@ -385,6 +387,7 @@ Before adding a shared_ptr, mark as shared ptr all its inheritance tree in the m
 %include "ChTire.i"
 
 %include "../../../chrono_vehicle/wheeled_vehicle/ChAxle.h"
+%include "../../../chrono_vehicle/wheeled_vehicle/ChSpindle.h"
 
 %include "../../../chrono_vehicle/wheeled_vehicle/ChWheeledVehicle.h"
 %include "../../../chrono_vehicle/wheeled_vehicle/ChWheeledTrailer.h"


### PR DESCRIPTION
Including the ChSpindle class for swig's module so C# can access it (and presumably python, but i haven't tested)

The #define __FILENAME__ in chutils.h was getting the source header literal char translated by swig, so I included a little workaround for that, while still enabling access to a getfilename (if desired, though I don't think the debug log will use that?).
But if not really needed, we could just use the %ignore __FILENAME__; and that would stop swig mistranslating it.