### PR TITLE
AMD/HIP runtime fix

### DIFF
--- a/src/chrono/gpu/ChGpuPrimitives.h
+++ b/src/chrono/gpu/ChGpuPrimitives.h
@@ -24,11 +24,10 @@
 
 #if defined(__CUDACC__) || defined(CHRONO_USE_CUDA)
     #include <cuda_runtime.h>
-    #include <cuda/std/limits>
 
-static constexpr double double_max = ::cuda::std::numeric_limits<double>::max();
-static constexpr float float_max = ::cuda::std::numeric_limits<float>::max();
-static constexpr int int_max = ::cuda::std::numeric_limits<int>::max();
+static constexpr double double_max = std::numeric_limits<double>::max();
+static constexpr float float_max = std::numeric_limits<float>::max();
+static constexpr int int_max = std::numeric_limits<int>::max();
 
 #elif defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
     #ifndef __HIP_PLATFORM_AMD__

--- a/src/chrono/gpu/ChGpuRuntime.h
+++ b/src/chrono/gpu/ChGpuRuntime.h
@@ -27,7 +27,6 @@
 
     #include <cuda_runtime.h>
     #include <cuda_runtime_api.h>
-    #include <cuda/std/limits>
 
 // Type aliases
 using gpuStream = cudaStream_t;
@@ -70,15 +69,13 @@ inline gpuError gpuMemcpy(void* dst, const void* src, std::size_t bytes, gpuMemc
 inline gpuError gpuMemcpyAsync(void* dst, const void* src, std::size_t bytes, gpuMemcpyKind kind, gpuStream stream = 0) {
     return cudaMemcpyAsync(dst, src, bytes, kind, stream);
 }
-inline gpuError gpuMemcpyToSymbolAsync(const void* symbol, const void* src, size_t count, size_t offset, gpuMemcpyKind kind, gpuStream stream = 0) {
-    return cudaMemcpyToSymbolAsync(symbol, src, count, offset, kind, stream);
-}
-inline gpuError gpuMemcpyToSymbolAsync(const void* symbol, const void* src, size_t count) {
-    return cudaMemcpyToSymbolAsync(symbol, src, count, 0, cudaMemcpyHostToDevice, 0);
-}
-inline gpuError gpuMemcpyFromSymbol(void* dst, const void* symbol, size_t count, size_t offset = 0, gpuMemcpyKind kind = cudaMemcpyDeviceToHost) {
-    return cudaMemcpyFromSymbol(dst, symbol, count, offset, cudaMemcpyDeviceToHost);
-}
+    // cudaMemcpyTo/FromSymbol need the actual device symbol token, not the address of that
+    // token. Keep these as macros so CUDA and HIP call sites use the same spelling.
+    // Current Chrono GPU code only uses the 3-argument forms, so map exactly those here.
+    #define gpuMemcpyToSymbolAsync(symbol, src, bytes) \
+        cudaMemcpyToSymbolAsync(symbol, src, bytes, 0, cudaMemcpyHostToDevice, 0)
+    #define gpuMemcpyFromSymbol(dst, symbol, bytes) \
+        cudaMemcpyFromSymbol(dst, symbol, bytes, 0, cudaMemcpyDeviceToHost)
 inline gpuError gpuMemset(void* dst, int value, std::size_t bytes) {
     return cudaMemset(dst, value, bytes);
 }

--- a/src/chrono_fsi/sph/physics/SphBceManager.cu
+++ b/src/chrono_fsi/sph/physics/SphBceManager.cu
@@ -35,6 +35,16 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
+#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+void CopyParametersToDevice_SphBceManager(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
+    gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuCheckError();
+    gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
+    gpuCheckError();
+}
+
+#endif
+
 SphBceManager::SphBceManager(FsiDataManager& data_mgr, NodeDirections node_directions_mode, bool verbose, bool check_errors)
     : m_data_mgr(data_mgr),
       m_node_directions_mode(node_directions_mode),
