### PR TITLE
Fix syntax issue in MBS emit cluster demo

### DIFF
--- a/src/demos/python/mbs/demo_MBS_emit_cluster.py
+++ b/src/demos/python/mbs/demo_MBS_emit_cluster.py
@@ -172,7 +172,7 @@ sys.GetSolver().AsIterative().SetMaxIterations(40)
 sys.SetGravitationalAcceleration(chrono.ChVector3d(0, 0, 0))
 
 # Add one force accumulator to each body in the system
-for body in sys.GetBodies()
+for body in sys.GetBodies():
     body.AddAccumulator()
 
 # Simulation loop


### PR DESCRIPTION
## PR Summary
This small PR fixes a syntax issue (missing `:` in the for loop) in MBS emit cluster demo.