### PR TITLE
Fix typos in src/chrono_vehicle directory

### DIFF
--- a/src/chrono_vehicle/CMakeLists.txt
+++ b/src/chrono_vehicle/CMakeLists.txt
@@ -53,7 +53,7 @@ if(CH_ENABLE_OPENCRG)
     install(FILES "${CMAKE_SOURCE_DIR}/cmake/FindOpenCRG.cmake" DESTINATION ${CH_CONFIG_INSTALL_PATH})
 
   else()
-    message("WARNINIG: OpenCRG not found; disabling CRG support in Chrono::Vehicle")
+    message("WARNING: OpenCRG not found; disabling CRG support in Chrono::Vehicle")
 
     set(OpenCRG_INCLUDE_DIR "" CACHE PATH "Directory containing OpenCRG include files")
     set(OpenCRG_LIBRARY "" CACHE FILEPATH "OpenCRG library")

--- a/src/chrono_vehicle/ChConfigVehicle.h.in
+++ b/src/chrono_vehicle/ChConfigVehicle.h.in
@@ -29,7 +29,7 @@
 // If OpenCRG support was enabled, define CHRONO_OPENCRG
 @CHRONO_OPENCRG@
 
-// If Irrklang suppport was enabled, define CHRONO_IRRKLANG
+// If Irrklang support was enabled, define CHRONO_IRRKLANG
 @CHRONO_IRRKLANG@
 
 

--- a/src/chrono_vehicle/ChDriver.cpp
+++ b/src/chrono_vehicle/ChDriver.cpp
@@ -37,7 +37,7 @@ DriverInputs ChDriver::GetInputs() const {
     return {m_steering, m_throttle, m_braking, m_clutch};
 }
 
