### PR TITLE
a couple more swig adjustments

### DIFF
--- a/src/chrono_swig/interface/irrlicht/ChModuleIrrlicht.i
+++ b/src/chrono_swig/interface/irrlicht/ChModuleIrrlicht.i
@@ -132,6 +132,7 @@ using namespace gui;
 %import(module="pychrono.core") "chrono_swig/interface/core/ChFrame.i"
 // %import(module="pychrono.core") "../../../chrono/functions/ChFunction.h"
 // %import(module="pychrono.core") "chrono_swig/interface/core/ChFunction.i"
+%import(module="pychrono.core") "chrono_swig/interface/core/ChObject.i" // ChObject should be imported before ChPhysicsItem
 %import(module="pychrono.core") "chrono_swig/interface/core/ChPhysicsItem.i"
 %import(module="pychrono.core") "chrono_swig/interface/core/ChVisualMaterial.i"
 %import(module="pychrono.core") "chrono_swig/interface/core/ChVisualShape.i"

--- a/src/chrono_swig/interface/irrlicht/ChVisualSystemIrrlicht.i
+++ b/src/chrono_swig/interface/irrlicht/ChVisualSystemIrrlicht.i
@@ -9,8 +9,6 @@
 ////#endif // --------------------------------------------------------------------- CSHARP
 
 %{
-#include "chrono/assets/ChVisualSystem.h"
-
 #include "chrono_irrlicht/ChIrrNodeShape.h"
 #include "chrono_irrlicht/ChIrrNodeModel.h"
 #include "chrono_irrlicht/ChVisualSystemIrrlicht.h"

--- a/src/chrono_swig/interface/vehicle/ChModuleVehicle.i
+++ b/src/chrono_swig/interface/vehicle/ChModuleVehicle.i
@@ -119,8 +119,6 @@
 
 #include "chrono_vehicle/tracked_vehicle/ChTrackContactManager.h"
 
-#include "chrono_vehicle/ChVehicleVisualSystem.h"
-
 // Vehicle models
 #include "chrono_models/ChApiModels.h"
 #include "chrono_models/vehicle/ChVehicleModelDefs.h"
@@ -424,6 +422,14 @@ Before adding a shared_ptr, mark as shared ptr all its inheritance tree in the m
 %include "chrono_swig/interface/models/VehicleModels.i"
 
 %include "vehicleUtils.i"
+
+#ifdef SWIGCSHARP  // --------------------------------------------------------------------- CSHARP
+// Import ChVisualSystem base class unconditionally (ChVehicleVisualSystem inherits from it)
+// Python gets this via module imports from pychrono.irrlicht or pychrono.vsg3d into appropriate module
+// but C# Unity with no visualisation module but with this vehicle module needs an unconditional
+// for SWIG to understand the inheritance
+%import "chrono_swig/interface/core/ChVisualSystem.i"
+#endif             // --------------------------------------------------------------------- CSHARP
 
 %include "../../../chrono_vehicle/ChVehicleVisualSystem.h" 
 

--- a/src/chrono_swig/interface/vehicle/ChVehicleVisualSystemIrrlicht.i
+++ b/src/chrono_swig/interface/vehicle/ChVehicleVisualSystemIrrlicht.i
@@ -57,9 +57,8 @@ using namespace irr::scene; // This is inserted for the extend functions that us
     // Extending the missing functions is a workaround
     //
 
-    // Visual Systems, in SWIG order, 1- ChVehicleVisualSystem, 2- ChVisualSystemIrrlicht, 3 - ChVehicleVisualSystemIrrlicht
+    // Visual Systems, in SWIG order, 1- ChVehicleVisualSystem (in base ChModuleVehicle.i), 2- ChVisualSystemIrrlicht, 3- ChVehicleVisualSystemIrrlicht
     // Ensure both base classes are fully defined before the derived MI class to avoid incomplete base warnings in C#.
-    %include "../../../chrono_vehicle/ChVehicleVisualSystem.h"
     %include "../../../chrono_irrlicht/ChVisualSystemIrrlicht.h"
     %include "../../../chrono_vehicle/visualization/ChVehicleVisualSystemIrrlicht.h"
 

--- a/src/chrono_swig/interface/vsg/ChModuleVsg.i
+++ b/src/chrono_swig/interface/vsg/ChModuleVsg.i
@@ -75,6 +75,7 @@ using namespace chrono::vsg3d;
 %import(module="pychrono.core") "chrono_swig/interface/core/ChFrame.i"
 // %import(module="pychrono.core") "../../../chrono/functions/ChFunction.h"
 // %import(module="pychrono.core") "chrono_swig/interface/core/ChFunction.i"
+%import(module="pychrono.core") "chrono_swig/interface/core/ChObject.i" // ChObject import before ChPhysicsItem
 %import(module="pychrono.core") "chrono_swig/interface/core/ChPhysicsItem.i"
 %import(module="pychrono.core") "chrono_swig/interface/core/ChVisualMaterial.i"
 %import(module="pychrono.core") "chrono_swig/interface/core/ChVisualShape.i"

--- a/src/chrono_swig/interface/vsg/ChVisualSystemVSG.i
+++ b/src/chrono_swig/interface/vsg/ChVisualSystemVSG.i
@@ -12,6 +12,9 @@ using namespace chrono::vsg3d;
 %shared_ptr(chrono::vsg3d::ChVisualSystemVSG)
 %shared_ptr(chrono::vsg3d::ChVisualSystemVSGPlugin)
 
+// Import base class ChVisualSystem (same pattern as in ChVisualSystemIrrlicht.i)
+%import(module="pychrono.core") "chrono_swig/interface/core/ChVisualSystem.i"
+
 /* Parse the header file to generate wrappers */
 %include "../../../chrono_vsg/ChVisualSystemVSG.h"    
 


### PR DESCRIPTION
removed double include of ChVehicleVisualSystem.h (line 122 and 80) and redundant include in ChVisualSystemIrrlicht

fixed ChObj swig warnings in some builds

added ChVisualSystem.i import to VSG visual system (for building when no vehicle module) in python - same pattern as the Irrlicht visual system import

tested against C# and python irrlicht and vsg (with and without vehicle module). and C# Unity with no visual module.