### PR TITLE
swig wrapper adjustments for the Chtimestepper implicit classes

### DIFF
--- a/src/chrono_swig/interface/core/ChSystem.i
+++ b/src/chrono_swig/interface/core/ChSystem.i
@@ -29,12 +29,26 @@ void SetSolver(std::shared_ptr<ChSolverBiCGSTAB> solver) {$self->SetSolver(std::
 void SetSolver(std::shared_ptr<ChSolverMINRES> solver)   {$self->SetSolver(std::static_pointer_cast<ChSolver>(solver));}
 }
 
+// SetTimestepper overloads for implicit timesteppers (multiple inheritance workaround) use dynamic_pointer_cast for the multi-inheritance robustness
+// Recommend to use settimesteppertype() and 'gettimestepper() as XXXX' instead where possible to create new timesteppers
+%extend chrono::ChSystem
+{
+void SetTimestepper(std::shared_ptr<ChTimestepperEulerImplicit> stepper)           {$self->SetTimestepper(std::dynamic_pointer_cast<ChTimestepper>(stepper));}
+void SetTimestepper(std::shared_ptr<ChTimestepperEulerImplicitLinearized> stepper) {$self->SetTimestepper(std::dynamic_pointer_cast<ChTimestepper>(stepper));}
+void SetTimestepper(std::shared_ptr<ChTimestepperEulerImplicitProjected> stepper)  {$self->SetTimestepper(std::dynamic_pointer_cast<ChTimestepper>(stepper));}
+void SetTimestepper(std::shared_ptr<ChTimestepperTrapezoidal> stepper)             {$self->SetTimestepper(std::dynamic_pointer_cast<ChTimestepper>(stepper));}
+void SetTimestepper(std::shared_ptr<ChTimestepperTrapezoidalLinearized> stepper)   {$self->SetTimestepper(std::dynamic_pointer_cast<ChTimestepper>(stepper));}
+void SetTimestepper(std::shared_ptr<ChTimestepperNewmark> stepper)                 {$self->SetTimestepper(std::dynamic_pointer_cast<ChTimestepper>(stepper));}
+void SetTimestepper(std::shared_ptr<ChTimestepperHHT> stepper)                     {$self->SetTimestepper(std::dynamic_pointer_cast<ChTimestepper>(stepper));}
+}
+
 #endif             // --------------------------------------------------------------------- CSHARP
 
 %{
 #include "chrono/physics/ChSystem.h"
 #include "chrono/timestepper/ChIntegrable.h"
 #include "chrono/timestepper/ChTimestepper.h"
+#include "chrono/timestepper/ChTimestepperImplicit.h"
 #include "chrono/timestepper/ChTimestepperHHT.h"
 
 using namespace chrono;

--- a/src/chrono_swig/interface/core/ChTimestepper.i
+++ b/src/chrono_swig/interface/core/ChTimestepper.i
@@ -1,66 +1,7 @@
-#ifdef SWIGCSHARP  // --------------------------------------------------------------------- CSHARP
-
-// MULTIPLE INHERITANCE WORKAROUND
-
-// (A) Methods inherited from base classes that SWIG discards
-//     (i.e. methods that *are not* overriden in ChTimestepperHHT and ChTimestepperEulerImplicit)
-
-// First, ensure that these functions are not marked as 'overrides' in the generated C# code.
-
-%csmethodmodifiers chrono::ChTimestepperHHT::SetMaxIters "public"
-%csmethodmodifiers chrono::ChTimestepperHHT::SetRelTolerance "public"
-%csmethodmodifiers chrono::ChTimestepperHHT::SetAbsTolerances "public"
-%csmethodmodifiers chrono::ChTimestepperHHT::GetNumStepIterations "public"
-%csmethodmodifiers chrono::ChTimestepperHHT::GetNumStepSetupCalls "public"
-%csmethodmodifiers chrono::ChTimestepperHHT::GetNumStepSolveCalls "public"
-%csmethodmodifiers chrono::ChTimestepperHHT::GetNumIterations "public"
-%csmethodmodifiers chrono::ChTimestepperHHT::GetNumSetupCalls "public"
-%csmethodmodifiers chrono::ChTimestepperHHT::GetNumSolveCalls "public"
-
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::SetMaxIters "public"
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::SetRelTolerance "public"
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::SetAbsTolerances "public"
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::GetNumStepIterations "public"
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::GetNumStepSetupCalls "public"
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::GetNumStepSolveCalls "public"
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::GetNumIterations "public"
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::GetNumSetupCalls "public"
-%csmethodmodifiers chrono::ChTimestepperEulerImplicit::GetNumSolveCalls "public"
-
-%csmethodmodifiers chrono::ChTimestepper::GetType "public virtual new"
-
-
-// Second, extend ChTimestepperHHT and ChTimestepperEulerImplicit with implementations of these functions
-
-%extend chrono::ChTimestepperHHT
-{
-    void SetMaxIters(int iters)                             {$self->SetMaxIters(iters);}
-    void SetRelTolerance(double rel_tol)                    {$self->SetRelTolerance(rel_tol);}
-    void SetAbsTolerances(double abs_tolS, double abs_tolL) {$self->SetAbsTolerances(abs_tolS, abs_tolL);}
-    void SetAbsTolerances(double abs_tol)                   {$self->SetAbsTolerances(abs_tol);}
-    int GetNumStepIterations() const {return $self->GetNumStepIterations();}
-    int GetNumStepSetupCalls() const {return $self->GetNumStepSetupCalls();}
-    int GetNumStepSolveCalls() const {return $self->GetNumStepSolveCalls();}
-    int GetNumIterations() const {return $self->GetNumIterations();}
-    int GetNumSetupCalls() const {return $self->GetNumSetupCalls();}
-    int GetNumSolveCalls() const {return $self->GetNumSolveCalls();}
-}
-
-%extend chrono::ChTimestepperEulerImplicit
-{
-    void SetMaxIters(int iters)                             {$self->SetMaxIters(iters);}
-    void SetRelTolerance(double rel_tol)                    {$self->SetRelTolerance(rel_tol);}
-    void SetAbsTolerances(double abs_tolS, double abs_tolL) {$self->SetAbsTolerances(abs_tolS, abs_tolL);}
-    void SetAbsTolerances(double abs_tol)                   {$self->SetAbsTolerances(abs_tol);}
-    int GetNumStepIterations() const {return $self->GetNumStepIterations();}
-    int GetNumStepSetupCalls() const {return $self->GetNumStepSetupCalls();}
-    int GetNumStepSolveCalls() const {return $self->GetNumStepSolveCalls();}
-    int GetNumIterations() const {return $self->GetNumIterations();}
-    int GetNumSetupCalls() const {return $self->GetNumSetupCalls();}
-    int GetNumSolveCalls() const {return $self->GetNumSolveCalls();}
-}
-
-#endif             // --------------------------------------------------------------------- CSHARP
+// GetType hides System.Object.GetType - use 'new' keyword in C#
+#ifdef SWIGCSHARP
+%csmethodmodifiers chrono::ChTimestepper::GetType "public new virtual"
+#endif
 
 %{
 #include <cmath>
@@ -71,6 +12,7 @@
 #include "chrono/timestepper/ChIntegrable.h"
 #include "chrono/timestepper/ChState.h"
 #include "chrono/timestepper/ChTimestepper.h"
+#include "chrono/timestepper/ChTimestepperImplicit.h"
 #include "chrono/timestepper/ChTimestepperHHT.h"
 #include "chrono/timestepper/ChAssemblyAnalysis.h"
 #include "chrono/timestepper/ChStaticAnalysis.h"
@@ -113,9 +55,90 @@ using namespace chrono;
 %shared_ptr(chrono::ChStaticNonLinearRheonomicAnalysis)
 %shared_ptr(chrono::ChStaticNonLinearIncremental)
 
+// Special handling: C++ implicit timesteppers inherit from both ChTimestepperIIorder and ChTimestepperImplicit
+// ChTimestepperIIorder does NOT inherit from ChTimestepper, but ChTimestepperImplicit does but the problem is
+// SWIG picks the first base (ChTimestepperIIorder), breaking any expecting ChTimestepper
+// These typemaps must come after the %shared_ptr declarations and before includes
+//
+// shared_ptr in C++ (held by ChSystem) manages the lifetime so we setting swigCMemOwnDerived
+// to false to stop C# from trying to delete the c++ object
+// instead - just let the chsystem handle the timestepper on c++ side, and c# side just clears the handle at dispose
+
+#ifdef SWIGCSHARP
+
+// Force correct base class for the implicit timesteppers
+%typemap(csbase, replace="1") chrono::ChTimestepperEulerImplicit "ChTimestepperImplicit"
+%typemap(csbase, replace="1") chrono::ChTimestepperEulerImplicitLinearized "ChTimestepperImplicit"
+%typemap(csbase, replace="1") chrono::ChTimestepperEulerImplicitProjected "ChTimestepperImplicit"
+%typemap(csbase, replace="1") chrono::ChTimestepperTrapezoidal "ChTimestepperImplicit"
+%typemap(csbase, replace="1") chrono::ChTimestepperTrapezoidalLinearized "ChTimestepperImplicit"
+%typemap(csbase, replace="1") chrono::ChTimestepperNewmark "ChTimestepperImplicit"
+%typemap(csbase, replace="1") chrono::ChTimestepperHHT "ChTimestepperImplicit"
+
+// Macro to define complete typemap set for implicit timesteppers with forced base class
+// (ince we're forcing a different base class with csbase, we must override all dispose-related typemaps(
+// But since these are shared_ptr wrapped objects - C# must not try to garbage colleect/delete them
+// c++ shared_ptr (in ChSystem) manages the lifetime and handles deletion (csharp does not own the memory!)
+%define IMPLICIT_TIMESTEPPER_CSHARP_TYPEMAPS(CPPTYPE, CSTYPE)
+
+// Body with derived pattern - calls base constructor with pointer
+// Note: No swigCMemOwn tracking needed - shared_ptr in C++ manages lifetime, not C#
+%typemap(csbody) CPPTYPE %{
+  private global::System.Runtime.InteropServices.HandleRef swigCPtr;
+
+  internal $csclassname(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, false) {
+    swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+  }
+
+  internal static global::System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
+    return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
+  }
+%}
+
+// Suppress the default csdispose
+%typemap(csdispose) CPPTYPE ""
+// Suppress the default csdisposing
+%typemap(csdisposing, methodname="Dispose", methodmodifiers="protected override", parameters="bool disposing") CPPTYPE ""
+
+// Since shared_ptr owns the memory just clear the handle (avoid GB collection issues if any)
+%typemap(cscode) CPPTYPE %{
+  ~$csclassname() {
+    Dispose(false);
+  }
+
+  public new void Dispose() {
+    Dispose(true);
+    global::System.GC.SuppressFinalize(this);
+  }
+
+  protected override void Dispose(bool disposing) {
+    lock(this) {
+      if (swigCPtr.Handle != global::System.IntPtr.Zero) {
+        // Do not delete - C++ owns the memory (since set up with a chrono_typres::make_shared)
+        swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+      }
+      base.Dispose(disposing);
+    }
+  }
+%}
+
+%enddef
+
+// Apply the typemaps to all the implicit timesteppers
+IMPLICIT_TIMESTEPPER_CSHARP_TYPEMAPS(chrono::ChTimestepperEulerImplicit, ChTimestepperEulerImplicit)
+IMPLICIT_TIMESTEPPER_CSHARP_TYPEMAPS(chrono::ChTimestepperEulerImplicitLinearized, ChTimestepperEulerImplicitLinearized)
+IMPLICIT_TIMESTEPPER_CSHARP_TYPEMAPS(chrono::ChTimestepperEulerImplicitProjected, ChTimestepperEulerImplicitProjected)
+IMPLICIT_TIMESTEPPER_CSHARP_TYPEMAPS(chrono::ChTimestepperTrapezoidal, ChTimestepperTrapezoidal)
+IMPLICIT_TIMESTEPPER_CSHARP_TYPEMAPS(chrono::ChTimestepperTrapezoidalLinearized, ChTimestepperTrapezoidalLinearized)
+IMPLICIT_TIMESTEPPER_CSHARP_TYPEMAPS(chrono::ChTimestepperNewmark, ChTimestepperNewmark)
+IMPLICIT_TIMESTEPPER_CSHARP_TYPEMAPS(chrono::ChTimestepperHHT, ChTimestepperHHT)
+
+#endif // SWIGCSHARP
+
 %include "../../../chrono/timestepper/ChState.h"
 %include "../../../chrono/timestepper/ChIntegrable.h"
 %include "../../../chrono/timestepper/ChTimestepper.h"
+%include "../../../chrono/timestepper/ChTimestepperImplicit.h"
 %include "../../../chrono/timestepper/ChTimestepperHHT.h"
 %include "../../../chrono/timestepper/ChAssemblyAnalysis.h"
 %include "../../../chrono/timestepper/ChStaticAnalysis.h"


### PR DESCRIPTION
fix base class mapping for implicit timesteppers, and introduce custom typemaps to prevent memory ownership problems in C#. Implemented swig macro and applied it to all implicit timesteppers, ensuring C# does not attempt to delete C++ objects owned by shared_ptr and the c++ memory (to stop garbage collection on c# side). 

Added dyanamic ptr overloads in Chsystem.i to allow for settimestepper multiinheritance if changing (optional if the user is creating with settimestepper() and "gettimestepper as" in c# for c++ chsystem ownership)