### PR TITLE
Fix transparent objects not casting shadows

### DIFF
--- a/src/chrono_vsg/utils/ChShaderUtilsVSG.cpp
+++ b/src/chrono_vsg/utils/ChShaderUtilsVSG.cpp
@@ -424,10 +424,9 @@ vsg::ref_ptr<vsg::StateGroup> createPbrStateGroup(vsg::ref_ptr<const vsg::Option
                 rs.polygonMode = VK_POLYGON_MODE_FILL;
             }
         }
-        void apply(vsg::DepthStencilState& dss) {
-            // Transparent surfaces must not write to depth buffer, otherwise geometry behind them is occluded
-            if (blending)
-                dss.depthWriteEnable = VK_FALSE;
+        void apply(vsg::DepthStencilState& /*dss*/) {
+            // Depth writes intentionally left enabled for transparent objects so they cast shadows.
+            // Correct visual rendering order is ensured by vsg::DepthSorted wrapping in ShapeBuilder.
         }
         void apply(vsg::InputAssemblyState& ias) {
             // if (wireframe) ias.topology = VK_POLYGON_MODE_LINE;

--- a/src/chrono_vsg/utils/ChShapeBuilderVSG.cpp
+++ b/src/chrono_vsg/utils/ChShapeBuilderVSG.cpp
@@ -14,6 +14,9 @@
 
 #include <cmath>
 
+#include <vsg/nodes/DepthSorted.h>
+#include <vsg/utils/ComputeBounds.h>
+
 #include "chrono_vsg/utils/ChDataUtilsVSG.h"
 #include "chrono_vsg/utils/ChShapeBuilderVSG.h"
 #include "chrono_vsg/utils/ChShaderUtilsVSG.h"
@@ -25,6 +28,21 @@ using std::cos;
 
 namespace chrono {
 namespace vsg3d {
+
+namespace {
+/// Wrap a node in vsg::DepthSorted for correct back-to-front rendering of transparent objects.
+/// Must be called after geometry has been added as child so bounds can be computed.
+vsg::ref_ptr<vsg::Node> wrapIfTransparent(vsg::ref_ptr<vsg::Node> node, std::shared_ptr<ChVisualMaterial> material) {
+    bool use_blending = (material->GetOpacity() < 1.0) || (!material->GetOpacityTexture().empty());
+    if (!use_blending)
+        return node;
+
+    auto cb = vsg::visit<vsg::ComputeBounds>(node);
+    auto center = (cb.bounds.min + cb.bounds.max) * 0.5;
+    auto radius = vsg::length(cb.bounds.max - cb.bounds.min) * 0.5;
+    return vsg::DepthSorted::create(10, vsg::dsphere(center.x, center.y, center.z, radius), node);
+}
+}  // namespace
 
 ShapeBuilder::ShapeBuilder(vsg::ref_ptr<vsg::Options> options, int num_divs) : m_options(options) {
     // Create the primitive shape builders
@@ -81,7 +99,7 @@ vsg::ref_ptr<vsg::Group> ShapeBuilder::CreatePbrShape(vsg::ref_ptr<vsg::vec3Arra
     vid->instanceCount = instanceCount;
 
     stategraph->addChild(vid);
-    transform->addChild(stategraph);
+    transform->addChild(wrapIfTransparent(stategraph, material));
     scenegraph->addChild(transform);
 
     if (m_compileTraversal)
@@ -339,7 +357,7 @@ vsg::ref_ptr<vsg::Group> ShapeBuilder::CreateTrimeshColShape(std::shared_ptr<ChT
 
     auto stategraph = createPbrStateGroup(m_options, chronoMat, double_faced, wireframe, wire_width);
     stategraph->addChild(vid);
-    transform->addChild(stategraph);
+    transform->addChild(wrapIfTransparent(stategraph, chronoMat));
 
     scenegraph->addChild(transform);
 
@@ -420,7 +438,7 @@ vsg::ref_ptr<vsg::Group> ShapeBuilder::CreateTrimeshColAvgShape(std::shared_ptr<
 
     auto stategraph = createPbrStateGroup(m_options, chronoMat, double_faced, wireframe, wire_width);
     stategraph->addChild(vid);
-    transform->addChild(stategraph);
+    transform->addChild(wrapIfTransparent(stategraph, chronoMat));
 
     scenegraph->addChild(transform);
 
@@ -540,7 +558,7 @@ vsg::ref_ptr<vsg::Group> ShapeBuilder::CreateTrimeshPbrMatShape(std::shared_ptr<
 
         auto stategraph = createPbrStateGroup(m_options, chronoMat, double_faced, wireframe, wire_width);
         stategraph->addChild(vid);
-        transform->addChild(stategraph);
+        transform->addChild(wrapIfTransparent(stategraph, chronoMat));
     }
 
     if (m_compileTraversal)


### PR DESCRIPTION
## Summary

This PR fixes the issue reported in #698 where transparent objects no longer cast shadows after the `depthWriteEnable = VK_FALSE` fix was merged.

**Root cause:** Setting `depthWriteEnable = VK_FALSE` for transparent pipelines makes them invisible to the shadow map depth pass — correct for visual transparency, but prevents shadow casting.

**Fix:** Replace the `depthWriteEnable = VK_FALSE` approach with `vsg::DepthSorted` wrapping:
- **Depth writes stay enabled** → shadow maps see transparent geometry → shadows are cast
- **`vsg::DepthSorted` (bin 10)** ensures transparent objects render *after* opaques, sorted back-to-front → correct visual blending without needing depth write disable

### Changes

| File | Change |
|------|--------|
| `ChShaderUtilsVSG.cpp` | Remove `depthWriteEnable = VK_FALSE` from `SetPipelineStates` visitor |
| `ChShapeBuilderVSG.cpp` | Add `wrapIfTransparent()` helper that wraps transparent `StateGroup` nodes in `vsg::DepthSorted`; applied at all 4 `createPbrStateGroup` call sites |

### Test

Standalone test program (3 objects on a ground plane with shadows enabled):
- Red opaque box — casts shadow ✓
- Blue transparent sphere (35% opacity) — **now casts shadow** ✓
- Green opaque cylinder — casts shadow ✓

Test code available as a [gist](https://gist.github.com/Tudor-MS/46c27d8d5db075935a3de0c97f5f3209).

Fixes #698