@@ -51,8 +61,8 @@ SphBceManager::~SphBceManager() {}
 // -----------------------------------------------------------------------------
 
 void SphBceManager::Initialize(std::vector<int> fsiBodyBceNum) {
-    gpuMemcpyToSymbolAsync(&paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
-    gpuMemcpyToSymbolAsync(&countersD, m_data_mgr.countersH.get(), sizeof(Counters));
+    gpuMemcpyToSymbolAsync(paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuMemcpyToSymbolAsync(countersD, m_data_mgr.countersH.get(), sizeof(Counters));
 
     // Resizing the arrays used to modify the BCE velocity and pressure according to Adami
     m_totalForceRigid.resize(m_data_mgr.countersH->numFsiBodies);

--- a/src/chrono_fsi/sph/physics/SphCollisionSystem.cu
+++ b/src/chrono_fsi/sph/physics/SphCollisionSystem.cu
@@ -25,6 +25,16 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
+#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+void CopyParametersToDevice_SphCollisionSystem(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
+    gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuCheckError();
+    gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
+    gpuCheckError();
+}
+
+#endif
+
 // =============================================================================
 
 // Create the active list
@@ -307,8 +317,8 @@ SphCollisionSystem::SphCollisionSystem(FsiDataManager& data_mgr) : m_data_mgr(da
 SphCollisionSystem::~SphCollisionSystem() {}
 
 void SphCollisionSystem::Initialize() {
-    gpuMemcpyToSymbolAsync(&paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
-    gpuMemcpyToSymbolAsync(&countersD, m_data_mgr.countersH.get(), sizeof(Counters));
+    gpuMemcpyToSymbolAsync(paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuMemcpyToSymbolAsync(countersD, m_data_mgr.countersH.get(), sizeof(Counters));
 }
 
 void SphCollisionSystem::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarkersD,

--- a/src/chrono_fsi/sph/physics/SphFluidDynamics.cu
+++ b/src/chrono_fsi/sph/physics/SphFluidDynamics.cu
@@ -33,6 +33,16 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
+#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+void CopyParametersToDevice_SphFluidDynamics(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
+    gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuCheckError();
+    gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
+    gpuCheckError();
+}
+
+#endif
+
 SphFluidDynamics::SphFluidDynamics(FsiDataManager& data_mgr, SphBceManager& bce_mgr, bool verbose, bool check_errors)
     : m_data_mgr(data_mgr), m_verbose(verbose), m_check_errors(check_errors) {
     collisionSystem = chrono_types::make_shared<SphCollisionSystem>(data_mgr);
@@ -52,9 +62,9 @@ SphFluidDynamics::~SphFluidDynamics() {
 // -----------------------------------------------------------------------------
 
 void SphFluidDynamics::Initialize() {
-    gpuMemcpyToSymbolAsync(&paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
-    gpuMemcpyToSymbolAsync(&countersD, m_data_mgr.countersH.get(), sizeof(Counters));
-    gpuMemcpyFromSymbol(m_data_mgr.paramsH.get(), &paramsD, sizeof(ChFsiParamsSPH));
+    gpuMemcpyToSymbolAsync(paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuMemcpyToSymbolAsync(countersD, m_data_mgr.countersH.get(), sizeof(Counters));
+    gpuMemcpyFromSymbol(m_data_mgr.paramsH.get(), paramsD, sizeof(ChFsiParamsSPH));
 
     forceSystem->Initialize();
     collisionSystem->Initialize();

--- a/src/chrono_fsi/sph/physics/SphForce.cu
+++ b/src/chrono_fsi/sph/physics/SphForce.cu
@@ -36,8 +36,7 @@ SphForce::~SphForce() {
 }
 
 void SphForce::Initialize() {
-    gpuMemcpyToSymbolAsync(&paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
-    gpuMemcpyToSymbolAsync(&countersD, m_data_mgr.countersH.get(), sizeof(Counters));
+    CopyParametersToDevice(m_data_mgr.paramsH, m_data_mgr.countersH);
 }
 
 // Use invasive to avoid one extra copy.

--- a/src/chrono_fsi/sph/physics/SphForceISPH.cu
+++ b/src/chrono_fsi/sph/physics/SphForceISPH.cu
@@ -37,6 +37,16 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
+#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+void CopyParametersToDevice_SphForceISPH(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
+    gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuCheckError();
+    gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
+    gpuCheckError();
+}
+
+#endif
+
 __device__ void BCE_Vel_Acc(int i_idx,
                             Real3& myAcc,         // output: BCE marker acceleration
                             Real3& V_prescribed,  // output: BCE marker velocity
@@ -918,8 +928,8 @@ void SphForceISPH::Initialize() {
 
     */
 
-    gpuMemcpyToSymbolAsync(&paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
-    gpuMemcpyToSymbolAsync(&countersD, m_data_mgr.countersH.get(), sizeof(Counters));
+    gpuMemcpyToSymbolAsync(paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuMemcpyToSymbolAsync(countersD, m_data_mgr.countersH.get(), sizeof(Counters));
 
     numAllMarkers = m_data_mgr.countersH->numAllMarkers;
     _sumWij_inv.resize(numAllMarkers);

--- a/src/chrono_fsi/sph/physics/SphForceWCSPH.cu
+++ b/src/chrono_fsi/sph/physics/SphForceWCSPH.cu
@@ -26,6 +26,16 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
+#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+void CopyParametersToDevice_SphForceWCSPH(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
+    gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuCheckError();
+    gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
+    gpuCheckError();
+}
+
+#endif
+
 // =============================================================================
 
 __device__ __inline__ void calc_G_Matrix(Real4* sortedPosRad,
@@ -555,8 +565,8 @@ SphForceWCSPH::~SphForceWCSPH() {}
 
 void SphForceWCSPH::Initialize() {
     SphForce::Initialize();
-    gpuMemcpyToSymbolAsync(&paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
-    gpuMemcpyToSymbolAsync(&countersD, m_data_mgr.countersH.get(), sizeof(Counters));
+    gpuMemcpyToSymbolAsync(paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuMemcpyToSymbolAsync(countersD, m_data_mgr.countersH.get(), sizeof(Counters));
 }
 
 void SphForceWCSPH::ForceSPH(std::shared_ptr<SphMarkerDataD> sortedSphMarkersD, Real time, Real step) {

--- a/src/chrono_fsi/sph/physics/SphGeneral.cu
+++ b/src/chrono_fsi/sph/physics/SphGeneral.cu
@@ -24,11 +24,29 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
+#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+static void CopyParametersToDevice_SphGeneral(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
+    gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
+    gpuCheckError();
+    gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
+    gpuCheckError();
+}
+#endif
+
 void CopyParametersToDevice(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
-    gpuMemcpyToSymbolAsync(&paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
+#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+    CopyParametersToDevice_SphGeneral(paramsH, countersH);
+    CopyParametersToDevice_SphBceManager(paramsH, countersH);
+    CopyParametersToDevice_SphCollisionSystem(paramsH, countersH);
+    CopyParametersToDevice_SphFluidDynamics(paramsH, countersH);
+    CopyParametersToDevice_SphForceWCSPH(paramsH, countersH);
+    CopyParametersToDevice_SphForceISPH(paramsH, countersH);
+#else
+    gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
     gpuCheckError();
-    gpuMemcpyToSymbolAsync(&countersD, countersH.get(), sizeof(Counters));
+    gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
     gpuCheckError();
+#endif
 }
 
 //--------------------------------------------------------------------------------------------------------------------------------

--- a/src/chrono_fsi/sph/physics/SphGeneral.cuh
+++ b/src/chrono_fsi/sph/physics/SphGeneral.cuh
@@ -43,12 +43,23 @@ namespace sph {
 
 struct Counters;
 
-//--------------------------------------------------------------------------------------------------------------------------------
-
-// Declared as const variables static in order to be able to use them in a different translation units in the utils
+// Declared as static device constants so each GPU translation unit gets the
+// symbol used by the kernels compiled in that translation unit.
+//
+// CUDA accepted this pattern in the original code. HIP needs each TU-local
+// symbol initialized explicitly; the CopyParametersToDevice_* functions below
+// do that without relying on cross-TU device symbols or RDC.
 __constant__ static ChFsiParamsSPH paramsD;
 #if defined(__CUDACC__) || defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
 __constant__ static Counters countersD;
+#endif
+
+#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+void CopyParametersToDevice_SphBceManager(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
+void CopyParametersToDevice_SphCollisionSystem(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
+void CopyParametersToDevice_SphFluidDynamics(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
+void CopyParametersToDevice_SphForceWCSPH(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
+void CopyParametersToDevice_SphForceISPH(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
 #endif
 
 void CopyParametersToDevice(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);


### PR DESCRIPTION
@rserban I had a look, there are some issue atm.
Here is a quick fix.

Fixes AMD Runtime Errors (compilation works fin):
- SphGeneral.cu:29 Message: invalid device symbol
- 'thrust::THRUST_200805_400100_NS::system::system_error' what(): parallel_for failed: hipErrorInvalidSymbol: invalid device symbol

Additionally CUDA compilation on my System (Ubuntu 24.04 and cuda 13.1):
- ChGpuPrimitives.h:27:14: #include <cuda/std/limits>