### PR TITLE
AMD HIP port compability initial

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -313,26 +313,151 @@ if(MPI_CXX_FOUND)
 endif()
 
 #-----------------------------------------------------------------------------
-# CUDA support
+# GPU backend support (CUDA and HIP)
 #-----------------------------------------------------------------------------
 
-message(STATUS "Searching for CUDA")
-
-# Notes:
-# - with new policy CM0104, CMake sets CMAKE_CUDA_ARCHITECTURES based on what nvcc reports
-# - nvcc uses as default sm_52
-# - we use our own cached CHRONO_CUDA_ARCHITECTURES variable
-# - for newer CMake versions, we set CHRONO_CUDA_ARCHITECTURES to 'all-major'
-# - for older CMake (e.g. 3.22 as in Ubuntu 22.04), we request the user to set CHRONO_CUDA_ARCHITECTURES
-# - we bypass CMAKE_CUDA_ARCHITECTURES (force it as advanced and set it from CHRONO_CUDA_ARCHITECTURES)
+set(CHRONO_GPU_BACKEND "AUTO" CACHE STRING "GPU backend for Chrono GPU modules: AUTO, CUDA, HIP")
+set_property(CACHE CHRONO_GPU_BACKEND PROPERTY STRINGS AUTO CUDA HIP)
 set(CHRONO_CUDA_ARCHITECTURES "" CACHE STRING "Chrono CUDA architectures")
+set(CHRONO_HIP_ARCHITECTURES "" CACHE STRING "Chrono HIP architectures")
+set(CHRONO_ROCM_ROOT "" CACHE PATH "Explicit ROCm root for HIP builds")
+set(CHRONO_MIN_HIP_VERSION "5.7.0" CACHE STRING "Minimum HIP version required by Chrono")
 mark_as_advanced(FORCE CMAKE_CUDA_ARCHITECTURES)
+mark_as_advanced(FORCE CMAKE_HIP_ARCHITECTURES)
+
+function(chrono_read_hip_version hip_header out_var)
+  if(NOT EXISTS "${hip_header}")
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  file(STRINGS "${hip_header}" _major REGEX "^#define[ 	]+HIP_VERSION_MAJOR[ 	]+[0-9]+")
+  file(STRINGS "${hip_header}" _minor REGEX "^#define[ 	]+HIP_VERSION_MINOR[ 	]+[0-9]+")
+  file(STRINGS "${hip_header}" _patch REGEX "^#define[ 	]+HIP_VERSION_PATCH[ 	]+[0-9]+")
+
+  if(NOT _major OR NOT _minor OR NOT _patch)
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  string(REGEX REPLACE ".*HIP_VERSION_MAJOR[ 	]+([0-9]+).*" "\\1" _maj "${_major}")
+  string(REGEX REPLACE ".*HIP_VERSION_MINOR[ 	]+([0-9]+).*" "\\1" _min "${_minor}")
+  string(REGEX REPLACE ".*HIP_VERSION_PATCH[ 	]+([0-9]+).*" "\\1" _pat "${_patch}")
+  set(${out_var} "${_maj}.${_min}.${_pat}" PARENT_SCOPE)
+endfunction()
+
+function(chrono_find_rocm out_root out_version)
+  set(_roots)
+  if(CHRONO_ROCM_ROOT)
+    list(APPEND _roots "${CHRONO_ROCM_ROOT}")
+  endif()
+  if(DEFINED ROCM_PATH AND NOT ROCM_PATH STREQUAL "")
+    list(APPEND _roots "${ROCM_PATH}")
+  endif()
+  if(DEFINED ENV{ROCM_PATH} AND NOT "$ENV{ROCM_PATH}" STREQUAL "")
+    list(APPEND _roots "$ENV{ROCM_PATH}")
+  endif()
+  if(DEFINED ENV{ROCM_HOME} AND NOT "$ENV{ROCM_HOME}" STREQUAL "")
+    list(APPEND _roots "$ENV{ROCM_HOME}")
+  endif()
+  if(DEFINED ENV{HIP_PATH} AND NOT "$ENV{HIP_PATH}" STREQUAL "")
+    list(APPEND _roots "$ENV{HIP_PATH}")
+  endif()
+  list(APPEND _roots /opt/rocm /usr/lib/rocm /usr/local/rocm)
+
+  foreach(_root IN LISTS _roots)
+    if(NOT _root)
+      continue()
+    endif()
+    set(_header "")
+    if(EXISTS "${_root}/include/hip/hip_version.h")
+      set(_header "${_root}/include/hip/hip_version.h")
+    elseif(EXISTS "${_root}/hip/include/hip/hip_version.h")
+      set(_header "${_root}/hip/include/hip/hip_version.h")
+    endif()
+    if(_header)
+      chrono_read_hip_version("${_header}" _ver)
+      if(_ver)
+        set(${out_root} "${_root}" PARENT_SCOPE)
+        set(${out_version} "${_ver}" PARENT_SCOPE)
+        return()
+      endif()
+    endif()
+  endforeach()
+
+  set(${out_root} "" PARENT_SCOPE)
+  set(${out_version} "" PARENT_SCOPE)
+endfunction()
 
 include(CheckLanguage)
-check_language(CUDA)
 
