### PR TITLE
python module compatability with SWIG 4.3.0+ for AppendOutput.

### DIFF
--- a/src/chrono_swig/interface/core/ChMatrix.i
+++ b/src/chrono_swig/interface/core/ChMatrix.i
@@ -39,13 +39,26 @@ defines the Python function return ($result) from the C++ args ($1, $2...)
     delete($1);
 %}
 
-%typemap(argout) (double* p, int len) {
+// version handling
+#if SWIG_VERSION >= 40300
+  // SWIG 4.3.0+ use a new three argument form with $isvoid flag
+  %typemap(argout) (double* p, int len) {
     PyObject* list = PyList_New($2);
-    int i;
-    for(i = 0; i < $2; ++i)
+    for (int i = 0; i < $2; ++i) {
         PyList_SET_ITEM(list, i, PyFloat_FromDouble($1[i]));
+    }
+    $result = SWIG_Python_AppendOutput($result, list, $isvoid);
+  }
+#else
+  // SWIG < 4.3.0 fall back to the older AppendOutput form
+  %typemap(argout) (double* p, int len) {
+    PyObject* list = PyList_New($2);
+    for (int i = 0; i < $2; ++i) {
+        PyList_SET_ITEM(list, i, PyFloat_FromDouble($1[i]));
+    }
     $result = SWIG_Python_AppendOutput($result, list);
-}
+  }
+#endif
 
 %typemap(in) (int numel, double* q) %{
     if (PyList_Check($input)) {
@@ -81,13 +94,26 @@ defines the Python function return ($result) from the C++ args ($1, $2...)
     delete($1);
 %}
 
-%typemap(argout) (int* p, int len) {
+#if SWIG_VERSION >= 40300
+  // SWIG 4.3.0+ use a new three argument form with $isvoid flag
+  %typemap(argout) (int* p, int len) {
     PyObject* list = PyList_New($2);
-    int i;
-    for(i = 0; i < $2; ++i)
-        PyList_SET_ITEM(list, i, PyLong_FromLong($1[i]));
+    for (int i = 0; i < $2; ++i) {
+      PyList_SET_ITEM(list, i, PyLong_FromLong($1[i]));
+    }
+    $result = SWIG_Python_AppendOutput($result, list, $isvoid);
+  }
+#else
+  // SWIG < 4.3.0 fall back to the older AppendOutput form
+  %typemap(argout) (int* p, int len) {
+    PyObject* list = PyList_New($2);
+    for (int i = 0; i < $2; ++i) {
+      PyList_SET_ITEM(list, i, PyLong_FromLong($1[i]));
+    }
     $result = SWIG_Python_AppendOutput($result, list);
-}
+  }
+#endif
+
 
 
 %typemap(in) (int numel, int* q) %{


### PR DESCRIPTION
See the following: 
https://sourceforge.net/projects/swig/files/swig/swig-4.3.0/#:~:text=New%20declaration%20of%20SWIG_Python_AppendOutput%20is,now

Alternatively, there's a macro approach that was set up:
https://github.com/swig/swig/pull/2907

Thus far I found with the core & vehicle python modules, only the chmatrix.i in core raises the issue. Also I found the older appendoutput with 2 args is also in Chrono's numpy.i under sensors (though i haven't compiled or tested that module) - presumably the same fix/upgrade could be applied there, or alternatively make use of the SWIG macro for a global approach :)