-// Initialize output file for recording deriver inputs.
+// Initialize output file for recording driver inputs.
 bool ChDriver::LogInit(const std::string& filename) {
     m_log_filename = filename;
 

--- a/src/chrono_vehicle/ChEngine.h
+++ b/src/chrono_vehicle/ChEngine.h
@@ -56,7 +56,7 @@ class CH_VEHICLE_API ChEngine : public ChPart {
 
     /// Update the engine system at the current time.
     /// The engine is provided the current driver throttle input, a value in the range [0,1].
-    /// The motorshaft speed represents the input to the engine from the transmision system.
+    /// The motorshaft speed represents the input to the engine from the transmission system.
     /// This default implementation sets the speed of the motorshaft.
     virtual void Synchronize(double time,                        ///< current time
                              const DriverInputs& driver_inputs,  ///< current driver inputs

--- a/src/chrono_vehicle/ChPart.h
+++ b/src/chrono_vehicle/ChPart.h
@@ -195,7 +195,7 @@ class CH_VEHICLE_API ChPart {
     static void RemoveVisualizationAsset(std::shared_ptr<ChPhysicsItem> item, std::shared_ptr<ChVisualShape> shape);
 
     std::string m_name;  ///< subsystem name
-    bool m_initialized;  ///< specifies whether ot not the part is fully constructed
+    bool m_initialized;  ///< specifies whether or not the part is fully constructed
     bool m_output;       ///< specifies whether or not output is generated for this subsystem
 
     std::shared_ptr<ChPart> m_parent;  ///< parent subsystem (empty if parent is vehicle)

--- a/src/chrono_vehicle/ChPowertrainAssembly.h
+++ b/src/chrono_vehicle/ChPowertrainAssembly.h
@@ -31,7 +31,7 @@ namespace vehicle {
 /// @addtogroup vehicle_powertrain
 /// @{
 
-/// Defintion of a powertrain assembly system.
+/// Definition of a powertrain assembly system.
 /// A powertrain assembly consists of an engine and a transmission.
 class CH_VEHICLE_API ChPowertrainAssembly {
   public:

--- a/src/chrono_vehicle/ChSubsysDefs.h
+++ b/src/chrono_vehicle/ChSubsysDefs.h
@@ -84,7 +84,7 @@ struct TerrainForce {
     ChVector3d moment;  ///< moment vector, expressed in the global frame
 };
 
-/// Vector of terrain conatct force structures.
+/// Vector of terrain contact force structures.
 typedef std::vector<TerrainForce> TerrainForces;
 
 /// Driver (vehicle control) inputs.

--- a/src/chrono_vehicle/ChTransmission.h
+++ b/src/chrono_vehicle/ChTransmission.h
@@ -71,7 +71,7 @@ class CH_VEHICLE_API ChTransmission : public ChPart {
     virtual double GetOutputDriveshaftTorque() const = 0;
 
     /// Return the transmission output speed of the motorshaft.
-    /// This represents the output from the transmision subsystem that is passed to the engine subsystem.
+    /// This represents the output from the transmission subsystem that is passed to the engine subsystem.
     virtual double GetOutputMotorshaftSpeed() const = 0;
 
     /// Return the reaction torque on the chassis body.

--- a/src/chrono_vehicle/ChVehicle.h
+++ b/src/chrono_vehicle/ChVehicle.h
@@ -122,13 +122,13 @@ class CH_VEHICLE_API ChVehicle {
     ChQuaternion<> GetRot() const { return m_chassis->GetRot(); }
 
     /// Get vehicle roll angle.
-    /// This version returns the roll angle with respect to the absolte frame; as such, this is a proper representation
+    /// This version returns the roll angle with respect to the absolute frame; as such, this is a proper representation
     /// of vehicle roll only on flat horizontal terrain. In the ISO frame convention, a positive roll angle corresponds
     /// to the vehicle left side lifting (e.g., in a turn to the left).
     double GetRoll() const;
 
     /// Get vehicle pitch angle.
-    /// This version returns the pitch angle with respect to the absolte frame; as such, this is a proper representation
+    /// This version returns the pitch angle with respect to the absolute frame; as such, this is a proper representation
     /// of vehicle pitch only on flat horizontal terrain. In the ISO frame convention, a positive pitch angle
     /// corresponds to the vehicle front dipping (e.g., during braking).
     double GetPitch() const;
@@ -152,7 +152,7 @@ class CH_VEHICLE_API ChVehicle {
     double GetSpeed() const { return m_chassis->GetSpeed(); }
 
     /// Get the vehicle slip angle.
-    /// This represents the angle betwwen the forward vehicle X axis and the vehicle velocity vector (calculated at the
+    /// This represents the angle between the forward vehicle X axis and the vehicle velocity vector (calculated at the
     /// origin of the vehicle frame). The return value is in radians with a positive sign for a left turn and a negative
     /// sign for a right turn.
     double GetSlipAngle() const;
@@ -265,7 +265,7 @@ class CH_VEHICLE_API ChVehicle {
 
     /// Advance the state of this vehicle by the specified time step.
     /// A call to ChSystem::DoStepDynamics is done only if the vehicle owns the underlying Chrono system.
-    /// Otherwise, the caller is responsible for advancing the sate of the entire system.
+    /// Otherwise, the caller is responsible for advancing the state of the entire system.
     virtual void Advance(double step);
 
     /// Log current constraint violations.
@@ -317,7 +317,7 @@ class CH_VEHICLE_API ChVehicle {
     ChFrame<> m_com;         ///< current vehicle COM (relative to the vehicle reference frame)
     ChMatrix33<> m_inertia;  ///< current total vehicle inertia (Relative to the vehicle COM frame)
 
-    bool m_output;                 ///< generate ouput for this vehicle system
+    bool m_output;                 ///< generate output for this vehicle system
     ChVehicleOutput* m_output_db;  ///< vehicle output database
     double m_output_step;          ///< output time step
     double m_next_output_time;     ///< time for next output

--- a/src/chrono_vehicle/ChWorldFrame.h
+++ b/src/chrono_vehicle/ChWorldFrame.h
@@ -77,7 +77,7 @@ class CH_VEHICLE_API ChWorldFrame {
     static void Project(ChVector3d& v);
 
   private:
-    /// Default world frame is ISO, corresonding to an identity rotation.
+    /// Default world frame is ISO, corresponding to an identity rotation.
     ChWorldFrame() : m_rot(1), m_quat(1, 0, 0, 0), m_vertical(0, 0, 1), m_forward(1, 0, 0), m_ISO(true) {}
 
     /// Return the (unique) instance of the world frame.
@@ -90,7 +90,7 @@ class CH_VEHICLE_API ChWorldFrame {
     ChQuaternion<> m_quat;  ///< world frame orientation (relative to ISO) as quaternion
     ChVector3d m_vertical;  ///< vertical direction of the world frame
     ChVector3d m_forward;   ///< forward direction of the world frame
-    bool m_ISO;             ///< flag indicating whther or not the world frame is ISO
+    bool m_ISO;             ///< flag indicating whether or not the world frame is ISO
 };
 
 /// @} vehicle

--- a/src/chrono_vehicle/chassis/ChChassisConnectorArticulated.h
+++ b/src/chrono_vehicle/chassis/ChChassisConnectorArticulated.h
@@ -42,7 +42,7 @@ class CH_VEHICLE_API ChChassisConnectorArticulated : public ChChassisConnector {
     virtual std::string GetTemplateName() const override { return "ChassisConnectorArticulated"; }
 
     /// Initialize this chassis connector subsystem.
-    /// The subsystem is initialized by attaching it to the specified front and rear chassis bodies at their conection
+    /// The subsystem is initialized by attaching it to the specified front and rear chassis bodies at their connection
     /// points.
     virtual void Initialize(std::shared_ptr<ChChassis> front,    ///< [in] front chassis
                             std::shared_ptr<ChChassisRear> rear  ///< [in] rear chassis

--- a/src/chrono_vehicle/chassis/ChChassisConnectorFifthWheel.h
+++ b/src/chrono_vehicle/chassis/ChChassisConnectorFifthWheel.h
@@ -39,7 +39,7 @@ class CH_VEHICLE_API ChChassisConnectorFifthWheel : public ChChassisConnector {
     virtual std::string GetTemplateName() const override { return "ChassisConnectorFifthWheel"; }
 
     /// Initialize this chassis connector subsystem.
-    /// The subsystem is initialized by attaching it to the specified front and rear chassis bodies at their conection
+    /// The subsystem is initialized by attaching it to the specified front and rear chassis bodies at their connection
     /// points.
     virtual void Initialize(std::shared_ptr<ChChassis> front,    ///< [in] front chassis
                             std::shared_ptr<ChChassisRear> rear  ///< [in] rear chassis

--- a/src/chrono_vehicle/chassis/ChChassisConnectorHitch.h
+++ b/src/chrono_vehicle/chassis/ChChassisConnectorHitch.h
@@ -38,7 +38,7 @@ class CH_VEHICLE_API ChChassisConnectorHitch : public ChChassisConnector {
     virtual std::string GetTemplateName() const override { return "ChassisConnectorHitch"; }
 
     /// Initialize this chassis connector subsystem.
-    /// The subsystem is initialized by attaching it to the specified front and rear chassis bodies at their conection
+    /// The subsystem is initialized by attaching it to the specified front and rear chassis bodies at their connection
     /// points.
     virtual void Initialize(std::shared_ptr<ChChassis> front,    ///< [in] front chassis
                             std::shared_ptr<ChChassisRear> rear  ///< [in] rear chassis

--- a/src/chrono_vehicle/chassis/ChChassisConnectorTorsion.h
+++ b/src/chrono_vehicle/chassis/ChChassisConnectorTorsion.h
@@ -41,7 +41,7 @@ class CH_VEHICLE_API ChChassisConnectorTorsion : public ChChassisConnector {
     virtual std::string GetTemplateName() const override { return "ChassisConnectorTorsion"; }
 
     /// Initialize this chassis connector subsystem.
-    /// The subsystem is initialized by attaching it to the specified front and rear chassis bodies at their conection
+    /// The subsystem is initialized by attaching it to the specified front and rear chassis bodies at their connection
     /// points.
     virtual void Initialize(std::shared_ptr<ChChassis> front,    ///< [in] front chassis
                             std::shared_ptr<ChChassisRear> rear  ///< [in] rear chassis

--- a/src/chrono_vehicle/cosim/ChVehicleCosimDBPRig.cpp
+++ b/src/chrono_vehicle/cosim/ChVehicleCosimDBPRig.cpp
@@ -257,7 +257,7 @@ void ChVehicleCosimDBPRigImposedAngVel::InitializeRig(std::shared_ptr<ChBody> ch
     prism_vert->Initialize(m_carrier, chassis, ChFrame<>(m_carrier->GetPos(), QUNIT));
     chassis->GetSystem()->AddLink(prism_vert);
 
-    // Connect carrier to ground with a horizonal prismatic joint
+    // Connect carrier to ground with a horizontal prismatic joint
     auto prism_horiz = chrono_types::make_shared<ChLinkLockPrismatic>();
     prism_horiz->Initialize(m_carrier, ground, ChFrame<>(m_carrier->GetPos(), QuatFromAngleY(CH_PI_2)));
     chassis->GetSystem()->AddLink(prism_horiz);

--- a/src/chrono_vehicle/cosim/ChVehicleCosimTrackedMBSNode.h
+++ b/src/chrono_vehicle/cosim/ChVehicleCosimTrackedMBSNode.h
@@ -107,7 +107,7 @@ class CH_VEHICLE_API ChVehicleCosimTrackedMBSNode : public ChVehicleCosimBaseNod
     virtual void PostAdvance(double step_size) {}
 
     /// Perform additional output at the specified frame (called from within OutputData).
-    /// For example, output mechanism-specific data for post-procesing.
+    /// For example, output mechanism-specific data for post-processing.
     virtual void OnOutputData(int frame) {}
 
     /// Apply the provided force to the specified track shoe body

--- a/src/chrono_vehicle/cosim/ChVehicleCosimWheeledMBSNode.cpp
+++ b/src/chrono_vehicle/cosim/ChVehicleCosimWheeledMBSNode.cpp
@@ -147,7 +147,7 @@ void ChVehicleCosimWheeledMBSNode::Initialize() {
     }
 
     // Incorporate information on tire mass, radius, and width.
-    // This is defered to this point so that the MBS system could be initialized first and correct spindle locations
+    // This is deferred to this point so that the MBS system could be initialized first and correct spindle locations
     // sent to the tire nodes. Only after their own initialization can the tire nodes send back here the tire info.
     ApplyTireInfo(tire_info);
 

--- a/src/chrono_vehicle/cosim/ChVehicleCosimWheeledMBSNode.h
+++ b/src/chrono_vehicle/cosim/ChVehicleCosimWheeledMBSNode.h
@@ -125,7 +125,7 @@ class CH_VEHICLE_API ChVehicleCosimWheeledMBSNode : public ChVehicleCosimBaseNod
     virtual void PostAdvance(double step_size) {}
 
     /// Perform additional output at the specified frame (called from within OutputData).
-    /// For example, output mechanism-specific data for post-procesing.
+    /// For example, output mechanism-specific data for post-processing.
     virtual void OnOutputData(int frame) {}
 
     /// Apply the provided force to the i-th spindle body.

--- a/src/chrono_vehicle/cosim/terrain/ChVehicleCosimTerrainNodeChrono.h
+++ b/src/chrono_vehicle/cosim/terrain/ChVehicleCosimTerrainNodeChrono.h
@@ -108,7 +108,7 @@ class CH_VEHICLE_API ChVehicleCosimTerrainNodeChrono : public ChVehicleCosimTerr
     /// Construct a base class terrain node.
     ChVehicleCosimTerrainNodeChrono(Type type,              ///< terrain type
                                     double length,          ///< terrain patch length
-                                    double width,           ///< terain patch width
+                                    double width,           ///< terrain patch width
                                     ChContactMethod method  ///< contact method (SMC or NSC)
     );
 

--- a/src/chrono_vehicle/cosim/terrain/ChVehicleCosimTerrainNodeGranularGPU.cpp
+++ b/src/chrono_vehicle/cosim/terrain/ChVehicleCosimTerrainNodeGranularGPU.cpp
@@ -229,7 +229,7 @@ void ChVehicleCosimTerrainNodeGranularGPU::Construct() {
 #endif
 
     // Calculate domain size
-    //// TODO: For now, we need to hack in a larger dimZ to accomodate any wheels that will only show up later.
+    //// TODO: For now, we need to hack in a larger dimZ to accommodate any wheels that will only show up later.
     ////       This limitations needs to be removed in Chrono::Gpu!
     ////       Second, we are limited to creating this domain centered at the origin!?!
     float r = m_separation_factor * (float)m_radius_g;

--- a/src/chrono_vehicle/cosim/terrain/ChVehicleCosimTerrainNodeGranularOMP.cpp
+++ b/src/chrono_vehicle/cosim/terrain/ChVehicleCosimTerrainNodeGranularOMP.cpp
@@ -909,7 +909,7 @@ void ChVehicleCosimTerrainNodeGranularOMP::UpdateMeshProxy(unsigned int i, MeshS
         //// RADU TODO: angular velocity
         proxy->bodies[it]->SetAngVelLocal(ChVector3d(0, 0, 0));
 
-        // Update triangle contact shape (expressed in local frame) by writting directly
+        // Update triangle contact shape (expressed in local frame) by writing directly
         // into the Chrono::Multicore data structures.
         // ATTENTION: It is assumed that no other triangle contact shapes have been added
         // to the system BEFORE those corresponding to the object mesh faces!

--- a/src/chrono_vehicle/cosim/terrain/ChVehicleCosimTerrainNodeSCM.h
+++ b/src/chrono_vehicle/cosim/terrain/ChVehicleCosimTerrainNodeSCM.h
@@ -102,7 +102,7 @@ class CH_VEHICLE_API ChVehicleCosimTerrainNodeSCM : public ChVehicleCosimTerrain
     double m_Mohr_friction;  ///< Friction angle (in degrees!), for shear failure
     double m_Janosi_shear;   ///< J , shear parameter, in meters, in Janosi-Hanamoto formula (usually few mm or cm)
     double m_elastic_K;      ///< elastic stiffness K per unit area [Pa/m]
-    double m_damping_R;      ///< vetical damping R per unit area [Pa.s/m]
+    double m_damping_R;      ///< vertical damping R per unit area [Pa.s/m]
 
     double m_radius_p;  ///< radius for a proxy body
 

--- a/src/chrono_vehicle/driver/ChHumanDriver.cpp
+++ b/src/chrono_vehicle/driver/ChHumanDriver.cpp
@@ -306,7 +306,7 @@ void ChHumanDriver::Advance(double step) {  // distance in front of the vehicle.
     // define field of view angle of the driver +-10 deg
     const double ny = 10.0 * CH_DEG_TO_RAD;
     // which speed to choose?
-    // search intervalls for longitudinal controller
+    // search intervals for longitudinal controller
     double d_long = 0;
     bool i_restrict = false;
     bool j_restrict = false;

--- a/src/chrono_vehicle/fmi/cosim/fmu2_force_element_tire/FMU_ForceElementTire.cpp
+++ b/src/chrono_vehicle/fmi/cosim/fmu2_force_element_tire/FMU_ForceElementTire.cpp
@@ -79,7 +79,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
     AddFmuVariable(&out_path, "out_path", FmuVariable::Type::String, "1", "output directory",    //
                    FmuVariable::CausalityType::parameter, FmuVariable::VariabilityType::fixed);  //
 
-    // Set CONTINOUS INPUTS for this FMU (wheel state)
+    // Set CONTINUOUS INPUTS for this FMU (wheel state)
     AddFmuVecVariable(wheel_state.pos, "wheel_state.pos", "m", "wheel position",                      //
                       FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);   //
     AddFmuQuatVariable(wheel_state.rot, "wheel_state.rot", "1", "wheel rotation",                     //

--- a/src/chrono_vehicle/fmi/cosim/fmu2_path_follower_driver/FMU_PathFollowerDriver.cpp
+++ b/src/chrono_vehicle/fmi/cosim/fmu2_path_follower_driver/FMU_PathFollowerDriver.cpp
@@ -144,7 +144,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
     AddFmuVariable(&init_yaw, "init_yaw", FmuVariable::Type::Real, "rad", "orientation of first path segment",  //
                    FmuVariable::CausalityType::output, FmuVariable::VariabilityType::constant);                 //
 
-    // Set CONTINOUS INPUTS for this FMU
+    // Set CONTINUOUS INPUTS for this FMU
     AddFmuFrameMovingVariable(ref_frame, "ref_frame", "m", "m/s", "reference frame",                         //
                               FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);  //
     AddFmuVariable(&target_speed, "target_speed", FmuVariable::Type::Real, "m/s", "target speed",            //
@@ -154,7 +154,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
     AddFmuVariable((int*)(&save_img), "save_img", FmuVariable::Type::Boolean, "1", "trigger saving images",  //
                    FmuVariable::CausalityType::input, FmuVariable::VariabilityType::discrete);               //
 
-    // Set CONTINOUS OUTPUTS for this FMU
+    // Set CONTINUOUS OUTPUTS for this FMU
     AddFmuVariable(&steering, "steering", FmuVariable::Type::Real, "1", "steering command",       //
                    FmuVariable::CausalityType::output, FmuVariable::VariabilityType::continuous,  //
                    FmuVariable::InitialType::exact);                                              //

--- a/src/chrono_vehicle/fmi/cosim/fmu2_path_follower_driver/FMU_PathFollowerDriver.h
+++ b/src/chrono_vehicle/fmi/cosim/fmu2_path_follower_driver/FMU_PathFollowerDriver.h
@@ -113,7 +113,7 @@ class FmuComponent : public chrono::fmi2::FmuChronoComponentBase {
     bool save_img;         ///< enable/disable saving of visualization snapshots
     double fps;            ///< snapshot saving frequency (in FPS)
 
-    // Vehicle driver commands (FMU countinuous outputs)
+    // Vehicle driver commands (FMU continuous outputs)
     double steering;  ///< steering command, in [-1,1]
     double throttle;  ///< throttle command, in [0,1]
     double braking;   ///< braking command, in [0,1]

--- a/src/chrono_vehicle/fmi/cosim/fmu2_powertrain/FMU_Powertrain.cpp
+++ b/src/chrono_vehicle/fmi/cosim/fmu2_powertrain/FMU_Powertrain.cpp
@@ -85,7 +85,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
     AddFmuVariable(&out_path, "out_path", FmuVariable::Type::String, "1", "output directory",    //
                    FmuVariable::CausalityType::parameter, FmuVariable::VariabilityType::fixed);  //
 
-    // Set CONTINOUS INPUTS for this FMU (driver inputs)
+    // Set CONTINUOUS INPUTS for this FMU (driver inputs)
     AddFmuVariable(&throttle, "throttle", FmuVariable::Type::Real, "1", "throttle input",         //
                    FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);  //
     AddFmuVariable(&clutch, "clutch", FmuVariable::Type::Real, "1", "clutch input",               //

--- a/src/chrono_vehicle/fmi/cosim/fmu2_wheeled_vehicle/FMU_WheeledVehicle.cpp
+++ b/src/chrono_vehicle/fmi/cosim/fmu2_wheeled_vehicle/FMU_WheeledVehicle.cpp
@@ -131,7 +131,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
     AddFmuVariable(&fps, "fps", FmuVariable::Type::Real, "1", "rendering frequency",             //
                    FmuVariable::CausalityType::parameter, FmuVariable::VariabilityType::fixed);  //
 
-    // Set CONTINOUS INPUTS for this FMU (driver inputs)
+    // Set CONTINUOUS INPUTS for this FMU (driver inputs)
     AddFmuVariable(&driver_inputs.m_steering, "steering", FmuVariable::Type::Real, "1", "steering input",  //
                    FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);           //
     AddFmuVariable(&driver_inputs.m_throttle, "throttle", FmuVariable::Type::Real, "1", "throttle input",  //
@@ -149,7 +149,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
     AddFmuFrameMovingVariable(ref_frame, "ref_frame", "m", "m/s", "reference frame",                          //
                               FmuVariable::CausalityType::output, FmuVariable::VariabilityType::continuous);  //
 
-    // Set CONTINOUS INPUTS and OUTPUTS for this FMU (driveshaft speed and torque for co-simulation)
+    // Set CONTINUOUS INPUTS and OUTPUTS for this FMU (driveshaft speed and torque for co-simulation)
     AddFmuVariable(&driveshaft_torque, "driveshaft_torque", FmuVariable::Type::Real,              //
                    "Nm", "driveshaft motor torque",                                               //
                    FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);  //
@@ -165,7 +165,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
                    "Nm", "transmission reaction torque",                                          //
                    FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);  //
 
-    // Set CONTINOUS INPUTS and OUTPUTS for this FMU (wheel state and forces for co-simulation)
+    // Set CONTINUOUS INPUTS and OUTPUTS for this FMU (wheel state and forces for co-simulation)
     for (int iw = 0; iw < 4; iw++) {
         wheel_data[iw].state.lin_vel = VNULL;
         wheel_data[iw].state.ang_vel = VNULL;

--- a/src/chrono_vehicle/fmi/cosim/fmu2_wheeled_vehicle/FMU_WheeledVehicle.h
+++ b/src/chrono_vehicle/fmi/cosim/fmu2_wheeled_vehicle/FMU_WheeledVehicle.h
@@ -125,8 +125,8 @@ class FmuComponent : public chrono::fmi2::FmuChronoComponentBase {
     // FMU continuous inputs and outputs for co-simulation (vehicle-powertrain)
     double driveshaft_speed;       ///< driveshaft angular speed (output)
     double driveshaft_torque;      ///< driveshaft motor torque (input)
-    double engine_reaction;        ///< engine reaction torque on chassis (intput)
-    double transmission_reaction;  ///< transmission reaction torque on chassis (intput)
+    double engine_reaction;        ///< engine reaction torque on chassis (input)
+    double transmission_reaction;  ///< transmission reaction torque on chassis (input)
 
     //// TODO - more outputs
 

--- a/src/chrono_vehicle/fmi/cosim/fmu2_wheeled_vehicle_ptrain/FMU_WheeledVehiclePtrain.cpp
+++ b/src/chrono_vehicle/fmi/cosim/fmu2_wheeled_vehicle_ptrain/FMU_WheeledVehiclePtrain.cpp
@@ -124,7 +124,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
     AddFmuVariable(&fps, "fps", FmuVariable::Type::Real, "1", "rendering frequency",             //
                    FmuVariable::CausalityType::parameter, FmuVariable::VariabilityType::fixed);  //
 
-    // Set CONTINOUS INPUTS for this FMU (driver inputs)
+    // Set CONTINUOUS INPUTS for this FMU (driver inputs)
     AddFmuVariable(&driver_inputs.m_steering, "steering", FmuVariable::Type::Real, "1", "steering input",  //
                    FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);           //
     AddFmuVariable(&driver_inputs.m_throttle, "throttle", FmuVariable::Type::Real, "1", "throttle input",  //
@@ -142,7 +142,7 @@ FmuComponent::FmuComponent(fmi2String instanceName,
     AddFmuFrameMovingVariable(ref_frame, "ref_frame", "m", "m/s", "reference frame",                          //
                               FmuVariable::CausalityType::output, FmuVariable::VariabilityType::continuous);  //
 
-    // Set CONTINOUS INPUTS and OUTPUTS for this FMU (wheel state and forces for co-simulation)
+    // Set CONTINUOUS INPUTS and OUTPUTS for this FMU (wheel state and forces for co-simulation)
     for (int iw = 0; iw < 4; iw++) {
         wheel_data[iw].state.lin_vel = VNULL;
         wheel_data[iw].state.ang_vel = VNULL;

--- a/src/chrono_vehicle/fmi/modex/fmu2_path_follower_driver/FMU_PathFollowerDriver.cpp
+++ b/src/chrono_vehicle/fmi/modex/fmu2_path_follower_driver/FMU_PathFollowerDriver.cpp
@@ -111,13 +111,13 @@ FmuComponent::FmuComponent(fmi2String instanceName,
                    "integral gain, speed controller",                                            //
                    FmuVariable::CausalityType::parameter, FmuVariable::VariabilityType::fixed);  //
 
-    // Set CONTINOUS INPUTS for this FMU
+    // Set CONTINUOUS INPUTS for this FMU
     AddFmuFrameMovingVariable(ref_frame, "ref_frame", "m", "m/s", "reference frame",                         //
                               FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);  //
     AddFmuVariable(&target_speed, "target_speed", FmuVariable::Type::Real, "m/s", "target speed",            //
                    FmuVariable::CausalityType::input, FmuVariable::VariabilityType::continuous);             //
 
-    // Set CONTINOUS OUTPUTS for this FMU
+    // Set CONTINUOUS OUTPUTS for this FMU
     AddFmuVariable(&steering, "steering", FmuVariable::Type::Real, "1", "steering command",       //
                    FmuVariable::CausalityType::output, FmuVariable::VariabilityType::continuous,  //
                    FmuVariable::InitialType::exact);                                              //

--- a/src/chrono_vehicle/fmi/modex/fmu2_path_follower_driver/FMU_PathFollowerDriver.h
+++ b/src/chrono_vehicle/fmi/modex/fmu2_path_follower_driver/FMU_PathFollowerDriver.h
@@ -82,9 +82,9 @@ class FmuComponent : public chrono::fmi2::FmuChronoComponentBase {
     chrono::ChFrameMoving<> ref_frame;  ///< vehicle reference frame
 
     // FMU outputs
-    double steering;  ///< (FMU countinuous output) steering command, in [-1,1]
-    double throttle;  ///< (FMU countinuous output) throttle command, in [0,1]
-    double braking;   ///< (FMU countinuous output) braking command, in [0,1]
+    double steering;  ///< (FMU continuous output) steering command, in [-1,1]
+    double throttle;  ///< (FMU continuous output) throttle command, in [0,1]
+    double braking;   ///< (FMU continuous output) braking command, in [0,1]
 
     chrono::ChVector3d sentinel_loc;  ///< (FMU continuous output) current sentinel point location
     chrono::ChVector3d target_loc;    ///< (FMU continuous output) current target point location

--- a/src/chrono_vehicle/powertrain/ChAutomaticTransmissionShafts.h
+++ b/src/chrono_vehicle/powertrain/ChAutomaticTransmissionShafts.h
@@ -80,7 +80,7 @@ class CH_VEHICLE_API ChAutomaticTransmissionShafts : public ChAutomaticTransmiss
     virtual double GetOutputDriveshaftTorque() const override;
 
     /// Return the transmission output speed of the motorshaft.
-    /// This represents the output from the transmision subsystem that is passed to the engine subsystem.
+    /// This represents the output from the transmission subsystem that is passed to the engine subsystem.
     virtual double GetOutputMotorshaftSpeed() const override;
 
     /// Return the reaction torque on the chassis body.

--- a/src/chrono_vehicle/powertrain/ChAutomaticTransmissionSimpleCVT.h
+++ b/src/chrono_vehicle/powertrain/ChAutomaticTransmissionSimpleCVT.h
@@ -63,7 +63,7 @@ class CH_VEHICLE_API ChAutomaticTransmissionSimpleCVT : public ChAutomaticTransm
     virtual double GetOutputDriveshaftTorque() const override { return m_driveshaft_torque; }
 
     /// Return the transmission output speed of the motorshaft.
-    /// This represents the output from the transmision subsystem that is passed to the engine subsystem.
+    /// This represents the output from the transmission subsystem that is passed to the engine subsystem.
     virtual double GetOutputMotorshaftSpeed() const override { return m_motorshaft_speed; }
 
     /// Set the operation range
@@ -71,7 +71,7 @@ class CH_VEHICLE_API ChAutomaticTransmissionSimpleCVT : public ChAutomaticTransm
                            double ratio_start,              // () smallest possible gear ratio
                            double driveshaft_speed_end,     // (rad/sec), end gear variation
                            double ratio_end,                // () greatest possible gear ratio
-                           double gearbox_efficiency = 1.0  // optional efficency setting
+                           double gearbox_efficiency = 1.0  // optional efficiency setting
     );
 
     /// Set the transmission gear ratios (one or more forward gear ratios and a single reverse gear ratio).

--- a/src/chrono_vehicle/powertrain/ChAutomaticTransmissionSimpleMap.h
+++ b/src/chrono_vehicle/powertrain/ChAutomaticTransmissionSimpleMap.h
@@ -69,7 +69,7 @@ class CH_VEHICLE_API ChAutomaticTransmissionSimpleMap : public ChAutomaticTransm
     virtual double GetOutputDriveshaftTorque() const override { return m_driveshaft_torque; }
 
     /// Return the transmission output speed of the motorshaft.
-    /// This represents the output from the transmision subsystem that is passed to the engine subsystem.
+    /// This represents the output from the transmission subsystem that is passed to the engine subsystem.
     virtual double GetOutputMotorshaftSpeed() const override { return m_motorshaft_speed; }
 
   protected:

--- a/src/chrono_vehicle/powertrain/ChManualTransmissionShafts.h
+++ b/src/chrono_vehicle/powertrain/ChManualTransmissionShafts.h
@@ -59,7 +59,7 @@ class CH_VEHICLE_API ChManualTransmissionShafts : public ChManualTransmission {
     virtual double GetOutputDriveshaftTorque() const override;
 
     /// Return the transmission output speed of the motorshaft.
-    /// This represents the output from the transmision subsystem that is passed to the engine subsystem.
+    /// This represents the output from the transmission subsystem that is passed to the engine subsystem.
     virtual double GetOutputMotorshaftSpeed() const override;
 
     /// Return the reaction torque on the chassis body.

--- a/src/chrono_vehicle/terrain/GranularTerrain.cpp
+++ b/src/chrono_vehicle/terrain/GranularTerrain.cpp
@@ -85,7 +85,7 @@ GranularTerrain::GranularTerrain(ChSystem* system)
     m_ground->SetFixed(true);
     m_ground->EnableCollision(false);
 
-    // Create a collsion model for the ground body (required for the custom boundary detection algorithm)
+    // Create a collision model for the ground body (required for the custom boundary detection algorithm)
     m_ground->AddCollisionModel(chrono_types::make_shared<ChCollisionModel>());
 
     system->AddBody(m_ground);

--- a/src/chrono_vehicle/terrain/ObsModTerrain.cpp
+++ b/src/chrono_vehicle/terrain/ObsModTerrain.cpp
@@ -16,7 +16,7 @@
 //  The obstacle is defined by three parameters
 //  - aa:        approach angle 180 deg = flat, aa < 180 deg = mound, aa > 180 deg = trench
 //  - length:    obstacle length for mound, base length for trench
-//  - obsheight: allways >= 0, obstacle height for mound, obstacle depth for trench
+//  - obsheight: always >= 0, obstacle height for mound, obstacle depth for trench
 //
 // =============================================================================
 
@@ -135,7 +135,7 @@ double ObsModTerrain::GetHeight(const ChVector3d& loc) const {
             }
         }
         if (ix1 == -1) {
-            std::cerr << "x intervall?\n";
+            std::cerr << "x interval?\n";
         }
         int jy1 = -1;
         int jy2 = -1;
@@ -147,7 +147,7 @@ double ObsModTerrain::GetHeight(const ChVector3d& loc) const {
             }
         }
         if (jy1 == -1) {
-            std::cerr << "y intervall?\n";
+            std::cerr << "y interval?\n";
         }
         double x = loc_ISO.x();
         double y = loc_ISO.y();

--- a/src/chrono_vehicle/terrain/ObsModTerrain.h
+++ b/src/chrono_vehicle/terrain/ObsModTerrain.h
@@ -16,7 +16,7 @@
 //  The obstacle is defined by three parameters
 //  - aa:        approach angle 180 deg = flat, aa < 180 deg = mound, aa > 180 deg = trench
 //  - length:    obstacle length for mound, base length for trench
-//  - obsheight: allways >= 0, obstacle height for mound, obstacle depth for trench
+//  - obsheight: always >= 0, obstacle height for mound, obstacle depth for trench
 //
 // =============================================================================
 
@@ -50,7 +50,7 @@ class CH_VEHICLE_API ObsModTerrain : public ChTerrain {
                   float friction = 0.8f,  ///< [] terrain coefficient of friction
                   double aa = 180.0,      ///< [deg] approach angle
                   double length = 10.0,   ///< [m] obstacle length for mound, base length for trench
-                  double obsheight = 0.0  ///< [m] allways >= 0, obstacle height for mound, obstacle depth for trench
+                  double obsheight = 0.0  ///< [m] always >= 0, obstacle height for mound, obstacle depth for trench
     );
 
     ~ObsModTerrain() {}
@@ -112,9 +112,9 @@ class CH_VEHICLE_API ObsModTerrain : public ChTerrain {
     double m_width;                    ///< [m] obstacle width
     double m_aa;                       ///< approach angle 180° flat, >180° trench, <180° mound, internally in [rad]
     double m_obslength;                ///< [m] obstacle length for mound, base length for trench
-    double m_obsheight;                ///< [m] allways >= 0, obstacle height for mound, obstacle depth for trench
+    double m_obsheight;                ///< [m] always >= 0, obstacle height for mound, obstacle depth for trench
     size_t m_nx;                       ///< number of obstacle coordinates in x direction
-    size_t m_ny;                       ///< numer of obstacle coordinates in y direction
+    size_t m_ny;                       ///< number of obstacle coordinates in y direction
     double m_xmin;                     ///< x coordinate, where the obstacle begins
     double m_xmax;                     ///< x coordinate, where the obstacle ends
     double m_ymin;                     ///< y coordinate, where the obstacle begins

--- a/src/chrono_vehicle/terrain/RandomSurfaceTerrain.h
+++ b/src/chrono_vehicle/terrain/RandomSurfaceTerrain.h
@@ -16,11 +16,11 @@
 // The uneven two-track surface is modeled by means of standard PSD spectra as
 // defined in the ISO 8608 standard. ISO 8608 defines 8 classes of uneven
 // roads all can be selected from preset configurations if the two tracks
-// shall be uncorrelated or independend. Tracks like this are used for
+// shall be uncorrelated or independent. Tracks like this are used for
 // intensive vehicle testing, because they apply a high load to the vehicle
 // structure.
 //
-// If normal road surface conditions are prefered, correlated tracks are the
+// If normal road surface conditions are preferred, correlated tracks are the
 // better choice. From test we know that the measured cohereny is a function of
 //  - vehicle track width
 //  - signal wavelength
@@ -36,7 +36,7 @@
 // where Phi_h0 is the unevenness and w is the waviness. ISO 8608 uses only w = 2.
 // omega is the spatial natural frequency. omega0 is defined to 1 rad/m.
 //
-// The transformation to spatial cordinates is done by inverse Fourier transform.
+// The transformation to spatial coordinates is done by inverse Fourier transform.
 // Care has been taken, that the signal does not repeat inside the demanded x
 // interval by selecting sufficient spectral coefficients.
 //
@@ -48,7 +48,7 @@
 // to generate a set of random phase angles in the range [0,2Pi] for every track.
 // We must use a uniform random number for this to avoid 'monster waves'.
 // Every track gets is own set of phase angles. If correlated signals are demanded
-// the phase angle sets left and right are blended whith the coherence function.
+// the phase angle sets left and right are blended with the coherence function.
 //
 // For practical work it is necessary to limit the used wavelengths. The minimal
 // useful wavelength is 0.3 m. This is roughly the contact patch length of the tire.
@@ -56,7 +56,7 @@
 // increase the amount of data.
 //
 // The maximal wavelength must also be limited. The disadvantage of the PSD
-// formula is the ability to increase the amplitude to infinity with decresing
+// formula is the ability to increase the amplitude to infinity with decreasing
 // spatial natural frequency. This can lead to enormous height differences
 // between left and right track that would tip the vehicle. For this reason
 // we limit the wavelength maximum to 20 m. As a side effect the RMS value this
@@ -64,7 +64,7 @@
 // for vehicle ride quality (6 Watt method). WES proposed to use 60 ft high pass
 // filter before calculating the RMS.
 //
-// Three different initilizer methods can be used: a preset based one, an
+// Three different initializer methods can be used: a preset based one, an
 // unevenness/waviness based one, and an IRI based one. The second one allows the
 // usage of non-ISO wavinesses. IRI must be given in [mm/m] to generate useful
 // results.
@@ -236,7 +236,7 @@ class CH_VEHICLE_API RandomSurfaceTerrain : public ChTerrain {
 
     int m_Nfft;                  ///< number of fft coefficients to avoid periodicity in x[xmin...xmax]
     std::vector<double> m_ck;    ///< Fourier coefficients
-    std::vector<double> m_wfft;  ///< natural freqencies for iFFT
+    std::vector<double> m_wfft;  ///< natural frequencies for iFFT
 
     ChVectorDynamic<> m_phase_left;
     ChVectorDynamic<> m_phase_right;

--- a/src/chrono_vehicle/terrain/RigidTerrain.cpp
+++ b/src/chrono_vehicle/terrain/RigidTerrain.cpp
@@ -863,7 +863,7 @@ void RigidTerrain::Patch::SetTexture(const std::string& filename, float scale_x,
 class RTContactCallback : public ChContactContainer::AddContactCallback {
   public:
     virtual void OnAddContact(const ChCollisionInfo& contactinfo, ChContactMaterialComposite* const material) override {
-        //// TODO: also accomodate terrain contact with FEA meshes.
+        //// TODO: also accommodate terrain contact with FEA meshes.
 
         // Loop over all patch bodies and check if this contact involves one of them.
         ChBody* body_patch = nullptr;
@@ -886,7 +886,7 @@ class RTContactCallback : public ChContactContainer::AddContactCallback {
         }
 
         // Do nothing if this contact does not involve a terrain body or if the other contactable
-        // is not a body or if the collsion does not involve a shape (e.g., a contact added by the user)
+        // is not a body or if the collision does not involve a shape (e.g., a contact added by the user)
         if (!body_patch || !body_other || !shape_other)
             return;
 

--- a/src/chrono_vehicle/terrain/RigidTerrain.h
+++ b/src/chrono_vehicle/terrain/RigidTerrain.h
@@ -226,7 +226,7 @@ class CH_VEHICLE_API RigidTerrain : public ChTerrain {
     /// Find the terrain height, normal, and coefficient of friction at the point below the specified location.
     /// The point on the terrain surface is obtained through ray casting into the terrain contact model. The return
     /// value is 'true' if the ray intersection succeeded and 'false' otherwise (in which case the output is set to
-    /// heigh=0, normal=world vertical, and friction=0.8).
+    /// height=0, normal=world vertical, and friction=0.8).
     bool FindPoint(const ChVector3d loc, double& height, ChVector3d& normal, float& friction) const;
 
     /// Set common collision family for patches. Default: 14.

--- a/src/chrono_vehicle/terrain/SCMTerrain.h
+++ b/src/chrono_vehicle/terrain/SCMTerrain.h
@@ -255,7 +255,7 @@ class CH_VEHICLE_API SCMTerrain : public ChTerrain {
     /// Initialize the terrain system (height map).
     /// The initial undeformed terrain profile is provided via the specified image file as a height map.
     /// The terrain patch is scaled in the horizontal plane of the SCM frame to sizeX x sizeY, while the initial height
-    /// is scaled between hMin and hMax (with the former corresponding to a pure balck pixel and the latter to a pure
+    /// is scaled between hMin and hMax (with the former corresponding to a pure black pixel and the latter to a pure
     /// white pixel).  The SCM grid resolution is specified through 'delta' and initial heights at grid points are
     /// obtained through interpolation (outside the terrain patch, the SCM node height is initialized to the height of
     /// the closest image pixel). For visualization purposes, a triangular mesh is also generated from the provided
@@ -301,12 +301,12 @@ class CH_VEHICLE_API SCMTerrain : public ChTerrain {
     /// Modify the level of grid nodes from the given list.
     void SetModifiedNodes(const std::vector<NodeLevel>& nodes);
 
-    /// Return the cummulative contact force on the specified body  (due to interaction with the SCM terrain).
+    /// Return the cumulative contact force on the specified body  (due to interaction with the SCM terrain).
     /// The return value is true if the specified body experiences contact forces and false otherwise.
     /// If contact forces are applied to the body, they are reduced to the body center of mass.
     bool GetContactForceBody(std::shared_ptr<ChBody> body, ChVector3d& force, ChVector3d& torque) const;
 
-    /// Return the cummulative contact force on the specified mesh node (due to interaction with the SCM terrain).
+    /// Return the cumulative contact force on the specified mesh node (due to interaction with the SCM terrain).
     /// The return value is true if the specified node experiences contact forces and false otherwise.
     bool GetContactForceNode(std::shared_ptr<fea::ChNodeFEAxyz> node, ChVector3d& force) const;
 
@@ -323,7 +323,7 @@ class CH_VEHICLE_API SCMTerrain : public ChTerrain {
     double GetTimerActiveDomains() const;
     /// Return time for geometric ray intersection tests at last step (ms).
     double GetTimerRayTesting() const;
-    /// Return time for ray casting at last step (ms). Includes time for ray intersectin testing.
+    /// Return time for ray casting at last step (ms). Includes time for ray intersection testing.
     double GetTimerRayCasting() const;
     /// Return time for computing contact patches at last step (ms).
     double GetTimerContactPatches() const;
@@ -350,14 +350,14 @@ class CH_VEHICLE_API SCMTerrain : public ChTerrain {
 /// Parameters for soil-contactable interaction.
 class CH_VEHICLE_API SCMContactableData {
   public:
-    SCMContactableData(double area_ratio,     ///< area fraction with overriden parameters (in [0,1])
+    SCMContactableData(double area_ratio,     ///< area fraction with overridden parameters (in [0,1])
                        double Mohr_cohesion,  ///< cohesion for shear failure [Pa]
                        double Mohr_friction,  ///< friction angle for shear failure [degree]
                        double Janosi_shear    ///< shear parameter in Janosi-Hanamoto formula [m]
     );
 
   private:
-    double area_ratio;     ///< fraction of contactable surface where soil-soil parameters are overriden
+    double area_ratio;     ///< fraction of contactable surface where soil-soil parameters are overridden
     double Mohr_cohesion;  ///< cohesion for shear failure [Pa]
     double Mohr_mu;        ///< coefficient of friction for shear failure [degree]
     double Janosi_shear;   ///< shear parameter in Janosi-Hanamoto formula [m]

--- a/src/chrono_vehicle/tracked_vehicle/ChTrackAssembly.h
+++ b/src/chrono_vehicle/tracked_vehicle/ChTrackAssembly.h
@@ -182,7 +182,7 @@ class CH_VEHICLE_API ChTrackAssembly : public ChPart {
     );
 
     /// Update the state of this track assembly at the current time.
-    /// This version is called if co-simulating with an external terain system.
+    /// This version is called if co-simulating with an external terrain system.
     void Synchronize(double time,                      ///< [in] current time
                      double braking,                   ///< [in] braking driver input
                      const TerrainForces& shoe_forces  ///< [in] vector of tire force structures

--- a/src/chrono_vehicle/tracked_vehicle/idler/ChDistanceIdler.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/idler/ChDistanceIdler.cpp
@@ -16,7 +16,7 @@
 // An idler consists of the idler wheel and a carrier body. The carrier body is
 // connected to the chassis and the idler wheel to the carrier. A linear
 // actuator connects the carrier body and a link body (the chassis or a
-// supsension arm).
+// suspension arm).
 //
 // The reference frame for a vehicle follows the ISO standard: Z-axis up, X-axis
 // pointing forward, and Y-axis towards the left of the vehicle.

--- a/src/chrono_vehicle/tracked_vehicle/idler/ChDistanceIdler.h
+++ b/src/chrono_vehicle/tracked_vehicle/idler/ChDistanceIdler.h
@@ -16,7 +16,7 @@
 // An idler consists of the idler wheel and a carrier body. The carrier body is
 // connected to the chassis and the idler wheel to the carrier. A linear
 // actuator connects the carrier body and a link body (the chassis or a
-// supsension arm).
+// suspension arm).
 //
 // An idler subsystem is defined with respect to a frame centered at the origin
 // of the idler wheel.
@@ -47,7 +47,7 @@ class ChTrackAssembly;
 
 /// Base class for an idler subsystem with a fixed distance tensioner.
 /// An idler consists of the idler wheel and a carrier body. The carrier body is connected to the chassis and the idler
-/// wheel to the carrier. A linear actuator connects the carrier body and a link body (the chassis or a supsension arm).
+/// wheel to the carrier. A linear actuator connects the carrier body and a link body (the chassis or a suspension arm).
 class CH_VEHICLE_API ChDistanceIdler : public ChIdler {
   public:
     ChDistanceIdler(const std::string& name);

--- a/src/chrono_vehicle/tracked_vehicle/sprocket/ChSprocketBand.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/sprocket/ChSprocketBand.cpp
@@ -153,8 +153,8 @@ class SprocketBandContactCB : public ChSystem::CustomCollisionCallback {
         minfo.Y = 1e7f;
         m_material = minfo.CreateMaterial(m_sprocket->GetGearBody()->GetSystem()->GetContactMethod());
 
-        // Since the shoe has not been initalized yet, set a flag to cache all of the parameters that depend on the shoe
-        // being initalized
+        // Since the shoe has not been initialized yet, set a flag to cache all of the parameters that depend on the shoe
+        // being initialized
         m_update_tread = true;
     }
 
@@ -234,7 +234,7 @@ void SprocketBandContactCB::OnCustomCollision(ChSystem* system) {
     if (m_track->GetNumTrackShoes() == 0)
         return;
 
-    // Temporary workaround since the shoe has not been intialized by the time the collision constructor is called.
+    // Temporary workaround since the shoe has not been initialized by the time the collision constructor is called.
     if (m_update_tread) {
         m_update_tread = false;
 
@@ -343,7 +343,7 @@ void SprocketBandContactCB::CheckTreadSegmentSprocket(std::shared_ptr<ChTrackSho
     ChVector2d tooth_center_p(tooth_center_p_3d.x(), tooth_center_p_3d.z());
 
     // Calculate the tooth arc starting point and end points in the sprocket frame
-    // Don't add in the tooth_center_p point postion since it will get subtracted off to calculate the angle
+    // Don't add in the tooth_center_p point position since it will get subtracted off to calculate the angle
     // This leads to the tooth arc angles in the sprocket frame
     ChVector2d tooth_arc_start_point_p = m_tread_arc_radius * std::cos(m_tread_center_p_start_angle) * tooth_x_axis +
                                          m_tread_arc_radius * std::sin(m_tread_center_p_start_angle) * tooth_z_axis;
@@ -388,7 +388,7 @@ void SprocketBandContactCB::CheckTreadSegmentSprocket(std::shared_ptr<ChTrackSho
     ChVector2d tooth_center_m(tooth_center_m_3d.x(), tooth_center_m_3d.z());
 
     // Calculate the tooth arc starting point and end points in the sprocket frame
-    // Don't add in the tooth_center_m point postion since it will get subtracted off to calculate the angle
+    // Don't add in the tooth_center_m point position since it will get subtracted off to calculate the angle
     // This leads to the tooth arc angles in the sprocket frame
     ChVector2d tooth_arc_start_point_m = m_tread_arc_radius * std::cos(m_tread_center_m_start_angle) * tooth_x_axis +
                                          m_tread_arc_radius * std::sin(m_tread_center_m_start_angle) * tooth_z_axis;
@@ -588,7 +588,7 @@ void SprocketBandContactCB::CheckTreadArcSprocketArc(std::shared_ptr<ChTrackShoe
 
 // Working in the (x-z) plane, perform a 2D collision test between the circle of radius 'cr'
 // centered at the origin (on the sprocket body) and the line segment with endpoints 'p1' and 'p2'
-// (on the Belt Segement body).
+// (on the Belt Segment body).
 void SprocketBandContactCB::CheckSegmentCircle(std::shared_ptr<ChTrackShoeBand> shoe,  // track shoe
                                                double cr,                              // circle radius
                                                const ChVector3d& p1,                   // segment end point 1
@@ -711,7 +711,7 @@ std::shared_ptr<ChLinePath> ChSprocketBand::GetProfile() const {
     // and the outer line segment edge of the tooth's base width
     double HalfBaseWidthCordAng = std::asin((BaseLen / 2) / OutRad);
 
-    // The angle measured at the center of the sprocket bewteen the end of one tooth profile
+    // The angle measured at the center of the sprocket between the end of one tooth profile
     // and the start of the next (angle where the profile runs along the outer radius
     // of the sprocket)
     double OuterRadArcAng = EntireToothArcAng - 2 * HalfBaseWidthCordAng;

--- a/src/chrono_vehicle/tracked_vehicle/sprocket/ChSprocketDoublePin.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/sprocket/ChSprocketDoublePin.cpp
@@ -306,7 +306,7 @@ void SprocketDoublePinContactCB::CheckCircleProfile(std::shared_ptr<ChBody> conn
 // centered at 'cc' (on the connector body) and an arc on the circle of radius 'ar' centered
 // at 'ac', with the arc endpoints 'p1' and 'p2' (on the gear body).
 void SprocketDoublePinContactCB::CheckCircleArc(std::shared_ptr<ChBody> connector,                 // connector body
-                                                std::shared_ptr<ChContactMaterial> mat_connector,  // conector material
+                                                std::shared_ptr<ChContactMaterial> mat_connector,  // connector material
                                                 const ChVector3d& cc,                              // circle center
                                                 double cr,                                         // circle radius
                                                 const ChVector3d ac,                               // arc center
@@ -361,7 +361,7 @@ void SprocketDoublePinContactCB::CheckCircleArc(std::shared_ptr<ChBody> connecto
 // (on the gear body).
 void SprocketDoublePinContactCB::CheckCircleSegment(
     std::shared_ptr<ChBody> connector,                 // connector body
-    std::shared_ptr<ChContactMaterial> mat_connector,  // conector material
+    std::shared_ptr<ChContactMaterial> mat_connector,  // connector material
     const ChVector3d& cc,                              // circle center
     double cr,                                         // circle radius
     const ChVector3d& p1,                              // segment end point 1

--- a/src/chrono_vehicle/tracked_vehicle/test_rig/ChTrackTestRig.h
+++ b/src/chrono_vehicle/tracked_vehicle/test_rig/ChTrackTestRig.h
@@ -221,7 +221,7 @@ class CH_VEHICLE_API ChTrackTestRig : public ChVehicle {
     std::shared_ptr<ChTrackTestRigDriver> m_driver;  ///< driver system
     double m_throttle_input;                         ///< current driver throttle input
     std::vector<double> m_displ_input;               ///< current post displacement inputs
-    std::string m_driver_logfile;                    ///< name of optioinal driver log file
+    std::string m_driver_logfile;                    ///< name of optional driver log file
 
     double m_ride_height;   ///< ride height
     double m_displ_offset;  ///< post displacement offset (to set reference position)

--- a/src/chrono_vehicle/tracked_vehicle/test_rig/ChTrackTestRigDriver.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/test_rig/ChTrackTestRigDriver.cpp
@@ -49,7 +49,7 @@ bool ChTrackTestRigDriver::Started() const {
 }
 
 // -----------------------------------------------------------------------------
-// Initialize output file for recording deriver inputs.
+// Initialize output file for recording driver inputs.
 // -----------------------------------------------------------------------------
 bool ChTrackTestRigDriver::LogInit(const std::string& filename) {
     m_log_filename = filename;

--- a/src/chrono_vehicle/tracked_vehicle/test_rig/ChTrackTestRigRoadDriver.h
+++ b/src/chrono_vehicle/tracked_vehicle/test_rig/ChTrackTestRigRoadDriver.h
@@ -66,7 +66,7 @@ class CH_VEHICLE_API ChTrackTestRigRoadDriver : public ChTrackTestRigDriver {
     double m_speed;               ///< vehicle speed over road profile
     ChCubicSpline* m_curve_road;  ///< spline for road profile
     double m_min;                 ///< first value of road x
-    double m_max;                 ///< last value fo road x
+    double m_max;                 ///< last value of road x
     bool m_ended;                 ///< flag indicating end of input data
 };
 

--- a/src/chrono_vehicle/tracked_vehicle/track_assembly/ChTrackAssemblyBand.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/track_assembly/ChTrackAssemblyBand.cpp
@@ -13,7 +13,7 @@
 // =============================================================================
 //
 // Base class for continuous band track assembly using rigid tread.
-// Derived classes specify the actual template defintions, using different track
+// Derived classes specify the actual template definitions, using different track
 // shoes.
 //
 // The reference frame for a vehicle follows the ISO standard: Z-axis up, X-axis
@@ -116,11 +116,11 @@ bool ChTrackAssemblyBand::FindAssemblyPoints(std::shared_ptr<ChBodyAuxRef> chass
     // Vector to save the indices of the circles that form the boundaries of the belt wrap
     std::vector<int> CircleIndex(CirclePosAll.size());
 
-    // At most each circle is visted once.  Something went wrong if
+    // At most each circle is visited once.  Something went wrong if
     // the loop is not closed within this many passes through the algorithm
     int iter;
     for (iter = 0; iter < CirclePosAll.size(); iter++) {
-        // Step 2: Create an ordered list of the circles with repect to their
+        // Step 2: Create an ordered list of the circles with respect to their
         // distance from the starting circle
 
         std::vector<double> Distances;
@@ -186,7 +186,7 @@ bool ChTrackAssemblyBand::FindAssemblyPoints(std::shared_ptr<ChBodyAuxRef> chass
                 Angle2 += CH_2PI;
             }
 
-            // If this is the first point that is examined, then save that point as the inital comparison value.
+            // If this is the first point that is examined, then save that point as the initial comparison value.
             if (i == 0) {
                 minAngle = Angle1;
                 TangentPoints[iter].first = Tan1Pnt1;
@@ -249,7 +249,7 @@ bool ChTrackAssemblyBand::FindAssemblyPoints(std::shared_ptr<ChBodyAuxRef> chass
     // Fit the track around the outermost wrapping.
     //
     // Start the iterations with the scale such that the belt length equals the
-    // outer wrapping circumferance(too small of a scale, but not by much).
+    // outer wrapping circumference (too small of a scale, but not by much).
     // After that, overshoot the extra length by a factor of 10 to make sure
     // that the scale is too large.
     // Then binary search tree on the scale to converge.
@@ -262,7 +262,7 @@ bool ChTrackAssemblyBand::FindAssemblyPoints(std::shared_ptr<ChBodyAuxRef> chass
     double ScaleMax = 0;
 
     // Start by calculating the original tangent(constant) and arc lengths (variable)
-    // to determine the inital scale for sprocket/idler/road wheel circles
+    // to determine the initial scale for sprocket/idler/road wheel circles
 
     double CombineShoeLength = 0;
     for (int i = 0; i < connection_lengths.size(); i++) {
@@ -442,7 +442,7 @@ bool ChTrackAssemblyBand::FindAssemblyPoints(std::shared_ptr<ChBodyAuxRef> chass
             }
 
             ExtraLength = 0;
-            // Check to see if I have wrapped past the inital point
+            // Check to see if I have wrapped past the initial point
             if ((!InitalSprocketWrap) && (CurrentFeature == 0)) {
                 CurrentAngle = std::atan2(Point.y() - CirclePos[0].y(), Point.x() - CirclePos[0].x());
                 while (CurrentAngle < Features(0, 3)) {

--- a/src/chrono_vehicle/tracked_vehicle/track_assembly/ChTrackAssemblyBand.h
+++ b/src/chrono_vehicle/tracked_vehicle/track_assembly/ChTrackAssemblyBand.h
@@ -13,7 +13,7 @@
 // =============================================================================
 //
 // Base class for continuous band track assembly using rigid tread.
-// Derived classes specify the actual template defintions, using different track
+// Derived classes specify the actual template definitions, using different track
 // shoes.
 //
 // The reference frame for a vehicle follows the ISO standard: Z-axis up, X-axis
@@ -41,7 +41,7 @@ namespace vehicle {
 /// A track assembly consists of a sprocket, an idler (with tensioner mechanism),
 /// a set of suspensions (road-wheel assemblies), and a collection of track shoes.
 /// This is the base class for continuous band track assembly using rigid tread.
-/// Derived classes specify the actual template defintions, using different track shoes.
+/// Derived classes specify the actual template definitions, using different track shoes.
 class CH_VEHICLE_API ChTrackAssemblyBand : public ChTrackAssembly {
   public:
     ChTrackAssemblyBand(const std::string& name,  ///< [in] name of the subsystem

--- a/src/chrono_vehicle/tracked_vehicle/track_assembly/ChTrackAssemblyBandANCF.h
+++ b/src/chrono_vehicle/tracked_vehicle/track_assembly/ChTrackAssemblyBandANCF.h
@@ -84,7 +84,7 @@ class CH_VEHICLE_API ChTrackAssemblyBandANCF : public ChTrackAssemblyBand {
     void SetElementStructuralDamping(double alpha);
 
     /// Set fiber angle for the three layers.
-    void SetLayerFiberAngles(double angle_1,  ///< fiber angle for bottom (outter) rubber layer (default: 0 rad)
+    void SetLayerFiberAngles(double angle_1,  ///< fiber angle for bottom (outer) rubber layer (default: 0 rad)
                              double angle_2,  ///< fiber angle for middle steel layer (default: 0 rad)
                              double angle_3   ///< fiber angle for top (inner) rubber layer (default: 0 rad)
     );

--- a/src/chrono_vehicle/tracked_vehicle/track_shoe/ChTrackShoeBand.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/track_shoe/ChTrackShoeBand.cpp
@@ -59,7 +59,7 @@ ChTrackShoeBand::ChTrackShoeBand(const std::string& name) : ChTrackShoe(name) {}
 void ChTrackShoeBand::Construct(std::shared_ptr<ChChassis> chassis,
                                 const ChVector3d& location,
                                 const ChQuaternion<>& rotation) {
-    // Cache the postive (+x) tooth arc position and arc starting and ending angles
+    // Cache the positive (+x) tooth arc position and arc starting and ending angles
     ChVector2d tooth_base_p(GetToothBaseLength() / 2, GetWebThickness() / 2);
     ChVector2d tooth_tip_p(GetToothTipLength() / 2, GetToothHeight() + GetWebThickness() / 2);
     m_center_p = CalcCircleCenter(tooth_base_p, tooth_tip_p, GetToothArcRadius(), -1);
@@ -188,7 +188,7 @@ void ChTrackShoeBand::AddShoeVisualization() {
 }
 
 // -----------------------------------------------------------------------------
-// Utilties for writing/exporting the tooth visualization mesh
+// Utilities for writing/exporting the tooth visualization mesh
 // -----------------------------------------------------------------------------
 void ChTrackShoeBand::WriteTreadVisualizationMesh(const std::string& out_dir) {
     auto mesh_shape1 = ToothMesh(GetBeltWidth() / 2 - GetToothWidth() / 2);

--- a/src/chrono_vehicle/tracked_vehicle/track_shoe/ChTrackShoeDoublePin.h
+++ b/src/chrono_vehicle/tracked_vehicle/track_shoe/ChTrackShoeDoublePin.h
@@ -147,11 +147,11 @@ class CH_VEHICLE_API ChTrackShoeDoublePin : public ChTrackShoeSegmented {
     );
 
     /// Add visualization of a connector body based on primitives corresponding to the contact shapes.
-    /// This version used with the two-conector topology.
+    /// This version used with the two-connector topology.
     void AddConnectorVisualization2(std::shared_ptr<ChBody> connector, VisualizationType vis);
 
     /// Add visualization of a connector body based on primitives corresponding to the contact shapes.
-    /// This version used with the one-conector topology.
+    /// This version used with the one-connector topology.
     void AddConnectorVisualization1(std::shared_ptr<ChBody> connector, VisualizationType vis);
 
     virtual void EnableTrackBendingStiffness(bool val) override final;

--- a/src/chrono_vehicle/tracked_vehicle/track_shoe/TrackShoeDoublePin.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/track_shoe/TrackShoeDoublePin.cpp
@@ -95,7 +95,7 @@ void TrackShoeDoublePin::Create(const rapidjson::Document& d) {
     }
     m_ground_geometry.materials = m_geometry.materials;
 
-    // Read geometric collison data
+    // Read geometric collision data
     int num_shapes = d["Contact"]["Shoe Shapes"].Size();
     assert(num_shapes > 0);
 

--- a/src/chrono_vehicle/tracked_vehicle/track_shoe/TrackShoeSinglePin.cpp
+++ b/src/chrono_vehicle/tracked_vehicle/track_shoe/TrackShoeSinglePin.cpp
@@ -76,7 +76,7 @@ void TrackShoeSinglePin::Create(const rapidjson::Document& d) {
     }
     m_ground_geometry.materials = m_geometry.materials;
 
-    // Read geometric collison data
+    // Read geometric collision data
     m_cyl_radius = d["Contact"]["Cylinder Shape"]["Radius"].GetDouble();
     m_front_cyl_loc = d["Contact"]["Cylinder Shape"]["Front Offset"].GetDouble();
     m_rear_cyl_loc = d["Contact"]["Cylinder Shape"]["Rear Offset"].GetDouble();

--- a/src/chrono_vehicle/utils/ChSteeringController.cpp
+++ b/src/chrono_vehicle/utils/ChSteeringController.cpp
@@ -445,7 +445,7 @@ ChPathSteeringControllerSR::ChPathSteeringControllerSR(std::shared_ptr<ChBezierC
       m_delta_max(max_wheel_turn_angle),
       m_umin(2),
       m_idx_curr(0) {
-    // retireve points
+    // retrieve points
     CalcPathPoints();
 }
 
@@ -461,7 +461,7 @@ ChPathSteeringControllerSR::ChPathSteeringControllerSR(const std::string& filena
       m_delta_max(max_wheel_turn_angle),
       m_umin(1),
       m_idx_curr(0) {
-    // retireve points
+    // retrieve points
     CalcPathPoints();
 
     Document d;

--- a/src/chrono_vehicle/utils/ChSteeringController.h
+++ b/src/chrono_vehicle/utils/ChSteeringController.h
@@ -187,7 +187,7 @@ class CH_VEHICLE_API ChPathSteeringController : public ChSteeringController {
 /// The path to be followed is specified as a ChBezierCurve object and the target point is defined to be the point on
 /// that path that is closest to the current location of the sentinel point. The sentinel point should never leave the
 /// end or beginning of the path.
-/// The controller is sensitive to tire relaxiation, when steering oscillations occure and do not calm down after a
+/// The controller is sensitive to tire relaxation, when steering oscillations occur and do not calm down after a
 /// short driving distance, Kp should be reduced carefully.
 class CH_VEHICLE_API ChPathSteeringControllerXT : public ChSteeringController {
   public:
@@ -302,9 +302,9 @@ class CH_VEHICLE_API ChPathSteeringControllerSR : public ChSteeringController {
     double m_Klat;       ///< lateral controller gain factor
     double m_Kug;        ///< understeering gradient in °/g, can be set to 0 if unknown
     double m_Tp;         ///< prediction time
-    double m_L;          ///< effective axlespace (bycicle model)
-    double m_delta;      ///< average turn angle of the steered wheels (bycicle model of the vehicle)
-    double m_delta_max;  ///< max. allowed average turn angle of the steered wheels (bycicle model of the vehicle)
+    double m_L;          ///< effective axlespace (bicycle model)
+    double m_delta;      ///< average turn angle of the steered wheels (bicycle model of the vehicle)
+    double m_delta_max;  ///< max. allowed average turn angle of the steered wheels (bicycle model of the vehicle)
     double m_umin;       ///< threshold where the controller gets active
 
     size_t m_idx_curr;             ///< current interval index
@@ -315,7 +315,7 @@ class CH_VEHICLE_API ChPathSteeringControllerSR : public ChSteeringController {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-/// "Stanley" path-following ontroller named after an autonomous vehicle called Stanley.
+/// "Stanley" path-following controller named after an autonomous vehicle called Stanley.
 /// It minimizes lateral error and heading error. Time delay of the driver's reaction is considered.
 /// This driver can be parametrized by a PID json file. It can consider a dead zone left and right to the
 /// path, where no path information is recognized. This can be useful when the path information contains
@@ -374,8 +374,8 @@ class CH_VEHICLE_API ChPathSteeringControllerStanley : public ChSteeringControll
     double m_Ki;  ///< Integral gain
     double m_Kd;  ///< Differential gain
 
-    double m_delta;      ///< average turn angle of the steered wheels (bycicle model of the vehicle)
-    double m_delta_max;  ///< max. allowed average turn angle of the steered wheels (bycicle model of the vehicle)
+    double m_delta;      ///< average turn angle of the steered wheels (bicycle model of the vehicle)
+    double m_delta_max;  ///< max. allowed average turn angle of the steered wheels (bicycle model of the vehicle)
     double m_umin;       ///< threshold where the controller gets active
     double m_Treset;     ///< the integral error gets reset after this time automatically, no wind-up should happen
     double m_deadZone;  ///< lateral zone where no lateral error is recognized, reduces sensitivity to path disturbances

--- a/src/chrono_vehicle/visualization/ChVehicleVisualSystemIrrlicht.cpp
+++ b/src/chrono_vehicle/visualization/ChVehicleVisualSystemIrrlicht.cpp
@@ -824,7 +824,7 @@ ChJoystickAxisIRR::ChJoystickAxisIRR()
 
 double ChJoystickAxisIRR::GetValue(const irr::SEvent::SJoystickEvent& joystickEvent) {
     if (joystickEvent.Joystick == id) {
-        // Scale raw_value fromm [scaled_min, scaled_max] to [min, max] range
+        // Scale raw_value from [scaled_min, scaled_max] to [min, max] range
         value = (joystickEvent.Axis[axis] - max) * (scaled_max - scaled_min) / (max - min) + scaled_max;
     }
     return value;

--- a/src/chrono_vehicle/visualization/ChVehicleVisualSystemVSG.cpp
+++ b/src/chrono_vehicle/visualization/ChVehicleVisualSystemVSG.cpp
@@ -209,7 +209,7 @@ void ShowHelp() {
     if (ImGui::CollapsingHeader("Vehicle controls", ImGuiTreeNodeFlags_DefaultOpen)) {
         ImGui::BulletText("Drive and steering controls");
         ImGui::Indent();
-        ImGui::TextUnformatted("W/S: acceleartion/decceleration (combined throttle/brake controls)");
+        ImGui::TextUnformatted("W/S: acceleration/deceleration (combined throttle/brake controls)");
         ImGui::TextUnformatted("A/D: steering (left/right)");
         ImGui::TextUnformatted("C: center steering wheel (set steering=0)");
         ImGui::TextUnformatted("R: release pedals (set throttle=brake=clutch=0)");

--- a/src/chrono_vehicle/wheeled_vehicle/ChTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/ChTire.h
@@ -243,7 +243,7 @@ class CH_VEHICLE_API ChTire : public ChPart {
         float& mu                       ///< [out] coefficient of friction at contact
     );
 
-    /// Collsion algorithm based on a paper of J. Shane Sui and John A. Hirshey II:
+    /// Collision algorithm based on a paper of J. Shane Sui and John A. Hirshey II:
     /// "A New Analytical Tire Model for Vehicle Dynamic Analysis" presented at 2001 MSC User Meeting
     static bool DiscTerrainCollisionEnvelope(
         const ChTerrain& terrain,         ///< [in] reference to terrain system

--- a/src/chrono_vehicle/wheeled_vehicle/driveline/ChShaftsDriveline2WD.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/driveline/ChShaftsDriveline2WD.cpp
@@ -79,7 +79,7 @@ void ChShaftsDriveline2WD::Initialize(std::shared_ptr<ChChassis> chassis,
     sys->AddShaft(m_differentialbox);
 
     // Create an angled gearbox, i.e a transmission ratio constraint between two
-    // non parallel shafts. This is the case of the 90° bevel gears in the
+    // non parallel shafts. This is the case of the 90ï¿½ bevel gears in the
     // differential. Note that, differently from the basic ChShaftsGear, this also
     // provides the possibility of transmitting a reaction torque to the box
     // (the truss).
@@ -116,7 +116,7 @@ void ChShaftsDriveline2WD::LockAxleDifferential(int axle, bool lock) {
 }
 
 void ChShaftsDriveline2WD::LockCentralDifferential(int which, bool lock) {
-    std::cerr << "WARNINIG: " << GetTemplateName() << " does not contain a central differential." << std::endl;
+    std::cerr << "WARNING: " << GetTemplateName() << " does not contain a central differential." << std::endl;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/chrono_vehicle/wheeled_vehicle/driveline/ChSimpleDriveline.h
+++ b/src/chrono_vehicle/wheeled_vehicle/driveline/ChSimpleDriveline.h
@@ -92,7 +92,7 @@ class CH_VEHICLE_API ChSimpleDriveline : public ChDrivelineWV {
   private:
     bool m_connected;
     double m_zero_torque;                    ///< zero band for motor torque
-    double m_driveshaft_speed;               ///< output to transmisson
+    double m_driveshaft_speed;               ///< output to transmission
     std::shared_ptr<ChShaft> m_front_left;   ///< associated front left wheel axle
     std::shared_ptr<ChShaft> m_front_right;  ///< associated front right wheel axle
     std::shared_ptr<ChShaft> m_rear_left;    ///< associated rear left wheel axle

--- a/src/chrono_vehicle/wheeled_vehicle/suspension/ChSAELeafspringAxle.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/suspension/ChSAELeafspringAxle.cpp
@@ -26,7 +26,7 @@
 // the lateral compliance of the leafspring. The leaves (front and rear) are connected
 // to clampA rsp. clampB via rotational joints around Y. The frontleaf also connects
 // to the chassis with a spherical joint, while the rearleaf connects to the shackle
-// body with a sperical joint. The shackle body connects to the chassis via a
+// body with a spherical joint. The shackle body connects to the chassis via a
 // rotational joint around Y.
 //
 // The vertical stiffnesses are simulated by the rotational springs of the frontleaf
@@ -34,8 +34,8 @@
 // joints of the clamp bodies.
 //
 // For the stiffness parameters the user can take the desired translatoric vertical
-// stiffness devided by two (we have two leaves). The preload can be set as a
-// vertical force devided by two. The conversion to the rotary setup is made
+// stiffness divided by two (we have two leaves). The preload can be set as a
+// vertical force divided by two. The conversion to the rotary setup is made
 // automatically.
 //
 // The SAE model allows to consider the correct axle movement due to wheel travel.

--- a/src/chrono_vehicle/wheeled_vehicle/suspension/ChSAELeafspringAxle.h
+++ b/src/chrono_vehicle/wheeled_vehicle/suspension/ChSAELeafspringAxle.h
@@ -24,7 +24,7 @@
 // the lateral compliance of the leafspring. The leaves (front and rear) are connected
 // to clampA rsp. clampB via rotational joints around Y. The frontleaf also connects
 // to the chassis with a spherical joint, while the rearleaf connects to the shackle
-// body with a sperical joint. The shackle body connects to the chassis via a
+// body with a spherical joint. The shackle body connects to the chassis via a
 // rotational joint around Y.
 //
 // The vertical stiffnesses are simulated by the rotational springs of the frontleaf
@@ -32,8 +32,8 @@
 // joints of the clamp bodies.
 //
 // For the stiffness parameters the user can take the desired translatoric vertical
-// stiffness devided by two (we have two leaves). The preload can be set as a
-// vertical force devided by two. The conversion to the rotary setup is made
+// stiffness divided by two (we have two leaves). The preload can be set as a
+// vertical force divided by two. The conversion to the rotary setup is made
 // automatically.
 //
 // The SAE model allows to consider the correct axle movement due to wheel travel.
@@ -86,7 +86,7 @@ namespace vehicle {
 /// the lateral compliance of the leafspring. The leaves (front and rear) are connected
 /// to clampA rsp. clampB via rotational joints around Y. The frontleaf also connects
 /// to the chassis with a spherical joint, while the rearleaf connects to the shackle
-/// body with a sperical joint. The shackle body connects to the chassis via a
+/// body with a spherical joint. The shackle body connects to the chassis via a
 /// rotational joint around Y.
 ///
 /// The vertical stiffnesses are simulated by the rotational springs of the frontleaf
@@ -94,8 +94,8 @@ namespace vehicle {
 /// joints of the clamp bodies.
 ///
 /// For the stiffness parameters the user can take the desired translatoric vertical
-/// stiffness devided by two (we have two leaves). The preload can be set as a
-/// vertical force devided by two. The conversion to the rotary setup is made
+/// stiffness divided by two (we have two leaves). The preload can be set as a
+/// vertical force divided by two. The conversion to the rotary setup is made
 /// automatically.
 ///
 /// The SAE model allows to consider the correct axle movement due to wheel travel.

--- a/src/chrono_vehicle/wheeled_vehicle/suspension/ChSAEToeBarLeafspringAxle.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/suspension/ChSAEToeBarLeafspringAxle.cpp
@@ -23,7 +23,7 @@
 // the lateral compliance of the leafspring. The leaves (front and rear) are connected
 // to clampA rsp. clampB via rotational joints around Y. The frontleaf also connects
 // to the chassis with a spherical joint, while the rearleaf connects to the shackle
-// body with a sperical joint. The shackle body connects to the chassis via a
+// body with a spherical joint. The shackle body connects to the chassis via a
 // rotational joint around Y.
 //
 // The vertical stiffnesses are simulated by the rotational springs of the frontleaf
@@ -31,8 +31,8 @@
 // joints of the clamp bodies.
 //
 // For the stiffness parameters the user can take the desired translatoric vertical
-// stiffness devided by two (we have two leaves). The preload can be set as a
-// vertical force devided by two. The conversion to the rotary setup is made
+// stiffness divided by two (we have two leaves). The preload can be set as a
+// vertical force divided by two. The conversion to the rotary setup is made
 // automatically.
 //
 // The SAE model allows to consider the correct axle movement due to wheel travel.

--- a/src/chrono_vehicle/wheeled_vehicle/suspension/ChSAEToeBarLeafspringAxle.h
+++ b/src/chrono_vehicle/wheeled_vehicle/suspension/ChSAEToeBarLeafspringAxle.h
@@ -24,7 +24,7 @@
 // the lateral compliance of the leafspring. The leaves (front and rear) are connected
 // to clampA rsp. clampB via rotational joints around Y. The frontleaf also connects
 // to the chassis with a spherical joint, while the rearleaf connects to the shackle
-// body with a sperical joint. The shackle body connects to the chassis via a
+// body with a spherical joint. The shackle body connects to the chassis via a
 // rotational joint around Y.
 //
 // The vertical stiffnesses are simulated by the rotational springs of the frontleaf
@@ -32,8 +32,8 @@
 // joints of the clamp bodies.
 //
 // For the stiffness parameters the user can take the desired translatoric vertical
-// stiffness devided by two (we have two leaves). The preload can be set as a
-// vertical force devided by two. The conversion to the rotary setup is made
+// stiffness divided by two (we have two leaves). The preload can be set as a
+// vertical force divided by two. The conversion to the rotary setup is made
 // automatically.
 //
 // The SAE model allows to consider the correct axle movement due to wheel travel.
@@ -79,7 +79,7 @@ namespace vehicle {
 /// the lateral compliance of the leafspring. The leaves (front and rear) are connected
 /// to clampA rsp. clampB via rotational joints around Y. The frontleaf also connects
 /// to the chassis with a spherical joint, while the rearleaf connects to the shackle
-/// body with a sperical joint. The shackle body connects to the chassis via a
+/// body with a spherical joint. The shackle body connects to the chassis via a
 /// rotational joint around Y.
 ///
 /// The vertical stiffnesses are simulated by the rotational springs of the frontleaf
@@ -87,8 +87,8 @@ namespace vehicle {
 /// joints of the clamp bodies.
 ///
 /// For the stiffness parameters the user can take the desired translatoric vertical
-/// stiffness devided by two (we have two leaves). The preload can be set as a
-/// vertical force devided by two. The conversion to the rotary setup is made
+/// stiffness divided by two (we have two leaves). The preload can be set as a
+/// vertical force divided by two. The conversion to the rotary setup is made
 /// automatically.
 ///
 /// The SAE model allows to consider the correct axle movement due to wheel travel.

--- a/src/chrono_vehicle/wheeled_vehicle/suspension/ChSemiTrailingArm.h
+++ b/src/chrono_vehicle/wheeled_vehicle/suspension/ChSemiTrailingArm.h
@@ -136,7 +136,7 @@ class CH_VEHICLE_API ChSemiTrailingArm : public ChSuspension {
     enum PointId {
         SPINDLE,   ///< spindle location (center of mass)
         TA_CM,     ///< trailing arm, center of mass
-        TA_O,      ///< trailing arm, chassis connection outter
+        TA_O,      ///< trailing arm, chassis connection outer
         TA_I,      ///< trailing arm, chassis connection inner
         TA_S,      ///< trailing arm, connection to spindle
         SHOCK_C,   ///< shock, chassis

--- a/src/chrono_vehicle/wheeled_vehicle/suspension/ChSolidBellcrankThreeLinkAxle.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/suspension/ChSolidBellcrankThreeLinkAxle.cpp
@@ -481,13 +481,13 @@ void ChSolidBellcrankThreeLinkAxle::AddVisualizationAssets(VisualizationType vis
     // visualize the axle tube
     AddVisualizationLink(m_axleTube, m_axleOuterL, m_axleOuterR, getAxleTubeRadius(), ChColor(0.7f, 0.7f, 0.7f));
 
-    // visualize the trangle body
+    // visualize the triangle body
     AddVisualizationLink(m_triangleBody, m_triangle_sph_point, m_triangle_left_point, getAxleTubeRadius() / 2.0,
                          ChColor(0.7f, 0.3f, 0.8f));
     AddVisualizationLink(m_triangleBody, m_triangle_sph_point, m_triangle_right_point, getAxleTubeRadius() / 2.0,
                          ChColor(0.7f, 0.3f, 0.8f));
 
-    // visualize the trangle body
+    // visualize the triangle body
     AddVisualizationLink(m_linkBody[LEFT], m_link_axleL, m_link_chassisL, getAxleTubeRadius() / 2.0,
                          ChColor(0.3f, 0.3f, 0.8f));
     AddVisualizationLink(m_linkBody[RIGHT], m_link_axleR, m_link_chassisR, getAxleTubeRadius() / 2.0,

--- a/src/chrono_vehicle/wheeled_vehicle/test_rig/ChTireTestRig.h
+++ b/src/chrono_vehicle/wheeled_vehicle/test_rig/ChTireTestRig.h
@@ -124,7 +124,7 @@ class CH_VEHICLE_API ChTireTestRig {
     void SetSlipAngleFunction(std::shared_ptr<ChFunction> funct) { m_sa_fun = funct; }
 
     /// Specify a constant given longitudinal slip. This version overrides the motion functions for the carrier
-    /// longitudinal slip and for the wheel angular speed to enfore the specified longitudinalslip value. A positive
+    /// longitudinal slip and for the wheel angular speed to enforce the specified longitudinalslip value. A positive
     /// slip value indicates that the wheel is spinning. A negative slip value indicates that the wheel is sliding
     /// (skidding); in particular, s=-1 indicates sliding without rotation.
     void SetConstantLongitudinalSlip(double long_slip, double base_speed = 1);
@@ -270,7 +270,7 @@ class CH_VEHICLE_API ChTireTestRig {
     std::shared_ptr<ChBody> m_slip_body;     ///< intermediate body for controlling slip angle
     std::shared_ptr<ChSpindle> m_spindle;    ///< wheel spindle
 
-    bool m_ls_actuated;                    ///< is linear spped actuated?
+    bool m_ls_actuated;                    ///< is linear speed actuated?
     bool m_rs_actuated;                    ///< is angular speed actuated?
     std::shared_ptr<ChFunction> m_ls_fun;  ///< longitudinal speed function of time
     std::shared_ptr<ChFunction> m_rs_fun;  ///< angular speed function of time

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChFialaTire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChFialaTire.cpp
@@ -149,7 +149,7 @@ void ChFialaTire::Advance(double step) {
 
     FialaPatchForces(Fx, Fy, Mz, m_states.kappa, m_states.alpha, m_data.normal_force);
 
-    // Smoothing factor dependend on m_state.abs_vx, allows soft switching of My
+    // Smoothing factor dependent on m_state.abs_vx, allows soft switching of My
     double myStartUp = ChFunctionSineStep::Eval(m_states.abs_vx, vx_min, 0.0, vx_max, 1.0);
     // Rolling Resistance
     My = -myStartUp * m_rolling_resistance * m_data.normal_force * ChSignum(m_states.omega);

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.cpp
@@ -86,7 +86,7 @@ double ChPac02Tire::GetNormalDampingForce(double depth, double velocity) const {
 void ChPac02Tire::CombinedCoulombForces(double& fx, double& fy, double fz) {
     ChVector2d F;
     /*
-     The Dahl Friction Model elastic tread blocks representated by a single bristle. At tire stand still it acts
+     The Dahl Friction Model elastic tread blocks represented by a single bristle. At tire stand still it acts
      like a spring which enables holding of a vehicle on a slope without creeping (hopefully). Damping terms
      have been added to calm down the oscillations of the pure spring.
 
@@ -98,7 +98,7 @@ void ChPac02Tire::CombinedCoulombForces(double& fx, double& fy, double fz) {
      differential equation:
          dz/dt = v - sigma0*z*abs(v)/fc
 
-     When z is known, the friction force F can be calulated to:
+     When z is known, the friction force F can be calculated to:
         F = sigma0 * z
 
      For practical use some damping is needed, that leads to:
@@ -145,7 +145,7 @@ void ChPac02Tire::CombinedCoulombForces(double& fx, double& fy, double fz) {
 
 void ChPac02Tire::CalcFxyMz(double& Fx, double& Fy, double& Mz, double kappa, double alpha, double Fz, double gamma) {
     // steady state calculation
-    double Fx0 = 0;  // longitudinal steady stae force
+    double Fx0 = 0;  // longitudinal steady state force
     double Cx = m_par.PCX1 * m_par.LCX;
     double Shx = (m_par.PHX1 + m_par.PHX2 * m_states.dfz0) * m_par.LHX;
     double Svx = Fz * (m_par.PVX1 + m_par.PVX2 * m_states.dfz0) * m_par.LVX * m_par.LMUX;
@@ -1708,7 +1708,7 @@ void ChPac02Tire::Initialize(std::shared_ptr<ChWheel> wheel) {
     // (used only with the ChTire::ENVELOPE method for terrain-tire collision detection)
     ConstructAreaDepthTable(m_par.UNLOADED_RADIUS, m_areaDep);
 
-    // all parameters are known now pepare mirroring
+    // all parameters are known now prepare mirroring
     if (m_allow_mirroring) {
         if (wheel->GetSide() != m_measured_side) {
             // we flip the sign of some parameters to compensate asymmetry

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac02Tire.h
@@ -178,7 +178,7 @@ class CH_VEHICLE_API ChPac02Tire : public ChForceElementTire {
         double DREFF = 0;               // Peak value of e.r.r.
         double FREFF = 0;               // High load stiffness e.r.r.
         double FNOMIN = 0;              // Nominal wheel load
-        double TIRE_MASS = 0;           // Tire mass (if belt dynmics is used)
+        double TIRE_MASS = 0;           // Tire mass (if belt dynamics is used)
         double QFZ1 = 0.0;              // Variation of vertical stiffness with deflection (linear)
         double QFZ2 = 0.0;              // Variation of vertical stiffness with deflection (quadratic)
         double QFZ3 = 0.0;              // Variation of vertical stiffness with inclination angle

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChPac89Tire.cpp
@@ -240,7 +240,7 @@ void ChPac89Tire::Advance(double step) {
         // Smoothing interval for My
         const double vx_min = 0.125;
         const double vx_max = 0.5;
-        // Smoothing factor dependend on m_state.abs_vx, allows soft switching of My
+        // Smoothing factor dependent on m_state.abs_vx, allows soft switching of My
         double myStartUp = ChFunctionSineStep::Eval(std::abs(m_states.vx), vx_min, 0.0, vx_max, 1.0);
         My = myStartUp * m_rolling_resistance * m_data.normal_force * Lrad * ChSignum(m_states.omega);
     }
@@ -255,7 +255,7 @@ void ChPac89Tire::Advance(double step) {
 void ChPac89Tire::CombinedCoulombForces(double& fx, double& fy, double fz, double muscale) {
     ChVector2d F;
     /*
-     The Dahl Friction Model elastic tread blocks representated by a single bristle. At tire stand still it acts
+     The Dahl Friction Model elastic tread blocks represented by a single bristle. At tire stand still it acts
      like a spring which enables holding of a vehicle on a slope without creeping (hopefully). Damping terms
      have been added to calm down the oscillations of the pure spring.
 
@@ -267,7 +267,7 @@ void ChPac89Tire::CombinedCoulombForces(double& fx, double& fy, double fz, doubl
      differential equation:
          dz/dt = v - sigma0*z*abs(v)/fc
 
-     When z is known, the friction force F can be calulated to:
+     When z is known, the friction force F can be calculated to:
         F = sigma0 * z
 
      For practical use some damping is needed, that leads to:

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.cpp
@@ -13,7 +13,7 @@
 // =============================================================================
 //
 // Template for the "Tire Model made Easy". Our implementation is a basic version
-// of the algorithms in http://www.tmeasy.de/, a comercial tire simulation code
+// of the algorithms in http://www.tmeasy.de/, a commercial tire simulation code
 // developed by Prof. Dr. Georg Rill.
 //
 //
@@ -24,7 +24,7 @@
 //      Georg Rill, "Simulation von Kraftfahrzeugen",
 //          https://www.researchgate.net/publication/317037037_Simulation_von_Kraftfahrzeugen
 //
-// Known differences to the comercial version:
+// Known differences to the commercial version:
 //  - No parking slip calculations
 //  - No dynamic parking torque
 //  - No dynamic tire inflation pressure
@@ -278,7 +278,7 @@ void ChTMeasyTire::Advance(double step) {
 void ChTMeasyTire::CombinedCoulombForces(double& fx, double& fy, double fz, double muscale) {
     ChVector2d F;
     /*
-     The Dahl Friction Model elastic tread blocks representated by a single bristle. At tire stand still it acts
+     The Dahl Friction Model elastic tread blocks represented by a single bristle. At tire stand still it acts
      like a spring which enables holding of a vehicle on a slope without creeping (hopefully). Damping terms
      have been added to calm down the oscillations of the pure spring.
 
@@ -290,7 +290,7 @@ void ChTMeasyTire::CombinedCoulombForces(double& fx, double& fy, double fz, doub
      differential equation:
          dz/dt = v - sigma0*z*abs(v)/fc
 
-     When z is known, the friction force F can be calulated to:
+     When z is known, the friction force F can be calculated to:
         F = sigma0 * z
 
      For practical use some damping is needed, that leads to:
@@ -627,7 +627,7 @@ void ChTMeasyTire::GuessPassCar70Par(double tireLoad,       // tire load force [
     m_par.sqe_p2n = 1.0714;
 }
 
-// Do some rough constency checks
+// Do some rough consistency checks
 bool ChTMeasyTire::CheckParameters() {
     // Nominal Load set?
     if (m_par.pn < GetTireMaxLoad(0)) {

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMeasyTire.h
@@ -13,7 +13,7 @@
 // =============================================================================
 //
 // Template for the "Tire Model made Easy". Our implementation is a basic version
-// of the algorithms in http://www.tmeasy.de/, a comercial tire simulation code
+// of the algorithms in http://www.tmeasy.de/, a commercial tire simulation code
 // developed by Prof. Dr. Georg Rill.
 //
 //
@@ -249,7 +249,7 @@ class CH_VEHICLE_API ChTMeasyTire : public ChForceElementTire {
         double q;                // Fz/Fz_nom
         double gamma;            // Inclination Angle
         double muscale;          // Scaling factor for Tire/Road friction
-        double vta;              // absolut transport velocity
+        double vta;              // absolute transport velocity
         double vsx;              // Longitudinal slip velocity
         double vsy;              // Lateral slip velocity = Lateral velocity
         double omega;            // Wheel angular velocity about its spin axis, filtered by running avg,

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMsimpleTire.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMsimpleTire.cpp
@@ -206,7 +206,7 @@ void ChTMsimpleTire::Advance(double step) {
 void ChTMsimpleTire::CombinedCoulombForces(double& fx, double& fy, double fz, double muscale) {
     ChVector2d F;
     /*
-     The Dahl Friction Model elastic tread blocks representated by a single bristle. At tire stand still it acts
+     The Dahl Friction Model elastic tread blocks represented by a single bristle. At tire stand still it acts
      like a spring which enables holding of a vehicle on a slope without creeping (hopefully). Damping terms
      have been added to calm down the oscillations of the pure spring.
 
@@ -218,7 +218,7 @@ void ChTMsimpleTire::CombinedCoulombForces(double& fx, double& fy, double fz, do
      differential equation:
          dz/dt = v - sigma0*z*abs(v)/fc
 
-     When z is known, the friction force F can be calulated to:
+     When z is known, the friction force F can be calculated to:
         F = sigma0 * z
 
      For practical use some damping is needed, that leads to:
@@ -541,7 +541,7 @@ void ChTMsimpleTire::GuessPassCar70Par(double tireLoad,       // tire load force
     SetHorizontalCoefficients();
 }
 
-// Do some rough constency checks
+// Do some rough consistency checks
 bool ChTMsimpleTire::CheckParameters() {
     // Nominal Load set?
     if (m_par.pn < GetTireMaxLoad(0)) {

--- a/src/chrono_vehicle/wheeled_vehicle/tire/ChTMsimpleTire.h
+++ b/src/chrono_vehicle/wheeled_vehicle/tire/ChTMsimpleTire.h
@@ -236,7 +236,7 @@ class CH_VEHICLE_API ChTMsimpleTire : public ChForceElementTire {
         double sy;               // Contact Path - Side Slip State (Alpha)
         double gamma;            // Inclination Angle
         double muscale;          // Scaling factor for Tire/Road friction
-        double vta;              // absolut transport velocity
+        double vta;              // absolute transport velocity
         double vsx;              // Longitudinal slip velocity
         double vsy;              // Lateral slip velocity = Lateral velocity
         double omega;            // Wheel angular velocity about its spin axis, filtered by running avg,


### PR DESCRIPTION
Found via `codespell -q 3 -S "./src/chrono_thirdparty" -L afile,childs,ges,ptd,seh,tread,yeld`