### PR TITLE
Fix coordinate frame mismatch in SCM Ray-OBB test

### DIFF
--- a/src/chrono_vehicle/terrain/SCMTerrain.cpp
+++ b/src/chrono_vehicle/terrain/SCMTerrain.cpp
@@ -973,7 +973,7 @@ void SCMLoader::UpdateActiveDomain(ActiveDomainInfo& ad, const ChVector3d& Z) {
     }
 
     // Calculate inverse of SCM normal expressed in body frame (for optimization of ray-OBB test)
-    ChVector3d dir = ad.m_body->TransformDirectionParentToLocal(Z);
+    ChVector3d dir = ad.m_body->GetFrameRefToAbs().TransformDirectionParentToLocal(Z);
     ad.m_ooN.x() = (dir.x() == 0) ? 1e10 : 1.0 / dir.x();
     ad.m_ooN.y() = (dir.y() == 0) ? 1e10 : 1.0 / dir.y();
     ad.m_ooN.z() = (dir.z() == 0) ? 1e10 : 1.0 / dir.z();


### PR DESCRIPTION
 fixes the issue observed in ./demo_ROBOT_Viper_SCM(_Sensor) after commit 2366a60, where rocks sink indefinitely and the Viper rover sinks deeper than it should.

Why:
The previous update moved the Ray-OBB intersection test to the Reference (Visual) Frame to likely support vehicles with offsets between their visual mesh and physics center. However, while the ray origin was updated to the Reference Frame, the ray direction was still being calculated in the Body Frame.

The Fix:
Updated UpdateActiveDomain to calculate the ray direction (SCM normal) in the Reference Frame.So both the ray origin and direction are consistent with the bounding box orientation, so collision detection will catch again.