-# If CUDA was found, enable the CUDA language
-if(CMAKE_CUDA_COMPILER)
+set(CHRONO_CUDA_FOUND FALSE)
+set(CHRONO_HIP_FOUND FALSE)
+set(CHRONO_GPU_FOUND FALSE)
+set(CHRONO_GPU_BACKEND_RESOLVED "NONE")
+set(CHRONO_ROCM_VERSION "")
+
+message(STATUS "Searching for GPU backends")
+
+set(_chrono_try_hip FALSE)
+set(_chrono_try_cuda FALSE)
+if(CHRONO_GPU_BACKEND STREQUAL "HIP")
+  set(_chrono_try_hip TRUE)
+elseif(CHRONO_GPU_BACKEND STREQUAL "CUDA")
+  set(_chrono_try_cuda TRUE)
+elseif(CHRONO_GPU_BACKEND STREQUAL "AUTO")
+  chrono_find_rocm(_chrono_rocm_root _chrono_rocm_ver)
+  if(_chrono_rocm_root AND _chrono_rocm_ver VERSION_GREATER_EQUAL CHRONO_MIN_HIP_VERSION)
+    set(_chrono_try_hip TRUE)
+  else()
+    set(_chrono_try_cuda TRUE)
+  endif()
+else()
+  message(FATAL_ERROR "Invalid CHRONO_GPU_BACKEND='${CHRONO_GPU_BACKEND}'. Expected AUTO, CUDA, or HIP.")
+endif()
+
+if(_chrono_try_hip)
+  chrono_find_rocm(_chrono_rocm_root _chrono_rocm_ver)
+  if(_chrono_rocm_root)
+    list(PREPEND CMAKE_PREFIX_PATH "${_chrono_rocm_root}")
+    if(NOT DEFINED CMAKE_HIP_COMPILER_ROCM_ROOT)
+      set(CMAKE_HIP_COMPILER_ROCM_ROOT "${_chrono_rocm_root}" CACHE PATH "ROCm root path")
+    endif()
+    if(NOT DEFINED CMAKE_HIP_PLATFORM)
+      set(CMAKE_HIP_PLATFORM "amd" CACHE STRING "HIP platform")
+    endif()
+    check_language(HIP)
+    if(CMAKE_HIP_COMPILER)
+      enable_language(HIP)
+      set(CHRONO_HIP_FOUND TRUE)
+      set(CHRONO_GPU_FOUND TRUE)
+      set(CHRONO_GPU_BACKEND_RESOLVED "HIP")
+      set(CHRONO_ROCM_ROOT "${_chrono_rocm_root}" CACHE PATH "Explicit ROCm root for HIP builds" FORCE)
+      set(CHRONO_ROCM_VERSION "${_chrono_rocm_ver}")
+      if(CHRONO_HIP_ARCHITECTURES STREQUAL "" AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.21")
+        set(CHRONO_HIP_ARCHITECTURES "native" CACHE STRING "Chrono HIP architectures" FORCE)
+      endif()
+      if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
+        set(CMAKE_HIP_ARCHITECTURES ${CHRONO_HIP_ARCHITECTURES} CACHE STRING "HIP architectures" FORCE)
+      endif()
+      message(STATUS "  HIP compiler:            ${CMAKE_HIP_COMPILER}")
+      message(STATUS "  ROCm version:            ${CHRONO_ROCM_VERSION}")
+      message(STATUS "  ROCm root dir:           ${CHRONO_ROCM_ROOT}")
+      if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
+        message(STATUS "  HIP archs:               ${CHRONO_HIP_ARCHITECTURES}")
+      endif()
+    else()
+      message(STATUS "  WARNING: HIP requested but no HIP compiler was found.")
+    endif()
+  else()
+    message(STATUS "  WARNING: HIP requested but ROCm was not found.")
+  endif()
+endif()
+
+if(NOT CHRONO_HIP_FOUND AND (_chrono_try_cuda OR CHRONO_GPU_BACKEND STREQUAL "AUTO"))
+  message(STATUS "Searching for CUDA")
+  check_language(CUDA)
+  if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
     find_package(CUDAToolkit)
     message(STATUS "  CUDA compiler:           ${CMAKE_CUDA_COMPILER}")
@@ -353,17 +478,40 @@ if(CMAKE_CUDA_COMPILER)
       message("  WARNING: CUDA architectures not found. Set CHRONO_CUDA_ARCHITECTURES")
     else()
       set(CHRONO_CUDA_FOUND TRUE)
+      set(CHRONO_GPU_FOUND TRUE)
+      set(CHRONO_GPU_BACKEND_RESOLVED "CUDA")
       message(STATUS "  CUDA found and enabled.")
       set(CMAKE_CUDA_ARCHITECTURES ${CHRONO_CUDA_ARCHITECTURES} CACHE STRING "CUDA architectures" FORCE)
-      ## TODO: DARIOM CUDA_SEPARABLE_COMPILATION has no meaning: either it is set on a target or should be CMAKE_CUDA_SEPARABLE_COMPILATION
       if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         set(CUDA_SEPARABLE_COMPILATION OFF)
       endif()
     endif()
-else()
+  else()
     set(CHRONO_CUDA_FOUND FALSE)
     mark_as_advanced(FORCE CHRONO_CUDA_ARCHITECTURES)
     message("  WARNING  CUDA not found. CUDA features will be disabled.")
+  endif()
+endif()
+
+set(CHRONO_GPU_BACKEND ${CHRONO_GPU_BACKEND_RESOLVED})
+#-----------------------------------------------------------------------------
+# HIP + Eigen alignment compatibility
+#-----------------------------------------------------------------------------
+
+# Some host-side Chrono classes contain fixed-size Eigen objects. With AVX,
+# Eigen may require 32-byte alignment; a few allocation paths used by demos,
+# visualization, or MBS coupling do not guarantee that in all environments.
+# In HIP builds this can abort demo_FSI-SPH_CouetteFlow before any SPH kernel is
+# reached. Limiting Eigen's maximum static alignment to 16 bytes avoids the
+# fragile 32-byte over-alignment requirement while keeping ordinary
+# SSE-friendly vectorization and without touching CUDA/NVIDIA builds.
+set(CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES "16" CACHE STRING
+    "Maximum Eigen alignment in HIP builds; set to 0 to fully disable fixed-size Eigen over-alignment")
+if(CHRONO_HIP_FOUND)
+  target_compile_definitions(Eigen3::Eigen INTERFACE
+    EIGEN_MAX_ALIGN_BYTES=${CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES}
+    EIGEN_MAX_STATIC_ALIGN_BYTES=${CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES})
+  message(STATUS "  HIP Eigen max alignment: ${CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES} bytes")
 endif()
 
 #-----------------------------------------------------------------------------
@@ -373,6 +521,16 @@ endif()
 message(STATUS "Searching for Thrust")
 
 find_package(Thrust)
+
+if(CHRONO_HIP_FOUND AND Thrust_FOUND AND CHRONO_ROCM_ROOT)
+  file(REAL_PATH "${THRUST_INCLUDE_DIR}" _chrono_thrust_include_real)
+  file(REAL_PATH "${CHRONO_ROCM_ROOT}" _chrono_rocm_root_real)
+  string(FIND "${_chrono_thrust_include_real}" "${_chrono_rocm_root_real}/" _chrono_rocm_thrust_pos)
+  if(_chrono_rocm_thrust_pos EQUAL 0 OR _chrono_thrust_include_real STREQUAL "${_chrono_rocm_root_real}")
+    message(STATUS "  Ignoring ROCm-packaged Thrust for host-side Chrono targets in HIP builds.")
+    set(Thrust_FOUND FALSE)
+  endif()
+endif()
 
 if(Thrust_FOUND)
   message(STATUS "  Thrust version:     ${THRUST_VERSION}")
@@ -765,6 +923,14 @@ if(CHRONO_CUDA_FOUND)
 else()
   set(CHRONO_HAS_CUDA "#undef CHRONO_HAS_CUDA")
   set(CHRONO_CUDA_VERSION "#undef CHRONO_CUDA_VERSION")
+endif()
+
+if(CHRONO_HIP_FOUND)
+  set(CHRONO_HAS_HIP "#define CHRONO_HAS_HIP")
+  set(CHRONO_HIP_VERSION "#define CHRONO_HIP_VERSION \"${CHRONO_ROCM_VERSION}\"")
+else()
+  set(CHRONO_HAS_HIP "#undef CHRONO_HAS_HIP")
+  set(CHRONO_HIP_VERSION "#undef CHRONO_HIP_VERSION")
 endif()
 
 if(CHRONO_THRUST_FOUND)

--- a/src/ChConfig.h.in
+++ b/src/ChConfig.h.in
@@ -189,12 +189,16 @@
 @CHRONO_HAS_CUDA@
 @CHRONO_CUDA_VERSION@
 
+// If HIP is available, define CHRONO_HAS_HIP and set HIP/ROCm version
+@CHRONO_HAS_HIP@
+@CHRONO_HIP_VERSION@
+
 // If THRUST is available, define CHRONO_HAS_THRUST and set Thrust version
 @CHRONO_HAS_THRUST@
 @CHRONO_THRUST_VERSION@
 
-// If CUDA is not available, force Thrust to always use the OMP backend
-#ifndef CHRONO_HAS_CUDA
+// If neither CUDA nor HIP is available, force Thrust to always use the OMP backend
+#if !defined(CHRONO_HAS_CUDA) && !defined(CHRONO_HAS_HIP)
   #ifndef THRUST_DEVICE_SYSTEM
     #define THRUST_DEVICE_SYSTEM THRUST_DEVICE_SYSTEM_OMP
   #endif

--- a/src/chrono_dem/CMakeLists.txt
+++ b/src/chrono_dem/CMakeLists.txt
@@ -14,9 +14,9 @@ endif()
 
 message(STATUS "\n==== Chrono DEM module ====\n")
 
-# Return now if CUDA is not available
-if(NOT CHRONO_CUDA_FOUND)
-    message("Chrono::DEM requires CUDA, but CUDA was not found; disabling Chrono::DEM")
+# Return now if neither CUDA nor HIP is available
+if(NOT CHRONO_CUDA_FOUND AND NOT CHRONO_HIP_FOUND)
+    message("Chrono::DEM requires CUDA or HIP, but neither backend was found; disabling Chrono::DEM")
     set(CH_ENABLE_MODULE_DEM OFF CACHE BOOL "Enable the Chrono::DEM module" FORCE)
     return()
 endif()
@@ -28,7 +28,11 @@ if(EIGEN3_VERSION VERSION_LESS "3.3.6")
     return()
 endif()
 
-message(STATUS "Chrono CUDA architectures: ${CHRONO_CUDA_ARCHITECTURES}")
+if(CHRONO_HIP_FOUND)
+  message(STATUS "Chrono HIP architectures: ${CHRONO_HIP_ARCHITECTURES}")
+else()
+  message(STATUS "Chrono CUDA architectures: ${CHRONO_CUDA_ARCHITECTURES}")
+endif()
 
 # ----------------------------------------------------------------------------
 # Generate and install configuration header file.
@@ -80,6 +84,15 @@ set(DEM_CUDA_FILES
     cuda/ChCudaMathUtils.cuh
     )
 source_group(cuda FILES ${DEM_CUDA_FILES})
+
+set(DEM_GPU_SOURCE_FILES
+    cuda/ChDem_SMC.cu
+    cuda/ChDem_SMC_trimesh.cu
+    )
+
+if(CHRONO_HIP_FOUND)
+    set_source_files_properties(${DEM_GPU_SOURCE_FILES} PROPERTIES LANGUAGE HIP)
+endif()
 
 set(DEM_UTILITY_FILES
     utils/ChDemUtilities.h
@@ -138,24 +151,49 @@ if(MSVC)
 endif()
 
 if(MSVC)
-  target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/wd4996>)  # deprecated function or class member
-  target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/wd4996>) # CUDA Deprecation: The type will be removed in the next major release
-  target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/wd4100>) # CUDA unreferenced formal parameter
+  target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/wd4996>)
+  target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/wd4996>)
+  target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/wd4100>)
 endif()
 
-target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>)
+if(CHRONO_CUDA_FOUND)
+  target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>)
+  target_compile_definitions(Chrono_dem PUBLIC CHRONO_USE_CUDA)
+endif()
 
 target_compile_definitions(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CXX>:CH_API_COMPILE_DEM>)
+if(CHRONO_HIP_FOUND)
+  target_compile_definitions(Chrono_dem PUBLIC CHRONO_USE_HIP __HIP_PLATFORM_AMD__)
+endif()
 
 target_link_libraries(Chrono_dem PRIVATE Chrono_core)
 
