### PR TITLE
Fix sensor otpix includes and NVRTC CUDA 13

### DIFF
--- a/src/chrono_sensor/CMakeLists.txt
+++ b/src/chrono_sensor/CMakeLists.txt
@@ -560,7 +560,7 @@ if(CH_USE_SENSOR_OPTIX)
     # Flags used directly in the source code as defines
 
     #set(CUDA_NVRTC_FLAGS -arch compute_30 -use_fast_math -lineinfo -default-device -rdc true -D__x86_64 CACHE STRING "NVRTC flags as list." FORCE)
-    set(CUDA_NVRTC_FLAGS -use_fast_math -std=c++11 -default-device -rdc true -D__x86_64 CACHE STRING "NVRTC flags as list." FORCE)
+    set(CUDA_NVRTC_FLAGS -use_fast_math -std=c++17 -default-device -rdc true -D__x86_64 CACHE STRING "NVRTC flags as list." FORCE)
     mark_as_advanced(CUDA_NVRTC_FLAGS)
     message(STATUS "  CUDA NVRTC flags: ${CUDA_NVRTC_FLAGS}")
 
@@ -570,9 +570,23 @@ if(CH_USE_SENSOR_OPTIX)
     endforeach()
     set(CUDA_NVRTC_FLAG_LIST "${CUDA_NVRTC_FLAG_LIST} \\\n  0,")
   
+    # CUDA 13 places CCCL/libcu++ headers in <cuda>/include/cccl, but curand_kernel.h
+    # includes them as <cuda/std/...>. NVRTC does not automatically add that directory.
+    set(_CHRONO_CUDA_CCCL_INCLUDE_DIRS)
+    foreach(_cuda_include_dir ${CUDAToolkit_INCLUDE_DIRS})
+      if(EXISTS "${_cuda_include_dir}/cccl/cuda/std/type_traits")
+        list(APPEND _CHRONO_CUDA_CCCL_INCLUDE_DIRS "${_cuda_include_dir}/cccl")
+      endif()
+    endforeach()
+    if(DEFINED CUDAToolkit_TARGET_DIR AND EXISTS "${CUDAToolkit_TARGET_DIR}/include/cccl/cuda/std/type_traits")
+      list(APPEND _CHRONO_CUDA_CCCL_INCLUDE_DIRS "${CUDAToolkit_TARGET_DIR}/include/cccl")
+    endif()
+    list(REMOVE_DUPLICATES _CHRONO_CUDA_CCCL_INCLUDE_DIRS)
+
     set(CUDA_NVRTC_INCLUDE_DIRS
         ${OptiX_INCLUDE}
         ${CUDAToolkit_INCLUDE_DIRS}
+        ${_CHRONO_CUDA_CCCL_INCLUDE_DIRS}
         ${CMAKE_INSTALL_PREFIX}/include
         ${CMAKE_SOURCE_DIR}/src
         CACHE STRING "NVRTC include dirs as list." FORCE)


### PR DESCRIPTION
The sensor module is now functional with OptiX.

Include directories have been updated for CUDA 13.

The most critical change is the requirement of **C++17** for the NVRTC compiler. Since this is a development build and Chrono 11 is unlikely to be used with legacy build tools or older operating systems (older such as Debian 9), adding this flag specifically for the RTC stack is not problematic.
Everything works fine (note: the top two windows were stretched).

<img width="1795" height="1008" alt="image" src="https://github.com/user-attachments/assets/2bb94439-6321-4f79-ba6d-b999435bd5f5" />
