### PR TITLE
add collisionSystem to make the example work

### DIFF
--- a/src/demos/python/core/demo_CH_buildsystem.py
+++ b/src/demos/python/core/demo_CH_buildsystem.py
@@ -19,6 +19,8 @@ import pychrono as chrono
 
 # Create a physical system,
 my_system = chrono.ChSystemNSC()
+my_system.SetCollisionSystemType(chrono.ChCollisionSystem.Type_BULLET)
+
 
 # Create a contact material, shared by all collision shapes
 material = chrono.ChContactMaterialNSC()


### PR DESCRIPTION
Without explicitly setting the collision system, the cube passes through objects, which makes the example confusing.

It might be helpful to add a short explanation in the code or the documentation mentioning that gravity is already set by default on the Y axis.