### PR TITLE
fix: cmake error in specific sensor module

### DIFF
--- a/src/chrono_sensor/CMakeLists.txt
+++ b/src/chrono_sensor/CMakeLists.txt
@@ -532,6 +532,9 @@ if(CH_USE_SENSOR_OPTIX)
 
   if(CH_ENABLE_MODULE_FSI_SPH)
     target_link_libraries(Chrono_sensor PUBLIC Chrono_fsisph)
+    if(CH_ENABLE_MODULE_VEHICLE AND TARGET Chrono_vehicle)
+      target_link_libraries(Chrono_sensor PUBLIC Chrono_vehicle)
+    endif()
   endif()
 
 endif()

--- a/src/demos/sensor/CMakeLists.txt
+++ b/src/demos/sensor/CMakeLists.txt
@@ -28,10 +28,15 @@ if(CH_USE_SENSOR_OPTIX)
       )
   endif()
 
-  if(CH_ENABLE_MODULE_FSI_SPH)
+  # demo_SEN_CRM_Rendering uses chrono::vehicle::CRMTerrain directly, so it
+  # must only be built when the Vehicle module is enabled and it must link
+  # Chrono_vehicle explicitly (see target-specific link below).
+  if(CH_ENABLE_MODULE_FSI_SPH AND CH_ENABLE_MODULE_VEHICLE)
       set(DEMOS ${DEMOS}
         demo_SEN_CRM_Rendering
       )
+  elseif(CH_ENABLE_MODULE_FSI_SPH)
+    message(WARNING "Skipping demo_SEN_CRM_Rendering because it requires CH_ENABLE_MODULE_VEHICLE=ON")
   endif()
   
 endif()


### PR DESCRIPTION
**Why:** 

During the linking of demo_SEN_CRM_Rendering an error occurs while CH_ENABLE_MODULE_VEHICLE is not set.

**Changes:**

Apply a warning in this specific build config and avoid building demo_SEN_CRM_Rendering without necessary dependencies.
