### PR TITLE
empty_mesh initialization and callback issue for Chrono imports, Fixes #669

### DIFF
--- a/src/importer_blender/chrono_import.py
+++ b/src/importer_blender/chrono_import.py
@@ -718,7 +718,7 @@ def make_chrono_object_clones(mname,mpos,mrot,
                                 masset_list, 
                                 list_clones_posrot):
     
-    chobject = bpy.data.objects.new(mname, empty_mesh)  
+    chobject = bpy.data.objects.new(mname, bpy.data.meshes.new('mesh_position_clones'))
     chobject.rotation_mode = 'QUATERNION'
     chobject.rotation_quaternion = mrot
     chobject.location = mpos
@@ -772,10 +772,9 @@ def make_chrono_object_clones(mname,mpos,mrot,
         verts[4*ic+2] = (mpos + mrot @ mathutils.Vector(( 0.1, 0.1,0)))[:]
         verts[4*ic+3] = (mpos + mrot @ mathutils.Vector((-0.1, 0.1,0)))[:]
         faces[ic] = (4*ic, 4*ic+1, 4*ic+2, 4*ic+3)    
-    new_mesh = bpy.data.meshes.new('mesh_position_clones')
-    new_mesh.from_pydata(verts, edges, faces)
-    new_mesh.update()
-    chobject.data = new_mesh
+
+    chobject.data.from_pydata(verts, edges, faces)
+    chobject.data.update()
     chobject.instance_type = 'FACES'
     chobject.show_instancer_for_render = False
     chobject.show_instancer_for_viewport = False


### PR DESCRIPTION
As specified in issue #669:

> "this is a known issue in Blender + plugins that implement the frame
> update callback. The solution is to save the Blender project and launch
> the blender rendering via command line in headless mode (no GUI)."

Following this workflow requires closing Blender and launching the animation rendering in headless mode.

However, closing Blender **resets the global variables**, including `empty_mesh`. This means that when the callback runs during rendering, `empty_mesh` is `None`. Consequently, the following lines:

```python
new_mesh = bpy.data.meshes.new('mesh_position_clones')
chobject.data = new_mesh
```

crash with a `TypeError` because `chobject.data` is **not prepared to receive a mesh**. This also causes only a subset of objects to be instantiated in the scene.

This PR ensures that `empty_mesh` is properly initialized **before it is used in the callback**, guaranteeing that all Chrono objects are correctly created and rendered in headless mode.
