### PR TITLE
Chrono::peridynamics  - corrected removal of cracked bonds.

### DIFF
--- a/src/chrono_peridynamics/ChMatterPeriBB.cpp
+++ b/src/chrono_peridynamics/ChMatterPeriBB.cpp
@@ -59,8 +59,8 @@ void ChMatterPeriBB::ComputeForces() {
     }
 
     // loop on bonds
-    for (auto& bond : this->bonds) {
-        ChMatterDataPerBondBB& mbond = bond.second;
+    for (auto it = bonds.begin(); it != bonds.end();) {
+        ChMatterDataPerBondBB& mbond = it->second;
         if (!mbond.broken) {
             ChVector3d old_vdist = mbond.nodeB->GetX0() - mbond.nodeA->GetX0();
             ChVector3d vdist = mbond.nodeB->GetPos() - mbond.nodeA->GetPos();
@@ -101,8 +101,9 @@ void ChMatterPeriBB::ComputeForces() {
                 mbond.nodeA->is_boundary = true;
                 mbond.nodeB->is_boundary = true;
             }
+            ++it;
         } else {
-            bonds.erase(bond.first);
+            it = bonds.erase(it);
         }
     }
 }


### PR DESCRIPTION
When running demo_PERI_fracture.cpp, the simulation could crash on some systems at the moment a sphere first contacts the elastic bar and fracture initiates. The crash manifests as a memory access violation during bond deletion.
This pull request addresses the issue by modifying the bond deletion strategy to avoid invalid memory access during fracture initiation, eliminating the crash while preserving the intended fracture behavior.