### PR TITLE
docs(amd): ROCm README, HIP install guidance, and FSI CUDA/HIP requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Implemented almost entirely in C++, Chrono also provides Python and C# APIs. The
   - [Release 9.0.0](http://api.projectchrono.org/9.0.0/)
 - Python interface
   - [PyChrono](https://api.projectchrono.org/pychrono_introduction.html)
+- **AMD GPUs (ROCm)** — [Chrono on AMD GPUs (ROCm)](docs/README_AMD_GPU.md) (CPU PyChrono vs HIP/FSI, CMake hints, `ROCR_VISIBLE_DEVICES`)
 - Reference manuals
   - [Core module](https://api.projectchrono.org/manual_root.html)
   - [Chrono::Vehicle module](https://api.projectchrono.org/manual_vehicle.html)

--- a/docs/README_AMD_GPU.md
+++ b/docs/README_AMD_GPU.md
@@ -22,7 +22,7 @@ If you only need **simulation + Python bindings** next to a **ROCm** ML stack, *
 
 - **CMake** (see [install Chrono](https://api.projectchrono.org/tutorial_install_chrono.html)), **Ninja** (recommended on Linux).
 - **Eigen3** — e.g. `libeigen3-dev` on Debian/Ubuntu, or set `Eigen3_DIR` / `EIGEN3_INCLUDE_DIR` per the core install guide.
-- **SWIG** — required for PyChrono; use a distro package or install a version compatible with your Python.
+- **SWIG** — required for PyChrono; use a distribution package or install a version compatible with your Python.
 
 ### Workflow B (HIP / FSI)
 

--- a/docs/README_AMD_GPU.md
+++ b/docs/README_AMD_GPU.md
@@ -1,0 +1,116 @@
+# Chrono on AMD GPUs (ROCm)
+
+This guide is for machines whose **GPUs are AMD** (ROCm userland): **CPU PyChrono** next to ML stacks such as **PyTorch ROCm**, optional **HIP**-accelerated **FSI / SPH** (continuum physics), and clear limits so expectations match what Chrono builds today.
+
+---
+
+## 1. Three workflows (pick one)
+
+| Workflow | GPU use in Chrono | NVIDIA CUDA toolkit |
+|----------|-------------------|---------------------|
+| **A. CPU PyChrono** (core, vehicle, robot, multibody) | None in Chrono | **Not required**. You may still install **PyTorch ROCm** (or other ML stacks) for separate training code. |
+| **B. HIP FSI / SPH** (continuum GPU physics) | Yes — set **`CHRONO_GPU_BACKEND=HIP`** and enable **`CH_ENABLE_MODULE_FSI`** | Not used; build with **ROCm** (`hipcc`). |
+| **C. Chrono::Sensor** (ray-tracing / OptiX-oriented paths) | N/A | **Not an AMD GPU path** for OptiX features; use non–ray-tracing workflows until upstream documents a maintained alternative. |
+
+If you only need **simulation + Python bindings** next to a **ROCm** ML stack, **workflow A** is usually enough.
+
+---
+
+## 2. Prerequisites
+
+### All Python binding builds
+
+- **CMake** (see [install Chrono](https://api.projectchrono.org/tutorial_install_chrono.html)), **Ninja** (recommended on Linux).
+- **Eigen3** — e.g. `libeigen3-dev` on Debian/Ubuntu, or set `Eigen3_DIR` / `EIGEN3_INCLUDE_DIR` per the core install guide.
+- **SWIG** — required for PyChrono; use a distro package or install a version compatible with your Python.
+
+### Workflow B (HIP / FSI)
+
+- **ROCm** with **HIP** so `hipcc` works.
+- **`hipify-perl`** on `PATH` only if you use a mechanical CUDA→HIP pass while developing (see §5).
+- Set **`CMAKE_HIP_COMPILER=hipcc`** and **`CHRONO_HIP_ARCHITECTURES`** (or **`CMAKE_HIP_ARCHITECTURES`**) to your GPU ISA, for example:
+  - **gfx942** — AMD Instinct MI300-class
+  - **gfx90a** — MI200-class  
+  Use `rocminfo` or vendor documentation for other ASICs.
+
+### Multi-GPU hosts (runtime)
+
+Select devices with **`ROCR_VISIBLE_DEVICES`** (ROCm). On AMD systems, do not rely on `CUDA_VISIBLE_DEVICES`.
+
+---
+
+## 3. Build: CPU PyChrono (workflow A)
+
+Minimal pattern (adjust `CH_ENABLE_MODULE_*` flags to your project):
+
+```bash
+sudo apt-get update && sudo apt-get install -y libeigen3-dev swig cmake ninja-build git
+git clone https://github.com/projectchrono/chrono.git && cd chrono
+cmake -S . -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCH_ENABLE_MODULE_PYTHON=ON \
+  -DPYTHON_EXECUTABLE="$(which python3)" \
+  -DCH_ENABLE_MODULE_CORE=ON \
+  -DCH_ENABLE_MODULE_ROBOT=ON
+ninja -C build
+ninja -C build install   # or set PYTHONPATH per the PYTHON module install guide
+python3 -c "import pychrono.core as ch; import pychrono.robot as rb; print('ok', ch.CHRONO_VERSION)"
+```
+
+**Sanity check:** `nvcc` is **not** required for this path.
+
+---
+
+## 4. Build: HIP + FSI (workflow B)
+
+Example configuration for **gfx942** (change `CHRONO_HIP_ARCHITECTURES` for your hardware):
+
+```bash
+git clone https://github.com/projectchrono/chrono.git && cd chrono
+cmake -S . -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_HIP_COMPILER=hipcc \
+  -DCHRONO_GPU_BACKEND=HIP \
+  -DCHRONO_HIP_ARCHITECTURES=gfx942 \
+  -DCH_ENABLE_MODULE_FSI=ON \
+  -DCH_ENABLE_MODULE_FSI_SPH=ON \
+  -DCH_ENABLE_MODULE_PYTHON=ON \
+  -DCH_ENABLE_MODULE_CORE=ON
+ninja -C build
+ninja -C build install
+python3 -c "import pychrono.fsi as f; print('fsi ok')"
+```
+
+See also the [FSI module installation](https://api.projectchrono.org/module_fsi_installation.html) page and the [HIP section](https://api.projectchrono.org/tutorial_install_chrono.html#hip) of the core install guide.
+
+---
+
+## 5. Contributing: CUDA sources and `hipify-perl`
+
+FSI / SPH device code lives under **`src/chrono_fsi/sph/`** (for example **`src/chrono_fsi/sph/physics/*.cu`**). For a **mechanical** pass on one file:
+
+```bash
+hipify-perl src/chrono_fsi/sph/physics/SphForceWCSPH.cu > /tmp/SphForceWCSPH.hip.cpp
+```
+
+Use the diff as a **checklist**; this repository may compile existing **`.cu`** translation units with **`hipcc`** when **`CHRONO_GPU_BACKEND=HIP`**—follow **`src/chrono_fsi/CMakeLists.txt`** on your branch.
+
+**Typical manual follow-ups** on AMD CDNA (64-wide warps): shuffle / mask patterns, rocPRIM vs CUB shims, device symbol macros, texture vs `__ldg`, and stream ordering. Validate on real hardware before submitting changes.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Hint |
+|---------|------|
+| Guides imply **CUDA** is required for PyChrono on an AMD-only machine | Use **workflow A**; CPU bindings do not require `nvcc`. |
+| HIP build errors mentioning **warp** or **mask** | Prefer **`warpSize`**-driven reductions and HIP-friendly shuffles; search issues and HIP port notes for FSI. |
+| **`pychrono`** missing after configure | Enable **`CH_ENABLE_MODULE_PYTHON=ON`**, install **SWIG**, set **`PYTHON_EXECUTABLE`**. |
+
+---
+
+## 7. Further reading
+
+- [Installation guides](https://api.projectchrono.org/install_guides.html) (all modules).
+- [Install PyChrono](https://api.projectchrono.org/pychrono_installation.html) (conda vs build from source).
+- [GPU accelerator support](https://api.projectchrono.org/tutorial_install_chrono.html#gpu) in the core Chrono install chapter.

--- a/docs/README_AMD_GPU.md
+++ b/docs/README_AMD_GPU.md
@@ -10,7 +10,7 @@ This guide is for machines whose **GPUs are AMD** (ROCm userland): **CPU PyChron
 |----------|-------------------|---------------------|
 | **A. CPU PyChrono** (core, vehicle, robot, multibody) | None in Chrono | **Not required**. You may still install **PyTorch ROCm** (or other ML stacks) for separate training code. |
 | **B. HIP FSI / SPH** (continuum GPU physics) | Yes — set **`CHRONO_GPU_BACKEND=HIP`** and enable **`CH_ENABLE_MODULE_FSI`** | Not used; build with **ROCm** (`hipcc`). |
-| **C. Chrono::Sensor** (ray-tracing / OptiX-oriented paths) | N/A | **Not an AMD GPU path** for OptiX features; use non–ray-tracing workflows until upstream documents a maintained alternative. |
+| **C. Chrono::Sensor**  | N/A | TBD. |
 
 If you only need **simulation + Python bindings** next to a **ROCm** ML stack, **workflow A** is usually enough.
 

--- a/doxygen/documentation/installation/install_chrono.md
+++ b/doxygen/documentation/installation/install_chrono.md
@@ -45,7 +45,7 @@ Note that most modern IDEs have git integration (e.g. the free [Visual Studio Co
 ------------------------------------------------------------
 ## Optional support {#optional}
 
-During CMake configuration, Chrono also checks availability of additional support in terms of compiler capabilities (e.g., SIMD-level support, OpenMP availability) and environments (e.g., availability of MPI and CUDA). If any of these is not found, specific optimizations in building Chrono and some modules is disabled (e.g., no multi-threaded support in FEA, Bullet collision, and Eigen if the C++ compiler is not OpenMP capable), some features are disabled (e.g., no multi-core collision detectino algorithm if OpenMP or Thrust), or entire modules are disabled (e.g., Chrono::FSI-SPH, Chrono::DEM, and Chrono::Sensor cannot be built without CUDA, Chrono::Multicore cannot be built without OpenMP and Thrust, and Chrono::Synchrono and the Chrono::Vehicle co-simulation module cannot be built without MPI).
+During CMake configuration, Chrono also checks availability of additional support in terms of compiler capabilities (e.g., SIMD-level support, OpenMP availability) and environments (e.g., availability of MPI and GPU toolchains). If any of these is not found, specific optimizations in building Chrono and some modules is disabled (e.g., no multi-threaded support in FEA, Bullet collision, and Eigen if the C++ compiler is not OpenMP capable), some features are disabled (e.g., no multi-core collision detection algorithm if OpenMP or Thrust), or entire modules are disabled (e.g., Chrono::FSI-SPH and Chrono::DEM require a GPU backend (**CUDA** or **HIP**); Chrono::Sensor ray-tracing paths require **CUDA** and NVIDIA OptiX; Chrono::Multicore cannot be built without OpenMP and Thrust; Chrono::Synchrono and the Chrono::Vehicle co-simulation module cannot be built without MPI).
 
 Additional support is checked if enabling specific Chrono modules. For example, a Fortran compiler is required to enable the Chrono::MUMPS module.
 
@@ -68,13 +68,15 @@ For users with multiple side-by-side CUDA installations, the desired version can
 
 The minimum HIP version required by Chrono is 5.7.0.
 
-**TODO**
+Install the [AMD ROCm](https://rocm.docs.amd.com/) stack for your distribution so that `hipcc` and the HIP runtime are available. Set `CHRONO_GPU_BACKEND=HIP` during CMake configuration (or use `AUTO` on a machine where ROCm is detected before CUDA). Set `CHRONO_HIP_ARCHITECTURES` to your GPU ISA (for example `gfx942` on AMD Instinct MI300-class accelerators, or `gfx90a` on MI200-class); alternatively set `CMAKE_HIP_ARCHITECTURES` as appropriate for your CMake version.
+
+For **CPU-only PyChrono** next to a ROCm PyTorch stack, you do **not** need the NVIDIA CUDA toolkit; see the repository guide [docs/README_AMD_GPU.md](../../../docs/README_AMD_GPU.md) (workflow summaries, Eigen3/SWIG notes, and `ROCR_VISIBLE_DEVICES` for multi-GPU hosts).
 
 #### Thrust support {#thrust}
 
-The Thrust library is used, with different back-ends, in various Chrono features and modules. For example, the multicore collision detection library (alternative to the default Bullet-based collision detection), as well as the Chrono::Multicore module require Thrust with the OpenMP back-end. The Chrono::FSI module requires Thrust with the CUDA-backend.
+The Thrust library is used, with different back-ends, in various Chrono features and modules. For example, the multicore collision detection library (alternative to the default Bullet-based collision detection), as well as the Chrono::Multicore module require Thrust with the OpenMP back-end. The Chrono::FSI GPU solver uses Thrust with the **CUDA** back-end when `CHRONO_GPU_BACKEND=CUDA`, and with the **HIP** port (rocThrust) when `CHRONO_GPU_BACKEND=HIP`.
 
-The easiest way to obtain the Thrust (headers-only) library is as part of a recent CUDA distribution. This allows using the latest Thrust version (e.g., 2.8.2 in CUDA 12.9.0).
+The easiest way to obtain the Thrust (headers-only) library is as part of a recent CUDA distribution. This allows using the latest Thrust version (e.g., 2.8.2 in CUDA 12.9.0). For **`CHRONO_GPU_BACKEND=HIP`**, the ROCm installation supplies **rocThrust** headers compatible with the HIP toolchain.
 
 It is possible to use Thrust stand-alone (e.g., for use on machines without an NVIDIA GPU to enable the Chrono::Multicore module). However, that requires using an older version of Thrust from its [GitHub repository](https://github.com/NVIDIA/thrust). Note that the latest version available there is 2.1.0, but the latest version that works with Chrono without any modifications is **1.7.1**.
 

--- a/doxygen/documentation/installation/install_guides.md
+++ b/doxygen/documentation/installation/install_guides.md
@@ -78,6 +78,8 @@ For more details, see the relevant [section](@ref scripts) in the Chrono core mo
 
 - @subpage pychrono_installation
 
+- **AMD GPU hosts (ROCm):** see [`docs/README_AMD_GPU.md`](../../../docs/README_AMD_GPU.md) for CPU PyChrono next to PyTorch ROCm, optional HIP/FSI, and device selection (`ROCR_VISIBLE_DEVICES`).
+
 
 ### Chrono::Solidworks add-in
 

--- a/doxygen/documentation/installation/module_fsi_installation.md
+++ b/doxygen/documentation/installation/module_fsi_installation.md
@@ -30,10 +30,12 @@ The **FSI-TDPF module** allows users to:
 
 ## Requirements
 
-- To **build** the FSI-SPH module and related applications, a CUDA installation and appropriate compiler are required.<br>
+- To **build** the FSI-SPH module and related applications with **CUDA**, an NVIDIA CUDA installation and appropriate compiler are required.<br>
   The FSI-SPH module requires CUDA version 12.9 (**NOTE**: CUDA 13 is not yet supported).
+- To **build** the FSI-SPH module with **HIP** (AMD GPUs), install **ROCm** and configure CMake with **`CHRONO_GPU_BACKEND=HIP`** (see the [HIP section](@ref tutorial_install_chrono) of the core install guide and **`docs/README_AMD_GPU.md`** in the repository root).
 - To **build** the FSI-TDPF module and related applications, HDF5 support is required and must be enabled (`CH_ENABLE_HDF5`).
-- To **run** applications based on the FSI-SPH module an NVIDIA GPU card is required.
+- To **run** FSI-SPH applications on **CUDA**, an NVIDIA GPU is required.
+- To **run** FSI-SPH applications on **HIP**, an AMD GPU with a supported ROCm stack is required.
 
 
 ## Building instructions

--- a/doxygen/documentation/manuals/pychrono/pychrono_installation.md
+++ b/doxygen/documentation/manuals/pychrono/pychrono_installation.md
@@ -67,6 +67,10 @@ Do this:
    Or, if you have hard disk space, better install a full stack like [Anaconda](https://www.anaconda.com/download/)
 3. build the PyChrono module, following [these instructions](@ref module_python_installation)
 
+<div class="ce-info">
+**AMD GPUs (ROCm):** If your machine has AMD Instinct or Radeon GPUs and you use **PyTorch ROCm** (or another ROCm ML stack) alongside Chrono, you can still build **CPU PyChrono** without the NVIDIA CUDA toolkit. See the repository file **`docs/README_AMD_GPU.md`** for workflows (CPU vs HIP/FSI), **Eigen3** / **SWIG** prerequisites, and **`ROCR_VISIBLE_DEVICES`** on multi-GPU hosts.
+</div>
+
 <div class="ce-warning">
 When building PyChrono from the C++ source, the PYTHONPATH environment variable must be edited to include the path to the bin/ directory in the Chrono build tree.
 For example:


### PR DESCRIPTION
### Summary

This PR lands **documentation** for **AMD ROCm** hosts and aligns several install chapters with the existing **HIP** path in CMake:

- New **`docs/README_AMD_GPU.md`** — workflows (CPU PyChrono vs HIP/FSI), prerequisites, CMake examples using **`CH_ENABLE_MODULE_*`** and **`CHRONO_HIP_ARCHITECTURES`**, `ROCR_VISIBLE_DEVICES`, and a short **`hipify-perl`** contributor note.
- **`README.md`** — link under Documentation.
- **`doxygen/documentation/installation/install_guides.md`** — pointer to the README from the PyChrono section.
- **`doxygen/documentation/manuals/pychrono/pychrono_installation.md`** — info box for ROCm + CPU PyChrono (no CUDA toolkit required for that path).
- **`doxygen/documentation/installation/install_chrono.md`** — replace the **HIP** subsection **TODO** with ROCm/`hipcc`/`CHRONO_HIP_ARCHITECTURES` guidance; fix the **optional support** paragraph and typo (“detectino”) so **FSI-SPH** / **DEM** are described as **CUDA or HIP**; extend **Thrust** notes for **rocThrust** when `CHRONO_GPU_BACKEND=HIP`.
- **`doxygen/documentation/installation/module_fsi_installation.md`** — **Requirements** list **CUDA vs HIP** build and run expectations.

**Not in this PR:** device-kernel gfx942 hardening in `src/chrono_fsi/sph/physics/*.cu` (can follow as a separate change once validated on hardware).

### Test plan

**Docs-only sanity (Ubuntu):** confirm new links resolve in the GitHub file tree (`docs/README_AMD_GPU.md`, relative links from `doxygen/...` sources).

**CPU PyChrono (no `nvcc`):**

```bash
sudo apt-get update && sudo apt-get install -y libeigen3-dev swig cmake ninja-build git
git clone https://github.com/projectchrono/chrono.git && cd chrono
cmake -S . -B build -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCH_ENABLE_MODULE_PYTHON=ON \
  -DPYTHON_EXECUTABLE="$(which python3)" \
  -DCH_ENABLE_MODULE_CORE=ON \
  -DCH_ENABLE_MODULE_ROBOT=ON
ninja -C build
```

**HIP + FSI (requires ROCm + AMD GPU):** use the CMake block in **`docs/README_AMD_GPU.md`** §4 on a gfx942 (or appropriate `CHRONO_HIP_ARCHITECTURES`) machine.
