### PR TITLE
Fix operator *= on ChStateDelta

### DIFF
--- a/src/chrono/timestepper/ChState.h
+++ b/src/chrono/timestepper/ChState.h
@@ -175,7 +175,7 @@ class ChStateDelta : public ChVectorDynamic<double> {
 
     /// Scale this state by the given value.
     ChStateDelta& operator*=(double factor) {
-        ChVectorDynamic<>::operator*(factor);
+        ChVectorDynamic<>::operator*=(factor);
         return *this;
     }
 


### PR DESCRIPTION
ChStateDelta's operator *= is overridden, and uses the operator * of its base class (instead of *=), making a statement such as "Dv *= c;" not doing anything on the Dv vector.