-target_link_libraries(Chrono_dem PUBLIC CUDA::cudart_static)
-target_link_libraries(Chrono_dem PUBLIC CUDA::nvrtc)
-target_link_libraries(Chrono_dem PUBLIC CUDA::cuda_driver)
-target_link_libraries(Chrono_dem PUBLIC CUDA::cublas)
-target_link_libraries(Chrono_dem PUBLIC CUDA::cusparse)
-
-set_target_properties(Chrono_dem PROPERTIES CUDA_ARCHITECTURES ${CHRONO_CUDA_ARCHITECTURES})
+if(CHRONO_CUDA_FOUND)
+  target_link_libraries(Chrono_dem PUBLIC CUDA::cudart_static)
+  target_link_libraries(Chrono_dem PUBLIC CUDA::nvrtc)
+  target_link_libraries(Chrono_dem PUBLIC CUDA::cuda_driver)
+  target_link_libraries(Chrono_dem PUBLIC CUDA::cublas)
+  target_link_libraries(Chrono_dem PUBLIC CUDA::cusparse)
+  set_target_properties(Chrono_dem PROPERTIES CUDA_ARCHITECTURES ${CHRONO_CUDA_ARCHITECTURES})
+elseif(CHRONO_HIP_FOUND)
+  find_package(hip QUIET CONFIG HINTS "${CHRONO_ROCM_ROOT}")
+  if(TARGET hip::host)
+    target_link_libraries(Chrono_dem PUBLIC hip::host)
+  endif()
+  if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
+    target_include_directories(Chrono_dem PUBLIC "${CHRONO_ROCM_ROOT}/include")
+  endif()
+  # Mixed CXX/HIP targets can leak HIP_ARCHITECTURES into ordinary CXX compilations
+  # (for example stb_image.cpp), which makes the host compiler see --offload-arch.
+  # Keep the target-level property disabled and pass the GPU arch flags only to real HIP TUs.
+  set_target_properties(Chrono_dem PROPERTIES HIP_ARCHITECTURES OFF)
+  if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
+    foreach(_chrono_hip_arch IN LISTS CHRONO_HIP_ARCHITECTURES)
+      target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:HIP>:--offload-arch=${_chrono_hip_arch}>)
+      target_link_options(Chrono_dem PRIVATE $<$<LINK_LANGUAGE:HIP>:--offload-arch=${_chrono_hip_arch}>)
+    endforeach()
+  endif()
+endif()
 
 install(TARGETS Chrono_dem
         EXPORT ChronoTargets
@@ -192,11 +230,13 @@ if(CH_ENABLE_MODULE_VSG)
     target_link_libraries(Chrono_dem_vsg PRIVATE Chrono_core Chrono_dem)
     target_link_libraries(Chrono_dem_vsg PUBLIC Chrono_vsg)
 
-    target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cudart_static)
-    target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::nvrtc)
-    target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cuda_driver)
-    target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cublas)
-    target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cusparse)
+    if(CHRONO_CUDA_FOUND)
+      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cudart_static)
+      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::nvrtc)
+      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cuda_driver)
+      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cublas)
+      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cusparse)
+    endif()
 
     install(TARGETS Chrono_dem_vsg
             EXPORT ChronoTargets

--- a/src/chrono_dem/ChDemDefines.h
+++ b/src/chrono_dem/ChDemDefines.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <climits>
-#include <cuda_runtime.h>
+#include "chrono_dem/cuda/ChGpuRuntime.h"
 #include <cstdio>
 #include <cstdlib>
 #include <functional>

--- a/src/chrono_dem/cuda/ChDemBoundaryConditions.cuh
+++ b/src/chrono_dem/cuda/ChDemBoundaryConditions.cuh
@@ -19,7 +19,15 @@
 #include "chrono_dem/physics/ChDemBoundaryConditions.h"
 #include "chrono_dem/cuda/ChCudaMathUtils.cuh"
 #include "chrono_dem/cuda/ChDemHelpers.cuh"
-#include <math_constants.h>
+#if defined(CHRONO_USE_HIP)
+    #if __has_include(<hip/math_constants.h>)
+        #include <hip/math_constants.h>
+    #elif __has_include(<math_constants.h>)
+        #include <math_constants.h>
+    #endif
+#else
+    #include <math_constants.h>
+#endif
 using chrono::dem::CHDEM_TIME_INTEGRATOR;
 using chrono::dem::CHDEM_FRICTION_MODE;
 using chrono::dem::CHDEM_ROLLING_MODE;

--- a/src/chrono_dem/cuda/ChDemCUDAalloc.hpp
+++ b/src/chrono_dem/cuda/ChDemCUDAalloc.hpp
@@ -18,7 +18,8 @@
 #ifndef CUDALLOC_HPP
 #define CUDALLOC_HPP
 
-#include <cuda_runtime_api.h>
+#include "chrono_dem/ChDemDefines.h"
+#include "chrono_dem/cuda/ChGpuRuntime.h"
 #include <climits>
 #include <iostream>
 #include <memory>
@@ -91,7 +92,11 @@ class cudallocator {
         return (T*)vptr;
     }
 
-    void deallocate(pointer p, size_type n) { cudaFree(p); }
+    void deallocate(pointer p, size_type n) {
+        if (p) {
+            demErrchk(cudaFree(p));
+        }
+    }
 
     bool operator==(const cudallocator& other) const { return true; }
     bool operator!=(const cudallocator& other) const { return false; }

--- a/src/chrono_dem/cuda/ChDemCollision.cuh
+++ b/src/chrono_dem/cuda/ChDemCollision.cuh
@@ -19,6 +19,22 @@
 #include "chrono_dem/ChDemDefines.h"
 #include "chrono_dem/cuda/ChCudaMathUtils.cuh"
 
+__device__ inline double chrono_dem_drcp_ru_compat(double value) {
+#if defined(CHRONO_USE_HIP)
+    return __drcp_rn(value);
+#else
+    return __drcp_ru(value);
+#endif
+}
+
+__device__ inline double chrono_dem_dmul_ru_compat(double lhs, double rhs) {
+#if defined(CHRONO_USE_HIP)
+    return __dmul_rn(lhs, rhs);
+#else
+    return __dmul_ru(lhs, rhs);
+#endif
+}
+
 /// @addtogroup dem_cuda
 /// @{
 
@@ -89,9 +105,9 @@ __device__ bool snap_to_face(const double3& A, const double3& B, const double3& 
 
     // P inside face region. Return projection of P onto face
     // barycentric coordinates (u,v,w)
-    double denom = __drcp_ru(va + vb + vc);
-    double v = __dmul_ru(vb, denom);
-    double w = __dmul_ru(vc, denom);
+    double denom = chrono_dem_drcp_ru_compat(va + vb + vc);
+    double v = chrono_dem_dmul_ru_compat(vb, denom);
+    double w = chrono_dem_dmul_ru_compat(vc, denom);
     res = A + v * AB + w * AC;  // = u*A + v*B + w*C  where  (u = 1 - v - w)
     return false;
 }

--- a/src/chrono_dem/cuda/ChDemHelpers.cuh
+++ b/src/chrono_dem/cuda/ChDemHelpers.cuh
@@ -20,7 +20,7 @@
 #include "chrono_dem/cuda/ChCudaMathUtils.cuh"
 #include "chrono_dem/ChDemDefines.h"
 
-#include <cub/cub.cuh>
+#include "chrono_dem/cuda/ChGpuRuntime.h"
 
 using chrono::dem::ChSystemDem_impl;
 using chrono::dem::CHDEM_TIME_INTEGRATOR;
@@ -32,7 +32,7 @@ using chrono::dem::CHDEM_ROLLING_MODE;
     {                             \
         printf(__VA_ARGS__);      \
         __threadfence();          \
-        cuda::std::terminate();   \
+        CHGPU_DEVICE_ABORT();     \
     }
 
 #define CHDEM_DEBUG_PRINTF(...) printf(__VA_ARGS__)

--- a/src/chrono_dem/cuda/ChDem_SMC.cu
+++ b/src/chrono_dem/cuda/ChDem_SMC.cu
@@ -34,11 +34,11 @@ __host__ float ChSystemDem_impl::computeArray3SquaredSum(std::vector<float, cuda
 
     // Use CUB to reduce. And put the reduced result at the last element of sphere_stats_buffer array.
     size_t temp_storage_bytes = 0;
-    cub::DeviceReduce::Sum(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer,
-                           sphere_data->sphere_stats_buffer + num_spheres, num_spheres);
+    demErrchk(cub::DeviceReduce::Sum(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer,
+                                      sphere_data->sphere_stats_buffer + num_spheres, num_spheres));
     void* d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
-    cub::DeviceReduce::Sum(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer,
-                           sphere_data->sphere_stats_buffer + num_spheres, num_spheres);
+    demErrchk(cub::DeviceReduce::Sum(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer,
+                                      sphere_data->sphere_stats_buffer + num_spheres, num_spheres));
     demErrchk(cudaDeviceSynchronize());
     demErrchk(cudaPeekAtLastError());
     return *(sphere_data->sphere_stats_buffer + num_spheres);
@@ -58,17 +58,17 @@ __host__ double ChSystemDem_impl::GetMaxParticleZ(bool getMax) {
     // Use CUB to find the max or min Z.
     size_t temp_storage_bytes = 0;
     if (getMax) {
-        cub::DeviceReduce::Max(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer,
-                               sphere_data->sphere_stats_buffer + num_spheres, num_spheres);
+        demErrchk(cub::DeviceReduce::Max(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer,
+                                          sphere_data->sphere_stats_buffer + num_spheres, num_spheres));
         void* d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
-        cub::DeviceReduce::Max(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer,
-                               sphere_data->sphere_stats_buffer + num_spheres, num_spheres);
+        demErrchk(cub::DeviceReduce::Max(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer,
+                                          sphere_data->sphere_stats_buffer + num_spheres, num_spheres));
     } else {
-        cub::DeviceReduce::Min(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer,
-                               sphere_data->sphere_stats_buffer + num_spheres, num_spheres);
+        demErrchk(cub::DeviceReduce::Min(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer,
+                                          sphere_data->sphere_stats_buffer + num_spheres, num_spheres));
         void* d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
-        cub::DeviceReduce::Min(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer,
-                               sphere_data->sphere_stats_buffer + num_spheres, num_spheres);
+        demErrchk(cub::DeviceReduce::Min(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer,
+                                          sphere_data->sphere_stats_buffer + num_spheres, num_spheres));
     }
     demErrchk(cudaDeviceSynchronize());
     demErrchk(cudaPeekAtLastError());
@@ -88,11 +88,11 @@ __host__ unsigned int ChSystemDem_impl::GetNumParticleAboveZ(float ZValue) {
 
     // Use CUB to find the max or min Z.
     size_t temp_storage_bytes = 0;
-    cub::DeviceReduce::Sum(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer_int,
-                           sphere_data->sphere_stats_buffer_int + num_spheres, num_spheres);
+    demErrchk(cub::DeviceReduce::Sum(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer_int,
+                                      sphere_data->sphere_stats_buffer_int + num_spheres, num_spheres));
     void* d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
-    cub::DeviceReduce::Sum(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer_int,
-                           sphere_data->sphere_stats_buffer_int + num_spheres, num_spheres);
+    demErrchk(cub::DeviceReduce::Sum(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer_int,
+                                      sphere_data->sphere_stats_buffer_int + num_spheres, num_spheres));
     demErrchk(cudaDeviceSynchronize());
     demErrchk(cudaPeekAtLastError());
     return *(sphere_data->sphere_stats_buffer_int + num_spheres);
@@ -111,11 +111,11 @@ __host__ unsigned int ChSystemDem_impl::GetNumParticleAboveX(float XValue) {
 
     // Use CUB to find the max or min X.
     size_t temp_storage_bytes = 0;
-    cub::DeviceReduce::Sum(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer_int,
-                           sphere_data->sphere_stats_buffer_int + num_spheres, num_spheres);
+    demErrchk(cub::DeviceReduce::Sum(NULL, temp_storage_bytes, sphere_data->sphere_stats_buffer_int,
+                                      sphere_data->sphere_stats_buffer_int + num_spheres, num_spheres));
     void* d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
-    cub::DeviceReduce::Sum(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer_int,
-                           sphere_data->sphere_stats_buffer_int + num_spheres, num_spheres);
+    demErrchk(cub::DeviceReduce::Sum(d_scratch_space, temp_storage_bytes, sphere_data->sphere_stats_buffer_int,
+                                      sphere_data->sphere_stats_buffer_int + num_spheres, num_spheres));
     demErrchk(cudaDeviceSynchronize());
     demErrchk(cudaPeekAtLastError());
     return *(sphere_data->sphere_stats_buffer_int + num_spheres);
@@ -190,9 +190,9 @@ __host__ float ChSystemDem_impl::get_max_vel() const {
 
     void* d_temp_storage = NULL;
     size_t temp_storage_bytes = 0;
-    cub::DeviceReduce::Max(d_temp_storage, temp_storage_bytes, d_absv, d_max_vel, nSpheres);
+    demErrchk(cub::DeviceReduce::Max(d_temp_storage, temp_storage_bytes, d_absv, d_max_vel, nSpheres));
     demErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytes));
-    cub::DeviceReduce::Max(d_temp_storage, temp_storage_bytes, d_absv, d_max_vel, nSpheres);
+    demErrchk(cub::DeviceReduce::Max(d_temp_storage, temp_storage_bytes, d_absv, d_max_vel, nSpheres));
     demErrchk(cudaMemcpy(&h_max_vel, d_max_vel, sizeof(float), cudaMemcpyDeviceToHost));
 
     demErrchk(cudaFree(d_absv));
@@ -584,14 +584,14 @@ __host__ void ChSystemDem_impl::runSphereBroadphase() {
 
     // cold run; CUB determines the amount of storage it needs (since first argument is NULL pointer)
     size_t temp_storage_bytes = 0;
-    cub::DeviceScan::ExclusiveSum(NULL, temp_storage_bytes, in_ptr, out_ptr, nSDs);
+    demErrchk(cub::DeviceScan::ExclusiveSum(NULL, temp_storage_bytes, in_ptr, out_ptr, nSDs));
     demErrchk(cudaDeviceSynchronize());
     demErrchk(cudaPeekAtLastError());
 
     // give CUB needed temporary storage on the device
     void* d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
     // Run the actual exclusive prefix sum
-    cub::DeviceScan::ExclusiveSum(d_scratch_space, temp_storage_bytes, in_ptr, out_ptr, nSDs);
+    demErrchk(cub::DeviceScan::ExclusiveSum(d_scratch_space, temp_storage_bytes, in_ptr, out_ptr, nSDs));
     demErrchk(cudaDeviceSynchronize());
     demErrchk(cudaPeekAtLastError());
 

--- a/src/chrono_dem/cuda/ChDem_SMC.cuh
+++ b/src/chrono_dem/cuda/ChDem_SMC.cuh
@@ -16,9 +16,14 @@
 
 #pragma once
 
-#include <cub/cub.cuh>
+#include "chrono_dem/cuda/ChGpuRuntime.h"
 
-#include <cuda.h>
+#if defined(CHRONO_USE_HIP)
+    #include <hipcub/hipcub.hpp>
+    namespace cub = hipcub;
+#else
+    #include <cub/cub.cuh>
+#endif
 #include <cassert>
 #include <cstdio>
 #include <fstream>
@@ -369,7 +374,7 @@ inline __device__ void findNewLocalCoords(ChSystemDem_impl::GranSphereDataPtr sp
             (float)global_pos_Y * l_unit, (float)global_pos_Z * l_unit, (float)gran_params->BD_frame_X * l_unit,
             (float)gran_params->BD_frame_Y * l_unit, (float)gran_params->BD_frame_Z * l_unit);
         __threadfence();
-        cuda::std::terminate();
+        CHGPU_DEVICE_ABORT();
     }
 
     // write local pos back to global memory

--- a/src/chrono_dem/cuda/ChDem_SMC_trimesh.cu
+++ b/src/chrono_dem/cuda/ChDem_SMC_trimesh.cu
@@ -16,7 +16,15 @@
 #include "chrono_dem/cuda/ChDem_SMC.cuh"
 #include "chrono_dem/physics/ChSystemDemMesh_impl.h"
 #include "chrono_dem/utils/ChDemUtilities.h"
-#include <math_constants.h>
+#if defined(CHRONO_USE_HIP)
+    #if __has_include(<hip/math_constants.h>)
+        #include <hip/math_constants.h>
+    #elif __has_include(<math_constants.h>)
+        #include <math_constants.h>
+    #endif
+#else
+    #include <math_constants.h>
+#endif
 
 namespace chrono {
 namespace dem {
@@ -39,13 +47,13 @@ __host__ void ChSystemDemMesh_impl::runTriangleBroadphase() {
 
     // copy data into the tmp array
     demErrchk(cudaMemcpy(out_ptr, in_ptr, numTriangles * sizeof(unsigned int), cudaMemcpyDeviceToDevice));
-    cub::DeviceScan::ExclusiveSum(NULL, temp_storage_bytes, in_ptr, out_ptr, numTriangles);
+    demErrchk(cub::DeviceScan::ExclusiveSum(NULL, temp_storage_bytes, in_ptr, out_ptr, numTriangles));
     demErrchk(cudaDeviceSynchronize());
 
     // get pointer to device memory; this memory block will be used internally by CUB, for scratch area
     void* d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
     // Run exclusive prefix sum
-    cub::DeviceScan::ExclusiveSum(d_scratch_space, temp_storage_bytes, in_ptr, out_ptr, numTriangles);
+    demErrchk(cub::DeviceScan::ExclusiveSum(d_scratch_space, temp_storage_bytes, in_ptr, out_ptr, numTriangles));
     demErrchk(cudaDeviceSynchronize());
     unsigned int numOfTriangleTouchingSD_instances;  // total number of instances in which a triangle touches an SD
     numOfTriangleTouchingSD_instances = out_ptr[numTriangles - 1] + in_ptr[numTriangles - 1];
@@ -74,14 +82,15 @@ __host__ void ChSystemDemMesh_impl::runTriangleBroadphase() {
     // SDs:       23 23 23 89 89  89  89  107 107 107 etc.
     // Triangle:   5  9 17 43 67 108 221    6  12 298 etc.
     // First, determine temporary device storage requirements; pass null, CUB tells us what it needs
-    cub::DeviceRadixSort::SortPairs(NULL, temp_storage_bytes, d_keys_in, d_keys_out, d_values_in, d_values_out,
-                                    numOfTriangleTouchingSD_instances);
+    demErrchk(cub::DeviceRadixSort::SortPairs(NULL, temp_storage_bytes, d_keys_in, d_keys_out, d_values_in,
+                                                   d_values_out, numOfTriangleTouchingSD_instances));
     demErrchk(cudaDeviceSynchronize());
 
     // get pointer to device memory; this memory block will be used internally by CUB
     d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
-    cub::DeviceRadixSort::SortPairs(d_scratch_space, temp_storage_bytes, d_keys_in, d_keys_out, d_values_in,
-                                    d_values_out, numOfTriangleTouchingSD_instances);
+    demErrchk(cub::DeviceRadixSort::SortPairs(d_scratch_space, temp_storage_bytes, d_keys_in, d_keys_out,
+                                                   d_values_in, d_values_out,
+                                                   numOfTriangleTouchingSD_instances));
     demErrchk(cudaDeviceSynchronize());
 
     // We started with SDs touching a triangle; we just flipped this through the key-value sort. That is, we now
@@ -109,14 +118,15 @@ __host__ void ChSystemDemMesh_impl::runTriangleBroadphase() {
     // Output value represents the number of SDs that have at last one triangle touching the SD
     unsigned int* d_num_runs_out = Triangle_SDsCompositeOffsets.data();
     // dry run, figure out the number of bytes that will be used in the actual run
-    cub::DeviceRunLengthEncode::Encode(NULL, temp_storage_bytes, d_in, d_unique_out, d_counts_out, d_num_runs_out,
-                                       numOfTriangleTouchingSD_instances);
+    demErrchk(cub::DeviceRunLengthEncode::Encode(NULL, temp_storage_bytes, d_in, d_unique_out, d_counts_out,
+                                                      d_num_runs_out, numOfTriangleTouchingSD_instances));
     demErrchk(cudaDeviceSynchronize());
 
     d_scratch_space = TriangleIDS_ByMultiplicity.data();
     // Run the actual encoding operation
-    cub::DeviceRunLengthEncode::Encode(d_scratch_space, temp_storage_bytes, d_in, d_unique_out, d_counts_out,
-                                       d_num_runs_out, numOfTriangleTouchingSD_instances);
+    demErrchk(cub::DeviceRunLengthEncode::Encode(d_scratch_space, temp_storage_bytes, d_in, d_unique_out,
+                                                      d_counts_out, d_num_runs_out,
+                                                      numOfTriangleTouchingSD_instances));
     demErrchk(cudaDeviceSynchronize());
 
     // SD_numTrianglesTouching contains only zeros
@@ -135,10 +145,10 @@ __host__ void ChSystemDemMesh_impl::runTriangleBroadphase() {
     in_ptr = SD_numTrianglesTouching.data();
     // Just borrow the first element of SD_TrianglesCompositeOffsets to store the max value
     unsigned int* maxTriCount = SD_TrianglesCompositeOffsets.data();
-    cub::DeviceReduce::Max(NULL, temp_storage_bytes, in_ptr, maxTriCount, nSDs);
+    demErrchk(cub::DeviceReduce::Max(NULL, temp_storage_bytes, in_ptr, maxTriCount, nSDs));
     demErrchk(cudaDeviceSynchronize());
     d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
-    cub::DeviceReduce::Max(d_scratch_space, temp_storage_bytes, in_ptr, maxTriCount, nSDs);
+    demErrchk(cub::DeviceReduce::Max(d_scratch_space, temp_storage_bytes, in_ptr, maxTriCount, nSDs));
     demErrchk(cudaDeviceSynchronize());
     if (*maxTriCount > MAX_TRIANGLE_COUNT_PER_SD)
         CHDEM_ERROR("ERROR! %u triangles are found in one of the SDs! The max allowance is %u.\n", *maxTriCount,
@@ -147,11 +157,11 @@ __host__ void ChSystemDemMesh_impl::runTriangleBroadphase() {
     // Lastly, we need to do a CUB prefix scan to get the offsets in the big composite array
     in_ptr = SD_numTrianglesTouching.data();
     out_ptr = SD_TrianglesCompositeOffsets.data();
-    cub::DeviceScan::ExclusiveSum(NULL, temp_storage_bytes, in_ptr, out_ptr, nSDs);
+    demErrchk(cub::DeviceScan::ExclusiveSum(NULL, temp_storage_bytes, in_ptr, out_ptr, nSDs));
     demErrchk(cudaDeviceSynchronize());
     d_scratch_space = (void*)stateOfSolver_resources.pDeviceMemoryScratchSpace(temp_storage_bytes);
     // Run CUB exclusive prefix sum
-    cub::DeviceScan::ExclusiveSum(d_scratch_space, temp_storage_bytes, in_ptr, out_ptr, nSDs);
+    demErrchk(cub::DeviceScan::ExclusiveSum(d_scratch_space, temp_storage_bytes, in_ptr, out_ptr, nSDs));
     demErrchk(cudaDeviceSynchronize());
 }
 
@@ -228,7 +238,7 @@ __global__ void interactionGranMat_TriangleSoup_matBased(ChSystemDemMesh_impl::T
         if (local_ID < numSDTriangles) {
             size_t SD_composite_offset = SD_TrianglesCompositeOffsets[thisSD];
             if (SD_composite_offset == NULL_CHDEM_ID) {
-                ABORTABORTABORT("Invalid composite offset %lu for SD %u, touching %u triangles\n", NULL_CHDEM_ID,
+                ABORTABORTABORT("Invalid composite offset %u for SD %u, touching %u triangles\n", NULL_CHDEM_ID,
                                 thisSD, numSDTriangles);
             }
             size_t offset_in_composite_Array = SD_composite_offset + local_ID;
@@ -507,7 +517,7 @@ __global__ void interactionGranMat_TriangleSoup(ChSystemDemMesh_impl::TriangleSo
         if (local_ID < numSDTriangles) {
             size_t SD_composite_offset = SD_TrianglesCompositeOffsets[thisSD];
             if (SD_composite_offset == NULL_CHDEM_ID) {
-                ABORTABORTABORT("Invalid composite offset %lu for SD %u, touching %u triangles\n", NULL_CHDEM_ID,
+                ABORTABORTABORT("Invalid composite offset %u for SD %u, touching %u triangles\n", NULL_CHDEM_ID,
                                 thisSD, numSDTriangles);
             }
             size_t offset_in_composite_Array = SD_composite_offset + local_ID;

--- a/src/chrono_dem/cuda/ChGpuPrimitives.h
+++ b/src/chrono_dem/cuda/ChGpuPrimitives.h
@@ -1,0 +1,85 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Florian Reinle
+// =============================================================================
+// Use: Adaption for HIP/CUDA dual-backend support
+// =============================================================================
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#if defined(__CUDACC__) || defined(CHRONO_USE_CUDA)
+  #include <cuda_runtime.h>
+#elif defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+  #ifndef __HIP_PLATFORM_AMD__
+    #define __HIP_PLATFORM_AMD__
+  #endif
+  #include <hip/hip_runtime.h>
+#elif defined(CHRONO_USE_HIP) || defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_NVIDIA__)
+  // Host-side HIP build: reuse HIP's own vector types instead of declaring shadow
+  // structs with CUDA-style names. Otherwise, later inclusion of HIP runtime headers
+  // causes hard redefinition/conflict errors for int2/float3/double4/... .
+  #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIP_PLATFORM_NVIDIA__)
+    #define __HIP_PLATFORM_AMD__
+  #endif
+  #include <hip/hip_runtime_api.h>
+#else
+  #ifndef __host__
+    #define __host__
+  #endif
+  #ifndef __device__
+    #define __device__
+  #endif
+  #ifndef __global__
+    #define __global__
+  #endif
+  #ifndef __shared__
+    #define __shared__
+  #endif
+  #ifndef __constant__
+    #define __constant__
+  #endif
+  #ifndef __forceinline__
+    #define __forceinline__ inline
+  #endif
+
+struct int2 { int x, y; };
+struct int3 { int x, y, z; };
+struct int4 { int x, y, z, w; };
+struct uint2 { unsigned int x, y; };
+struct uint3 { unsigned int x, y, z; };
+struct uint4 { unsigned int x, y, z, w; };
+struct longlong3 { long long x, y, z; };
+struct float2 { float x, y; };
+struct float3 { float x, y, z; };
+struct float4 { float x, y, z, w; };
+struct double2 { double x, y; };
+struct double3 { double x, y, z; };
+struct double4 { double x, y, z, w; };
+
+constexpr inline int2 make_int2(int x, int y) { return {x, y}; }
+constexpr inline int3 make_int3(int x, int y, int z) { return {x, y, z}; }
+constexpr inline int4 make_int4(int x, int y, int z, int w) { return {x, y, z, w}; }
+constexpr inline uint2 make_uint2(unsigned int x, unsigned int y) { return {x, y}; }
+constexpr inline uint3 make_uint3(unsigned int x, unsigned int y, unsigned int z) { return {x, y, z}; }
+constexpr inline uint4 make_uint4(unsigned int x, unsigned int y, unsigned int z, unsigned int w) { return {x, y, z, w}; }
+constexpr inline longlong3 make_longlong3(long long x, long long y, long long z) { return {x, y, z}; }
+constexpr inline float2 make_float2(float x, float y) { return {x, y}; }
+constexpr inline float3 make_float3(float x, float y, float z) { return {x, y, z}; }
+constexpr inline float4 make_float4(float x, float y, float z, float w) { return {x, y, z, w}; }
+constexpr inline double2 make_double2(double x, double y) { return {x, y}; }
+constexpr inline double3 make_double3(double x, double y, double z) { return {x, y, z}; }
+constexpr inline double4 make_double4(double x, double y, double z, double w) { return {x, y, z, w}; }
+#endif

--- a/src/chrono_dem/cuda/ChGpuRuntime.h
+++ b/src/chrono_dem/cuda/ChGpuRuntime.h
@@ -1,0 +1,119 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Florian Reinle
+// =============================================================================
+// Use: Adaption for HIP/CUDA dual-backend support
+// =============================================================================
+
+#pragma once
+
+#include "chrono_dem/cuda/ChGpuPrimitives.h"
+
+#include <cstddef>
+#include <cstdlib>
+
+#if defined(__CUDACC__)
+  #include <cuda_runtime.h>
+  #include <cuda_runtime_api.h>
+  // CUB is not used by this compatibility header. Keep this include optional so
+  // normal CUDA builds do not require CUB to be on the host compiler include path.
+  #if __has_include(<cub/cub.cuh>)
+    #include <cub/cub.cuh>
+  #endif
+  #define CHGPU_DEVICE_ABORT() cuda::std::terminate()
+#elif defined(CHRONO_USE_CUDA)
+  // Host-side CUDA build: .cpp translation units need CUDA runtime declarations
+  // for cudaMallocManaged/cudaFree and CUDA vector types, but must not pull CUB.
+  #include <cuda_runtime.h>
+  #include <cuda_runtime_api.h>
+  #define CHGPU_DEVICE_ABORT() std::abort()
+#elif defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+  #ifndef __HIP_PLATFORM_AMD__
+    #define __HIP_PLATFORM_AMD__
+  #endif
+  #include <hip/hip_runtime.h>
+  #include <hip/hip_runtime_api.h>
+  #if __has_include(<hip/math_constants.h>)
+    #include <hip/math_constants.h>
+  #elif __has_include(<math_constants.h>)
+    #include <math_constants.h>
+  #endif
+  using cudaError_t = hipError_t;
+  using cudaMemcpyKind = hipMemcpyKind;
+  using cudaMemoryAdvise = hipMemoryAdvise;
+  static constexpr cudaError_t cudaSuccess = hipSuccess;
+  static constexpr cudaError_t cudaErrorMemoryAllocation = hipErrorMemoryAllocation;
+  static constexpr cudaError_t cudaErrorNotSupported = hipErrorNotSupported;
+  static constexpr unsigned int cudaMemAttachGlobal = hipMemAttachGlobal;
+  static constexpr cudaMemcpyKind cudaMemcpyHostToDevice = hipMemcpyHostToDevice;
+  static constexpr cudaMemcpyKind cudaMemcpyDeviceToHost = hipMemcpyDeviceToHost;
+  static constexpr cudaMemcpyKind cudaMemcpyDeviceToDevice = hipMemcpyDeviceToDevice;
+  static constexpr cudaMemoryAdvise cudaMemAdviseSetReadMostly = hipMemAdviseSetReadMostly;
+  inline const char* cudaGetErrorString(cudaError_t err) { return hipGetErrorString(err); }
+  inline cudaError_t cudaPeekAtLastError() { return hipPeekAtLastError(); }
+  inline cudaError_t cudaMalloc(void** ptr, std::size_t bytes) { return hipMalloc(ptr, bytes); }
+  template <class T> inline cudaError_t cudaMalloc(T** ptr, std::size_t bytes) { return hipMalloc(reinterpret_cast<void**>(ptr), bytes); }
+  inline cudaError_t cudaMallocManaged(void** ptr, std::size_t bytes, unsigned int flags = cudaMemAttachGlobal) { return hipMallocManaged(ptr, bytes, flags); }
+  template <class T> inline cudaError_t cudaMallocManaged(T** ptr, std::size_t bytes, unsigned int flags = cudaMemAttachGlobal) { return hipMallocManaged(reinterpret_cast<void**>(ptr), bytes, flags); }
+  inline cudaError_t cudaFree(void* ptr) { return hipFree(ptr); }
+  inline cudaError_t cudaMemcpy(void* dst, const void* src, std::size_t bytes, cudaMemcpyKind kind) { return hipMemcpy(dst, src, bytes, kind); }
+  inline cudaError_t cudaMemset(void* dst, int value, std::size_t bytes) { return hipMemset(dst, value, bytes); }
+  inline cudaError_t cudaDeviceSynchronize() { return hipDeviceSynchronize(); }
+  inline cudaError_t cudaGetDevice(int* dev) { return hipGetDevice(dev); }
+  inline cudaError_t cudaMemAdvise(const void* ptr, std::size_t bytes, cudaMemoryAdvise advice, int device) { return hipMemAdvise(ptr, bytes, advice, device); }
+  #ifndef CUDART_PI_F
+    #define CUDART_PI_F 3.14159265358979323846f
+  #endif
+  #define CHGPU_DEVICE_ABORT() __builtin_trap()
+#elif defined(CHRONO_USE_HIP) || defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_NVIDIA__)
+  #ifndef __HIP_PLATFORM_AMD__
+    #define __HIP_PLATFORM_AMD__
+  #endif
+  #include <hip/hip_runtime_api.h>
+  using cudaError_t = hipError_t;
+  using cudaMemcpyKind = hipMemcpyKind;
+  using cudaMemoryAdvise = hipMemoryAdvise;
+  static constexpr cudaError_t cudaSuccess = hipSuccess;
+  static constexpr cudaError_t cudaErrorMemoryAllocation = hipErrorMemoryAllocation;
+  static constexpr cudaError_t cudaErrorNotSupported = hipErrorNotSupported;
+  static constexpr unsigned int cudaMemAttachGlobal = hipMemAttachGlobal;
+  static constexpr cudaMemcpyKind cudaMemcpyHostToDevice = hipMemcpyHostToDevice;
+  static constexpr cudaMemcpyKind cudaMemcpyDeviceToHost = hipMemcpyDeviceToHost;
+  static constexpr cudaMemcpyKind cudaMemcpyDeviceToDevice = hipMemcpyDeviceToDevice;
+  static constexpr cudaMemoryAdvise cudaMemAdviseSetReadMostly = hipMemAdviseSetReadMostly;
+  inline const char* cudaGetErrorString(cudaError_t err) { return hipGetErrorString(err); }
+  inline cudaError_t cudaPeekAtLastError() { return hipPeekAtLastError(); }
+  inline cudaError_t cudaMalloc(void** ptr, std::size_t bytes) { return hipMalloc(ptr, bytes); }
+  template <class T> inline cudaError_t cudaMalloc(T** ptr, std::size_t bytes) { return hipMalloc(reinterpret_cast<void**>(ptr), bytes); }
+  inline cudaError_t cudaMallocManaged(void** ptr, std::size_t bytes, unsigned int flags = cudaMemAttachGlobal) { return hipMallocManaged(ptr, bytes, flags); }
+  template <class T> inline cudaError_t cudaMallocManaged(T** ptr, std::size_t bytes, unsigned int flags = cudaMemAttachGlobal) { return hipMallocManaged(reinterpret_cast<void**>(ptr), bytes, flags); }
+  inline cudaError_t cudaFree(void* ptr) { return hipFree(ptr); }
+  inline cudaError_t cudaMemcpy(void* dst, const void* src, std::size_t bytes, cudaMemcpyKind kind) { return hipMemcpy(dst, src, bytes, kind); }
+  inline cudaError_t cudaMemset(void* dst, int value, std::size_t bytes) { return hipMemset(dst, value, bytes); }
+  inline cudaError_t cudaDeviceSynchronize() { return hipDeviceSynchronize(); }
+  inline cudaError_t cudaGetDevice(int* dev) { return hipGetDevice(dev); }
+  inline cudaError_t cudaMemAdvise(const void* ptr, std::size_t bytes, cudaMemoryAdvise advice, int device) { return hipMemAdvise(ptr, bytes, advice, device); }
+  #ifndef CUDART_PI_F
+    #define CUDART_PI_F 3.14159265358979323846f
+  #endif
+  #define CHGPU_DEVICE_ABORT() std::abort()
+#else
+  using cudaError_t = int;
+  enum cudaMemcpyKind { cudaMemcpyHostToDevice = 1, cudaMemcpyDeviceToHost = 2, cudaMemcpyDeviceToDevice = 3 };
+  enum cudaMemoryAdvise { cudaMemAdviseSetReadMostly = 1 };
+  static constexpr cudaError_t cudaSuccess = 0;
+  static constexpr cudaError_t cudaErrorMemoryAllocation = 2;
+  static constexpr cudaError_t cudaErrorNotSupported = 801;
+  static constexpr unsigned int cudaMemAttachGlobal = 1u;
+  inline const char* cudaGetErrorString(cudaError_t) { return "GPU runtime unavailable in host-only translation unit"; }
+  #define CHGPU_DEVICE_ABORT() std::abort()
+#endif

--- a/src/chrono_dem/physics/ChSystemDemMesh_impl.cpp
+++ b/src/chrono_dem/physics/ChSystemDemMesh_impl.cpp
@@ -161,21 +161,21 @@ void ChSystemDemMesh_impl::ApplyFrameTransform(float3& p, float* pos, float* rot
 }
 
 void ChSystemDemMesh_impl::cleanupTriMesh() {
-    cudaFree(meshSoup->triangleFamily_ID);
-    cudaFree(meshSoup->familyMass_SU);
+    demErrchk(cudaFree(meshSoup->triangleFamily_ID));
+    demErrchk(cudaFree(meshSoup->familyMass_SU));
 
-    cudaFree(meshSoup->node1);
-    cudaFree(meshSoup->node2);
-    cudaFree(meshSoup->node3);
+    demErrchk(cudaFree(meshSoup->node1));
+    demErrchk(cudaFree(meshSoup->node2));
+    demErrchk(cudaFree(meshSoup->node3));
 
-    cudaFree(meshSoup->vel);
-    cudaFree(meshSoup->omega);
+    demErrchk(cudaFree(meshSoup->vel));
+    demErrchk(cudaFree(meshSoup->omega));
 
-    cudaFree(meshSoup->generalizedForcesPerFamily);
-    cudaFree(tri_params->fam_frame_broad);
-    cudaFree(tri_params->fam_frame_narrow);
-    cudaFree(meshSoup);
-    cudaFree(tri_params);
+    demErrchk(cudaFree(meshSoup->generalizedForcesPerFamily));
+    demErrchk(cudaFree(tri_params->fam_frame_broad));
+    demErrchk(cudaFree(tri_params->fam_frame_narrow));
+    demErrchk(cudaFree(meshSoup));
+    demErrchk(cudaFree(tri_params));
 }
 
 void ChSystemDemMesh_impl::ApplyMeshMotion(unsigned int mesh_id,

--- a/src/chrono_dem/physics/ChSystemDem_impl.cpp
+++ b/src/chrono_dem/physics/ChSystemDem_impl.cpp
@@ -12,8 +12,7 @@
 // Authors: Conlain Kelly, Nic Olsen, Dan Negrut, Luning Fang, Radu Serban
 // =============================================================================
 
-#include <cuda.h>
-#include <cuda_runtime.h>
+#include "chrono_dem/cuda/ChGpuRuntime.h"
 #include <cmath>
 #include <vector>
 #include <algorithm>

--- a/src/chrono_dem/physics/ChSystemDem_impl.h
+++ b/src/chrono_dem/physics/ChSystemDem_impl.h
@@ -55,10 +55,10 @@ class ChSolverStateData {
     float crntSimTime_SU;   // DN: needs to be brought here from GranParams
   public:
     ChSolverStateData() {
-        cudaMallocManaged(&pMaxNumberSpheresInAnySD, sizeof(unsigned int));
+        demErrchk(cudaMallocManaged(&pMaxNumberSpheresInAnySD, sizeof(unsigned int)));
         largestMaxNumberSpheresInAnySD_thusFar = 0;
     }
-    ~ChSolverStateData() { cudaFree(pMaxNumberSpheresInAnySD); }
+    ~ChSolverStateData() { demErrchk(cudaFree(pMaxNumberSpheresInAnySD)); }
     inline unsigned int* pMM_maxNumberSpheresInAnySD() {
         return pMaxNumberSpheresInAnySD;  ///< returns pointer to managed memory
     }

--- a/src/chrono_fsi/sph/CMakeLists.txt
+++ b/src/chrono_fsi/sph/CMakeLists.txt
@@ -23,14 +23,18 @@ if(EIGEN3_VERSION VERSION_LESS "3.3.6")
     return()
 endif()
 
-# Return now if CUDA is not available
-if(NOT CHRONO_CUDA_FOUND)
-    message(WARNING "Chrono::FSI::SPH requires CUDA, but CUDA was not found; disabling Chrono::FSI::SPH")
+# Return now if neither CUDA nor HIP is available
+if(NOT CHRONO_CUDA_FOUND AND NOT CHRONO_HIP_FOUND)
+    message(WARNING "Chrono::FSI::SPH requires CUDA or HIP, but neither backend was found; disabling Chrono::FSI::SPH")
     set(CH_ENABLE_MODULE_FSI_SPH OFF CACHE BOOL "Enable the Chrono::SPH FSI module" FORCE)
     return()
 endif()
 
-message(STATUS "  Chrono CUDA architectures: ${CHRONO_CUDA_ARCHITECTURES}")
+if(CHRONO_HIP_FOUND)
+    message(STATUS "  Chrono HIP architectures: ${CHRONO_HIP_ARCHITECTURES}")
+else()
+    message(STATUS "  Chrono CUDA architectures: ${CHRONO_CUDA_ARCHITECTURES}")
+endif()
 
 #-----------------------------------------------------------------------------
 
@@ -66,6 +70,7 @@ endif()
 # --------------- SPH FSI FILES
 
 set(FSISPH_BASE_FILES
+    ChSphGpuRuntime.h
     ChFsiDataTypesSPH.h
     ChFsiDefinitionsSPH.h
     ChFsiParamsSPH.h
@@ -132,6 +137,31 @@ set(FSISPH_UTILS_FILES
     utils/SphUtilsLogging.cuh
 )
 source_group("utils" FILES ${FSISPH_UTILS_FILES})
+
+set(FSISPH_GPU_SOURCE_FILES
+    ChFsiProblemSPH.cpp
+    ChFsiSystemSPH.cpp
+    ChFsiInterfaceSPH.cpp
+    ChFsiFluidSystemSPH.cpp
+    ChFsiSplashsurfSPH.cpp
+    physics/SphBceManager.cu
+    physics/SphCollisionSystem.cu
+    physics/SphDataManager.cu
+    physics/SphFluidDynamics.cu
+    physics/SphForce.cu
+    physics/SphForceWCSPH.cu
+    physics/SphForceISPH.cu
+    physics/SphFsiInterface.cu
+    physics/SphGeneral.cu
+    physics/SphParticleRelocator.cu
+    utils/SphUtilsDevice.cu
+    utils/SphUtilsPrint.cu
+)
+
+if(CHRONO_HIP_FOUND)
+    set_source_files_properties(${FSISPH_GPU_SOURCE_FILES} PROPERTIES LANGUAGE HIP)
+endif()
+
 
 # --------------- 3rd party STB FILES
 
@@ -208,24 +238,59 @@ if(MSVC)
   set_target_properties(Chrono_fsisph PROPERTIES MSVC_RUNTIME_LIBRARY ${CH_MSVC_RUNTIME_LIBRARY})
 endif()
 
-target_compile_options(Chrono_fsisph PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>)
+if(CHRONO_CUDA_FOUND)
+  target_compile_options(Chrono_fsisph PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>)
+endif()
 
 target_link_libraries(Chrono_fsisph PRIVATE Chrono_core)
 target_link_libraries(Chrono_fsisph PUBLIC Chrono_fsi)
 
-target_link_libraries(Chrono_fsisph PUBLIC CUDA::cudart_static)
-target_link_libraries(Chrono_fsisph PUBLIC CUDA::nvrtc)
-target_link_libraries(Chrono_fsisph PUBLIC CUDA::cuda_driver)
-target_link_libraries(Chrono_fsisph PUBLIC CUDA::cublas)
-target_link_libraries(Chrono_fsisph PUBLIC CUDA::cusparse)
+target_compile_definitions(Chrono_fsisph PRIVATE CH_API_COMPILE_FSI)
+if(CHRONO_HIP_FOUND)
+  target_compile_definitions(Chrono_fsisph PRIVATE CHRONO_USE_HIP)
+  target_compile_definitions(Chrono_fsisph INTERFACE CHRONO_FSI_SPH_USE_HIP_RUNTIME)
+endif()
 
-target_link_libraries(Chrono_fsisph PUBLIC Thrust::Thrust)
-target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA")
-target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
+if(CHRONO_CUDA_FOUND)
+  target_compile_definitions(Chrono_fsisph PUBLIC CHRONO_USE_CUDA)
+  target_link_libraries(Chrono_fsisph PUBLIC CUDA::cudart_static)
+  target_link_libraries(Chrono_fsisph PUBLIC CUDA::nvrtc)
+  target_link_libraries(Chrono_fsisph PUBLIC CUDA::cuda_driver)
+  target_link_libraries(Chrono_fsisph PUBLIC CUDA::cublas)
+  target_link_libraries(Chrono_fsisph PUBLIC CUDA::cusparse)
 
-target_compile_definitions(Chrono_fsisph PRIVATE $<$<COMPILE_LANGUAGE:CXX>:CH_API_COMPILE_FSI>)
+  target_link_libraries(Chrono_fsisph PUBLIC Thrust::Thrust)
+  target_compile_definitions(Chrono_fsisph PUBLIC "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA")
+  target_compile_definitions(Chrono_fsisph PUBLIC "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
 
-set_target_properties(Chrono_fsisph PROPERTIES CUDA_ARCHITECTURES ${CHRONO_CUDA_ARCHITECTURES})
+  set_target_properties(Chrono_fsisph PROPERTIES CUDA_ARCHITECTURES ${CHRONO_CUDA_ARCHITECTURES})
+elseif(CHRONO_HIP_FOUND)
+  find_package(hip QUIET CONFIG HINTS "${CHRONO_ROCM_ROOT}")
+  if(TARGET hip::host)
+    # Keep HIP compiler/runtime flags local to the fsisph target.
+    # Public consumers are regular C++ translation units that only need the ROCm
+    # headers for declarations from public headers, not the HIP target's compile
+    # definitions/options that can force Thrust onto the rocPRIM backend.
+    target_link_libraries(Chrono_fsisph PRIVATE hip::host)
+  endif()
+  if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
+    target_include_directories(Chrono_fsisph PUBLIC "${CHRONO_ROCM_ROOT}/include")
+  endif()
+  target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP")
+  target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
+  target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP")
+  target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
+  # Mixed CXX/HIP targets can leak HIP_ARCHITECTURES into ordinary CXX compilations
+  # (for example stb_image.cpp), which makes the host compiler see --offload-arch.
+  # Keep the target-level property disabled and pass the GPU arch flags only to real HIP TUs.
+  set_target_properties(Chrono_fsisph PROPERTIES HIP_ARCHITECTURES OFF)
+  if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
+    foreach(_chrono_hip_arch IN LISTS CHRONO_HIP_ARCHITECTURES)
+      target_compile_options(Chrono_fsisph PRIVATE $<$<COMPILE_LANGUAGE:HIP>:--offload-arch=${_chrono_hip_arch}>)
+      target_link_options(Chrono_fsisph PRIVATE $<$<LINK_LANGUAGE:HIP>:--offload-arch=${_chrono_hip_arch}>)
+    endforeach()
+  endif()
+endif()
 
 install(TARGETS Chrono_fsisph
         EXPORT ChronoTargets
@@ -259,20 +324,33 @@ if(CH_ENABLE_MODULE_VSG)
       set_target_properties(Chrono_fsisph_vsg PROPERTIES MSVC_RUNTIME_LIBRARY ${CH_MSVC_RUNTIME_LIBRARY})
     endif()
 
-    target_compile_definitions(Chrono_fsisph_vsg PRIVATE $<$<COMPILE_LANGUAGE:CXX>:CH_API_COMPILE_FSI>)
+    target_compile_definitions(Chrono_fsisph_vsg PRIVATE CH_API_COMPILE_FSI)
     
     target_link_libraries(Chrono_fsisph_vsg PRIVATE Chrono_core Chrono_fsisph)
     target_link_libraries(Chrono_fsisph_vsg PUBLIC Chrono_vsg)
 
-    target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cudart_static)
-    target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::nvrtc)
-    target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cuda_driver)
-    target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cublas)
-    target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cusparse)
+    if(CHRONO_CUDA_FOUND)
+      target_compile_definitions(Chrono_fsisph_vsg PRIVATE CHRONO_USE_CUDA)
+      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cudart_static)
+      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::nvrtc)
+      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cuda_driver)
+      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cublas)
+      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cusparse)
 
-    target_link_libraries(Chrono_fsisph_vsg PRIVATE Thrust::Thrust)
-    target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA")
-    target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
+      target_link_libraries(Chrono_fsisph_vsg PRIVATE Thrust::Thrust)
+      target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA")
+      target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
+    elseif(CHRONO_HIP_FOUND)
+      target_compile_definitions(Chrono_fsisph_vsg PRIVATE CHRONO_USE_HIP)
+      target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP")
+      target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
+      if(TARGET hip::host)
+        target_link_libraries(Chrono_fsisph_vsg PRIVATE hip::host)
+      endif()
+      if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
+        target_include_directories(Chrono_fsisph_vsg PRIVATE "${CHRONO_ROCM_ROOT}/include")
+      endif()
+    endif()
 
     install(TARGETS Chrono_fsisph_vsg
             EXPORT ChronoTargets

--- a/src/chrono_fsi/sph/ChFsiDataTypesSPH.h
+++ b/src/chrono_fsi/sph/ChFsiDataTypesSPH.h
@@ -23,8 +23,7 @@
 #include <cmath>
 #include <ostream>
 
-#include <cuda_runtime.h>
-#include <cuda/std/limits>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 
 #include "chrono_fsi/sph/ChFsiConfigSPH.h"
 

--- a/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
@@ -729,13 +729,18 @@ void ChFsiFluidSystemSPH::SetBcePattern2D(BcePatternMesh2D pattern, bool remove_
 
 void PrintDeviceProperties(const cudaDeviceProp& prop) {
     cout << "GPU device: " << prop.name << endl;
-    cout << "  Compute capability: " << prop.major << "." << prop.minor << endl;
     cout << "  Total global memory: " << prop.totalGlobalMem / (1024. * 1024. * 1024.) << " GB" << endl;
     cout << "  Total constant memory: " << prop.totalConstMem / 1024. << " KB" << endl;
     cout << "  Total available static shared memory per block: " << prop.sharedMemPerBlock / 1024. << " KB" << endl;
+    cout << "  Number of multiprocessors: " << prop.multiProcessorCount << endl;
+#if defined(CHRONO_USE_HIP)
+    cout << "  Warp/Wavefront size: " << prop.warpSize << endl;
+    cout << "  Max threads per block: " << prop.maxThreadsPerBlock << endl;
+#else
+    cout << "  Compute capability: " << prop.major << "." << prop.minor << endl;
     cout << "  Max. dynamic shared memory per block: " << prop.sharedMemPerBlockOptin / 1024. << " KB" << endl;
     cout << "  Total shared memory per multiprocessor: " << prop.sharedMemPerMultiprocessor / 1024. << " KB" << endl;
-    cout << "  Number of multiprocessors: " << prop.multiProcessorCount << endl;
+#endif
 }
 
 void PrintParams(const ChFsiParamsSPH& params, const Counters& counters) {

--- a/src/chrono_fsi/sph/ChSphGpuPrimitives.h
+++ b/src/chrono_fsi/sph/ChSphGpuPrimitives.h
@@ -1,0 +1,92 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Author: Florian Reinle
+// =============================================================================
+// Use: Adaption for HIP/CUDA dual-backend support
+// =============================================================================
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#if defined(__CUDACC__) || defined(CHRONO_USE_CUDA)
+  #include <cuda_runtime.h>
+#elif defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+  #ifndef __HIP_PLATFORM_AMD__
+    #define __HIP_PLATFORM_AMD__
+  #endif
+  #include <hip/hip_runtime.h>
+#elif defined(CHRONO_USE_HIP) || defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_NVIDIA__)
+  // Host-side HIP build: use HIP-provided vector aliases/functions so later HIP
+  // runtime includes do not collide with local fallback declarations.
+  #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIP_PLATFORM_NVIDIA__)
+    #define __HIP_PLATFORM_AMD__
+  #endif
+  #include <hip/hip_runtime_api.h>
+#else
+  #ifndef __host__
+    #define __host__
+  #endif
+  #ifndef __device__
+    #define __device__
+  #endif
+  #ifndef __global__
+    #define __global__
+  #endif
+  #ifndef __shared__
+    #define __shared__
+  #endif
+  #ifndef __constant__
+    #define __constant__
+  #endif
+  #ifndef __forceinline__
+    #define __forceinline__ inline
+  #endif
+
+struct int2 { int x, y; };
+struct int3 { int x, y, z; };
+struct int4 { int x, y, z, w; };
+struct uint2 { unsigned int x, y; };
+struct uint3 { unsigned int x, y, z; };
+struct uint4 { unsigned int x, y, z, w; };
+struct float2 { float x, y; };
+struct float3 { float x, y, z; };
+struct float4 { float x, y, z, w; };
+struct double2 { double x, y; };
+struct double3 { double x, y, z; };
+struct double4 { double x, y, z, w; };
+
+constexpr inline int2 make_int2(int x, int y) { return {x, y}; }
+constexpr inline int3 make_int3(int x, int y, int z) { return {x, y, z}; }
+constexpr inline int4 make_int4(int x, int y, int z, int w) { return {x, y, z, w}; }
+constexpr inline uint2 make_uint2(unsigned int x, unsigned int y) { return {x, y}; }
+constexpr inline uint3 make_uint3(unsigned int x, unsigned int y, unsigned int z) { return {x, y, z}; }
+constexpr inline uint4 make_uint4(unsigned int x, unsigned int y, unsigned int z, unsigned int w) { return {x, y, z, w}; }
+constexpr inline float2 make_float2(float x, float y) { return {x, y}; }
+constexpr inline float3 make_float3(float x, float y, float z) { return {x, y, z}; }
+constexpr inline float4 make_float4(float x, float y, float z, float w) { return {x, y, z, w}; }
+constexpr inline double2 make_double2(double x, double y) { return {x, y}; }
+constexpr inline double3 make_double3(double x, double y, double z) { return {x, y, z}; }
+constexpr inline double4 make_double4(double x, double y, double z, double w) { return {x, y, z, w}; }
+#endif
+
+// Provide cuda::std as a lightweight host fallback only when we are not
+// compiling against the real CUDA CCCL/libcudacxx headers. In CUDA builds,
+// cuda::std is provided by <cuda/std/...>; aliasing it to ::std in ordinary
+// C++ translation units conflicts with CUDA 12/13 CCCL headers.
+#if !defined(__CUDACC__) && !defined(CHRONO_USE_CUDA)
+namespace cuda {
+namespace std = ::std;
+}
+#endif

--- a/src/chrono_fsi/sph/ChSphGpuRuntime.h
+++ b/src/chrono_fsi/sph/ChSphGpuRuntime.h
@@ -1,0 +1,85 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Author: Florian Reinle
+// =============================================================================
+// Use: Adaption for HIP/CUDA dual-backend support
+// =============================================================================
+
+#pragma once
+
+#include "chrono_fsi/sph/ChSphGpuPrimitives.h"
+
+#include <cstddef>
+#include <utility>
+
+#if defined(__CUDACC__) || defined(CHRONO_USE_CUDA)
+  #include <cuda_runtime.h>
+  #include <cuda_runtime_api.h>
+  #include <cuda/std/limits>
+#elif defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+  #ifndef __HIP_PLATFORM_AMD__
+    #define __HIP_PLATFORM_AMD__
+  #endif
+  #include <hip/hip_runtime.h>
+  #include <hip/hip_runtime_api.h>
+  #define CHRONO_FSI_SPH_RUNTIME_IS_HIP 1
+  using cudaStream_t = hipStream_t;
+  using cudaEvent_t = hipEvent_t;
+  using cudaError_t = int;
+  using cudaDeviceProp = hipDeviceProp_t;
+  using cudaMemcpyKind = hipMemcpyKind;
+  static constexpr cudaError_t cudaSuccess = static_cast<int>(hipSuccess);
+  static constexpr cudaError_t cudaErrorMemoryAllocation = static_cast<int>(hipErrorMemoryAllocation);
+  static constexpr cudaError_t cudaErrorNotSupported = static_cast<int>(hipErrorNotSupported);
+  static constexpr cudaMemcpyKind cudaMemcpyHostToDevice = hipMemcpyHostToDevice;
+  static constexpr cudaMemcpyKind cudaMemcpyDeviceToHost = hipMemcpyDeviceToHost;
+  static constexpr cudaMemcpyKind cudaMemcpyDeviceToDevice = hipMemcpyDeviceToDevice;
+  inline const char* cudaGetErrorString(cudaError_t err) { return hipGetErrorString(static_cast<hipError_t>(err)); }
+  inline cudaError_t cudaGetLastError() { return hipGetLastError(); }
+  inline cudaError_t cudaPeekAtLastError() { return hipPeekAtLastError(); }
+  inline cudaError_t cudaMalloc(void** ptr, std::size_t bytes) { return hipMalloc(ptr, bytes); }
+  template <class T> inline cudaError_t cudaMalloc(T** ptr, std::size_t bytes) { return hipMalloc(reinterpret_cast<void**>(ptr), bytes); }
+  inline cudaError_t cudaFree(void* ptr) { return hipFree(ptr); }
+  inline cudaError_t cudaMemcpy(void* dst, const void* src, std::size_t bytes, cudaMemcpyKind kind) { return hipMemcpy(dst, src, bytes, kind); }
+  inline cudaError_t cudaMemcpyAsync(void* dst, const void* src, std::size_t bytes, cudaMemcpyKind kind, cudaStream_t stream = 0) { return hipMemcpyAsync(dst, src, bytes, kind, stream); }
+  // Important: HIP_SYMBOL must be applied at the call site to the actual device symbol token.
+  // Wrapping hipMemcpyTo/FromSymbol in a C++ function template would apply HIP_SYMBOL to the
+  // function parameter `symbol`, not to the original device symbol (e.g., paramsD/countersD),
+  // which can compile but route symbol copies incorrectly at runtime.
+  // Current SPH code only uses the 3-argument CUDA forms, so map exactly those here.
+  #define cudaMemcpyToSymbolAsync(symbol, src, bytes) hipMemcpyToSymbolAsync(HIP_SYMBOL(symbol), src, bytes, 0, hipMemcpyHostToDevice, 0)
+  #define cudaMemcpyFromSymbol(dst, symbol, bytes)    hipMemcpyFromSymbol(dst, HIP_SYMBOL(symbol), bytes, 0, hipMemcpyDeviceToHost)
+  inline cudaError_t cudaMemset(void* dst, int value, std::size_t bytes) { return hipMemset(dst, value, bytes); }
+  inline cudaError_t cudaDeviceSynchronize() { return hipDeviceSynchronize(); }
+  inline cudaError_t cudaGetDevice(int* dev) { return hipGetDevice(dev); }
+  inline cudaError_t cudaGetDeviceProperties(cudaDeviceProp* prop, int device) { return hipGetDeviceProperties(prop, device); }
+  inline cudaError_t cudaStreamCreate(cudaStream_t* stream) { return hipStreamCreate(stream); }
+  inline cudaError_t cudaStreamDestroy(cudaStream_t stream) { return hipStreamDestroy(stream); }
+  inline cudaError_t cudaStreamSynchronize(cudaStream_t stream) { return hipStreamSynchronize(stream); }
+  inline cudaError_t cudaEventCreate(cudaEvent_t* event) { return hipEventCreate(event); }
+  inline cudaError_t cudaEventDestroy(cudaEvent_t event) { return hipEventDestroy(event); }
+  inline cudaError_t cudaEventRecord(cudaEvent_t event, cudaStream_t stream = 0) { return hipEventRecord(event, stream); }
+  inline cudaError_t cudaEventSynchronize(cudaEvent_t event) { return hipEventSynchronize(event); }
+  inline cudaError_t cudaEventElapsedTime(float* ms, cudaEvent_t start, cudaEvent_t stop) { return hipEventElapsedTime(ms, start, stop); }
+#else
+  struct cudaDeviceProp { int _chrono_placeholder = 0; };
+  using cudaStream_t = void*;
+  using cudaEvent_t = void*;
+  using cudaError_t = int;
+  enum cudaMemcpyKind { cudaMemcpyHostToDevice = 1, cudaMemcpyDeviceToHost = 2, cudaMemcpyDeviceToDevice = 3 };
+  static constexpr cudaError_t cudaSuccess = 0;
+  static constexpr cudaError_t cudaErrorMemoryAllocation = 2;
+  static constexpr cudaError_t cudaErrorNotSupported = 801;
+  inline const char* cudaGetErrorString(cudaError_t) { return "GPU runtime unavailable in host-only translation unit"; }
+  inline cudaError_t cudaGetLastError() { return 0; }
+  inline cudaError_t cudaPeekAtLastError() { return 0; }
+#endif

--- a/src/chrono_fsi/sph/math/SphCustomMath.cuh
+++ b/src/chrono_fsi/sph/math/SphCustomMath.cuh
@@ -20,7 +20,7 @@
 #ifndef CH_SPH_CUSTOM_MATH_H
 #define CH_SPH_CUSTOM_MATH_H
 
-#include <cuda_runtime.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 #include <cmath>
 
 #include "chrono_fsi/sph/ChFsiDataTypesSPH.h"
@@ -1224,6 +1224,45 @@ __host__ __device__ inline Real4 make_Real4(Real3 a, Real w) {
 __host__ __device__ inline Real4 make_Real4(Real4 a) {
     return make_Real4(a.x, a.y, a.z, a.w);
 }
+
+// ----------------------------------------------------------------------------
+// Lightweight shorthand aliases
+// ----------------------------------------------------------------------------
+// Historically these convenience names were provided through
+// utils/SphUtilsDevice.cuh. That header also brings in thrust/device_vector and
+// rocPRIM, which is undesirable in ordinary host translation units during HIP
+// builds. Define the shorthand next to the math constructors instead so host
+// code keeps mR3/mI3/mR4 without depending on the heavy device-utility header.
+#ifndef mF2
+    #define mF2 make_float2
+#endif
+#ifndef mF3
+    #define mF3 make_float3
+#endif
+#ifndef mF4
+    #define mF4 make_float4
+#endif
+#ifndef mR2
+    #define mR2 make_Real2
+#endif
+#ifndef mR3
+    #define mR3 make_Real3
+#endif
+#ifndef mR4
+    #define mR4 make_Real4
+#endif
+#ifndef mI2
+    #define mI2 make_int2
+#endif
+#ifndef mI3
+    #define mI3 make_int3
+#endif
+#ifndef mI4
+    #define mI4 make_int4
+#endif
+#ifndef mU3
+    #define mU3 make_uint3
+#endif
 __host__ __device__ inline Real4 make_Real4(int4 a) {
     return make_Real4(Real(a.x), Real(a.y), Real(a.z), Real(a.w));
 }

--- a/src/chrono_fsi/sph/math/SphExactLinearSolvers.cuh
+++ b/src/chrono_fsi/sph/math/SphExactLinearSolvers.cuh
@@ -19,7 +19,7 @@
 #ifndef CH_SPH_EXACT_SOLVERS_H
 #define CH_SPH_EXACT_SOLVERS_H
 
-#include <cuda_runtime.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 
 namespace chrono {
 namespace fsi {

--- a/src/chrono_fsi/sph/math/SphLinearSolver.h
+++ b/src/chrono_fsi/sph/math/SphLinearSolver.h
@@ -19,7 +19,7 @@
 #define CHFSILINEARSOLVER_H_
 
 #include <ctype.h>
-#include <cuda_runtime.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/chrono_fsi/sph/math/SphLinearSolverBiCGStab.cpp
+++ b/src/chrono_fsi/sph/math/SphLinearSolverBiCGStab.cpp
@@ -16,7 +16,7 @@
 // =============================================================================
 
 #include <ctype.h>
-#include <cuda_runtime.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/chrono_fsi/sph/math/SphLinearSolverBiCGStab.h
+++ b/src/chrono_fsi/sph/math/SphLinearSolverBiCGStab.h
@@ -19,7 +19,7 @@
 #define CH_SPH_LINEARSOLVER_BICGSTAB_H
 
 #include <ctype.h>
-#include <cuda_runtime.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/chrono_fsi/sph/math/SphLinearSolverGMRES.cpp
+++ b/src/chrono_fsi/sph/math/SphLinearSolverGMRES.cpp
@@ -16,7 +16,7 @@
 // =============================================================================
 
 #include <ctype.h>
-#include <cuda_runtime.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/chrono_fsi/sph/math/SphLinearSolverGMRES.h
+++ b/src/chrono_fsi/sph/math/SphLinearSolverGMRES.h
@@ -19,7 +19,7 @@
 #define CH_SPH_LINEARSOLVER_GMRES_H
 
 #include <ctype.h>
-#include <cuda_runtime.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/chrono_fsi/sph/physics/SphGeneral.cuh
+++ b/src/chrono_fsi/sph/physics/SphGeneral.cuh
@@ -19,22 +19,42 @@
 #ifndef CH_SPH_GENERAL_CUH
 #define CH_SPH_GENERAL_CUH
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <cuda_runtime_api.h>
-#include <device_launch_parameters.h>
+#if __has_include("chrono_fsi/sph/ChSphGpuRuntime.h")
+  #include "chrono_fsi/sph/ChSphGpuRuntime.h"
+#else
+  #include <cuda.h>
+  #include <cuda_runtime.h>
+  #include <cuda_runtime_api.h>
+#endif
+#if defined(__CUDACC__)
+  #include <device_launch_parameters.h>
+#endif
 
-#include "chrono_fsi/sph/physics/SphDataManager.cuh"
+#include <memory>
+
+#include "chrono_fsi/sph/ChFsiParamsSPH.h"
+#include "chrono_fsi/sph/math/SphCustomMath.cuh"
+
+#if defined(__CUDACC__) || defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+  #include "chrono_fsi/sph/physics/SphDataManager.cuh"
+#endif
 
 namespace chrono {
 namespace fsi {
 namespace sph {
 
+/// @addtogroup fsisph_physics
+/// @{
+
+struct Counters;
+
 //--------------------------------------------------------------------------------------------------------------------------------
 
 // Declared as const variables static in order to be able to use them in a different translation units in the utils
 __constant__ static ChFsiParamsSPH paramsD;
+#if defined(__CUDACC__) || defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
 __constant__ static Counters countersD;
+#endif
 
 void CopyParametersToDevice(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
 
@@ -42,9 +62,6 @@ void CopyParametersToDevice(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared
 
 #define INVPI Real(0.31830988618379)
 #define EPSILON Real(1e-8)
-
-/// @addtogroup fsisph_physics
-/// @{
 
 //--------------------------------------------------------------------------------------------------------------------------------
 // Cubic Spline SPH kernel function

--- a/src/chrono_fsi/sph/physics/SphMarkerType.cuh
+++ b/src/chrono_fsi/sph/physics/SphMarkerType.cuh
@@ -17,9 +17,7 @@
 #ifndef CH_SPH_MARKER_TYPE_CUH
 #define CH_SPH_MARKER_TYPE_CUH
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <cuda_runtime_api.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 
 #include "chrono_fsi/ChApiFsi.h"
 #include "chrono_fsi/sph/ChFsiDataTypesSPH.h"

--- a/src/chrono_fsi/sph/physics/SphParticleRelocator.cu
+++ b/src/chrono_fsi/sph/physics/SphParticleRelocator.cu
@@ -37,6 +37,7 @@
 
 #include "chrono/utils/ChUtils.h"
 
+#include "chrono_fsi/sph/physics/SphDataManager.cuh"
 #include "chrono_fsi/sph/physics/SphParticleRelocator.cuh"
 #include "chrono_fsi/sph/utils/SphUtilsDevice.cuh"
 

--- a/src/chrono_fsi/sph/physics/SphParticleRelocator.cuh
+++ b/src/chrono_fsi/sph/physics/SphParticleRelocator.cuh
@@ -19,7 +19,8 @@
 #ifndef SPH_PARTICLE_RELOCATOR_CUH
 #define SPH_PARTICLE_RELOCATOR_CUH
 
-#include "chrono_fsi/sph/physics/SphDataManager.cuh"
+#include "chrono_fsi/sph/ChFsiDataTypesSPH.h"
+#include "chrono_fsi/sph/physics/SphMarkerType.cuh"
 
 namespace chrono {
 namespace fsi {
@@ -27,6 +28,8 @@ namespace sph {
 
 /// @addtogroup fsisph_physics
 /// @{
+
+class FsiDataManager;
 
 class SphParticleRelocator {
   public:

--- a/src/chrono_fsi/sph/utils/SphUtilsDevice.cuh
+++ b/src/chrono_fsi/sph/utils/SphUtilsDevice.cuh
@@ -18,7 +18,7 @@
 #ifndef CH_SPH_UTILS_DEVICE_H
 #define CH_SPH_UTILS_DEVICE_H
 
-#include <cuda_runtime.h>
+#include "chrono_fsi/sph/ChSphGpuRuntime.h"
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>

--- a/src/chrono_sensor/CMakeLists.txt
+++ b/src/chrono_sensor/CMakeLists.txt
@@ -37,7 +37,10 @@ set(CH_USE_SENSOR_OPTIX TRUE CACHE BOOL "Enable OptiX-dependent Chrono::Sensor f
 
 if(CH_USE_SENSOR_OPTIX)
 
-  if(CHRONO_CUDA_FOUND)
+  if(CHRONO_HIP_FOUND)
+    message(STATUS "WARNING: Chrono::Sensor / OptiX is CUDA-only and not supported with HIP; disabling OptiX-dependent features")
+    set(CH_USE_SENSOR_OPTIX FALSE CACHE BOOL "Enable OptiX-dependent Chrono::Sensor features" FORCE)
+  elseif(CHRONO_CUDA_FOUND)
     message(STATUS "Chrono CUDA architectures: ${CHRONO_CUDA_ARCHITECTURES}")
   
     message(STATUS "Looking for OptiX")


### PR DESCRIPTION
This is a port of the Chrono code to be AMD HIP compatible. The CUDA parts have been modified to support a dual CUDA-HIP backend. This affects 34 files, with what I consider minimal and useful changes.

Three modules are affected:

Chrono DEM: fully ported
Chrono FSI SPH: fully ported
Chrono Sensor: runs without OptiX on AMD, but the OptiX part is not ported

Runtime checks were performed, but only on AMD gfx1151 (Radeon 8060S iGPU); therefore, testing was **not** very extensive.

CUDA still runs fine as well, tested on an RTX 4090.