### PR TITLE
Fix C++14 compatibility issues: std::istream::read buffer & missing Chrono template args

### DIFF
--- a/src/chrono/serialization/ChArchiveBinary.cpp
+++ b/src/chrono/serialization/ChArchiveBinary.cpp
@@ -288,7 +288,7 @@ std::istream& ChArchiveInBinary::read(std::string& val) {
     size_t str_len = 0;
     read(str_len);
     val.resize(str_len);
-    return m_istream.read(val.data(), str_len);
+    return m_istream.read(&val[0], str_len);
 }
 
 template <>

--- a/src/chrono_multicore/physics/Ch3DOFContainer.cpp
+++ b/src/chrono_multicore/physics/Ch3DOFContainer.cpp
@@ -40,7 +40,7 @@ class ChMulticoreVisualizationCloud : public ChParticleCloud {
     virtual size_t GetNumParticles() const override { return dm->num_particles; }
     virtual const ChVector3d& GetParticlePos(unsigned int n) const override {
         const auto& p = dm->host_data.pos_3dof[n];
-        tmp = ChVector3(p.x, p.y, p.z);
+        tmp = ChVector3d(p.x, p.y, p.z);
         return tmp;
     }
     virtual const ChVector3d& GetParticleVel(unsigned int n) const override {

--- a/src/demos/fsi/demo_FSI_Flap.cpp
+++ b/src/demos/fsi/demo_FSI_Flap.cpp
@@ -531,7 +531,7 @@ int main(int argc, char* argv[]) {
 
     ChTimer timer;
     timer.start();
-    ChVector3 reaction_force;
+    ChVector3d reaction_force;
     double flap_angular_velo;  // pitch velo
     double pto_power;
 

--- a/src/demos/robot/industrial/demo_ROBOT_Industrial.cpp
+++ b/src/demos/robot/industrial/demo_ROBOT_Industrial.cpp
@@ -67,9 +67,9 @@ int main(int argc, char* argv[]) {
     double motion_cycle_time = 6;
     ChCoordsysd key_0 = robot->GetMarkerTCP()->GetAbsCoordsys();
     ChCoordsysd key_1 =
-        ChCoordsys(key_0.pos + ChVector3d(-0.1, 0.2, 0), QuatFromAngleZ(30 * CH_DEG_TO_RAD) * key_0.rot);
+        ChCoordsysd(key_0.pos + ChVector3d(-0.1, 0.2, 0), QuatFromAngleZ(30 * CH_DEG_TO_RAD) * key_0.rot);
     ChCoordsysd key_2 =
-        ChCoordsys(key_1.pos + ChVector3d(0.2, -0.1, 0.2), QuatFromAngleX(-50 * CH_DEG_TO_RAD) * key_0.rot);
+        ChCoordsysd(key_1.pos + ChVector3d(0.2, -0.1, 0.2), QuatFromAngleX(-50 * CH_DEG_TO_RAD) * key_0.rot);
     std::vector<ChCoordsysd> keys = {key_0, key_1, key_2, key_0};
 
     // Create a trajectory interpolator from given keyframes


### PR DESCRIPTION
### Summary
This PR resolves several C++14-related compatibility problems.

### Changes Made
1. Fix for std::istream::read() with std::string
Replaced: `return m_istream.read(val.data(), str_len);`
By: `return m_istream.read(&val[0], str_len);`
> In C++14, val.data() returns a const char*, which is not valid as a writable buffer for read(). Using &val[0] provides a non-const pointer safely.

2. Fixed Template Argument Errors (E0441)
Replaced:
`ChVector3` ➜ `ChVector3d`
`ChCoordsys` ➜ `ChCoordsysd`
> Prevents "missing argument list for class template" errors during compilation under C++14.


###  Notes
A successful build with C++14 was verified.
Correct file reading behaviour at runtime confirmed.
It was coupled to an external library using C++14 with no errors.
