### PR TITLE
[FSI] Fix incorrect torque readout in demo_FSI_SingleWheelTest

### DIFF
--- a/src/demos/fsi/demo_FSI_SingleWheelTest.cpp
+++ b/src/demos/fsi/demo_FSI_SingleWheelTest.cpp
@@ -75,6 +75,7 @@ double dT = 2.5e-4;
 
 // linear actuator and angular actuator
 auto actuator = chrono_types::make_shared<ChLinkLockLinActuator>();
+auto motor = chrono_types::make_shared<ChLinkMotorRotationAngle>();
 
 // Save data as csv files to see the results off-line using Paraview
 bool output = true;
@@ -246,7 +247,6 @@ void CreateSolidPhase(ChFsiSystemSPH& sysFSI) {
     sysMBS.AddLink(prismatic2);
 
     // Connect the wheel to the axle through a motor.
-    auto motor = chrono_types::make_shared<ChLinkMotorRotationAngle>();
     motor->SetName("engine_wheel_axle");
     motor->Initialize(wheel, axle, ChFrame<>(wheel->GetPos(), chrono::QuatFromAngleX(-CH_PI_2)));
     motor->SetAngleFunction(chrono_types::make_shared<ChFunctionRamp>(0, wheel_AngVel));
@@ -408,8 +408,9 @@ int main(int argc, char* argv[]) {
     while (time < total_time) {
         // Get the infomation of the wheel
         const auto& reaction = actuator->GetReaction2();
+        const auto& reaction_motor = motor->GetReaction2();
         const auto& force = reaction.force;
-        const auto& torque = reaction.torque;
+        const auto& torque = reaction_motor.torque;
         const auto& w_pos = wheel->GetPos();
         const auto& w_vel = wheel->GetPosDt();
         const auto& angvel = wheel->GetAngVelLocal();


### PR DESCRIPTION
While using the Chrono::FSI module for terramechanics simulations, specifically for rover wheel analysis, I noticed that the torque output in the demo was yielding inconsistent values, close to zero, at the order of 1e-26. The issue stems from the output logic querying the torque from the linear actuator rather than the angular motor.

**Changes**
* Updated the data retrieval logic to query the motor torque from `ChLinkMotorRotationAngle` rather than `ChLinkLockLinActuator`
* The motor definition was moved out of the `CreateSolidPhase` function, so it can be called at main to output

Happy to contribute!

Best,
Rebeca Guimarães