### PR TITLE
perf(vehicle): SCM HIP device body reduction and async host bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # CMake configuration file for the Chrono Project
 #
 #=============================================================================
-# --- amd-chronos SCM GPU (Phase 2c) ---
+# --- Optional HIP SCM contact-force backend (vehicle) ---
 option(CH_ENABLE_VEHICLE_SCM_GPU "Enable HIP SCM contact-force backend" OFF)
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@
 # CMake configuration file for the Chrono Project
 #
 #=============================================================================
+# --- amd-chronos SCM GPU (Phase 2c) ---
+option(CH_ENABLE_VEHICLE_SCM_GPU "Enable HIP SCM contact-force backend" OFF)
 
 #-----------------------------------------------------------------------------
 # Check backward compatibility

--- a/docs/OPENMP_TO_HIP.md
+++ b/docs/OPENMP_TO_HIP.md
@@ -1,0 +1,168 @@
+# OpenMP (CPU) → HIP (GPU) porting guide
+
+A short playbook for Chrono modules that are **CPU + OpenMP today** and need a **HIP kernel** on AMD GPUs (ROCm). The **SCM terrain contact-force** backend (`CH_ENABLE_VEHICLE_SCM_GPU`) is the reference walkthrough in this repository.
+
+**Hardware:** AMD Instinct GPUs (e.g. gfx942 MI300X, gfx90a MI210). Use ROCm and `ROCR_VISIBLE_DEVICES` — not CUDA-only APIs.
+
+---
+
+## 1. Three port strategies (pick one)
+
+| Strategy | When to use | SCM example |
+|----------|-------------|-------------|
+| **A. Split CPU/GPU** | OpenMP loop is mixed with I/O, callbacks, or sparse data structures | **Yes** — ray cast + BFS on CPU; force loop on GPU |
+| **B. Hipify CUDA** | Module already has `.cu` kernels (e.g. FSI/SPH) | Not applicable to SCM |
+| **C. OpenMP target offload** | Quick experiment; compiler-dependent on ROCm | Not used for SCM |
+
+**Rule of thumb:** If the hot loop touches Chrono collision, callbacks, or `std::map`, **do not** put it in a kernel. Extract a **dense, embarrassingly parallel** inner loop instead.
+
+---
+
+## 2. Step-by-step workflow (SCM template)
+
+### Step 0 — Inventory the CPU path
+
+1. Find the hot loop in Chrono (for SCM: `SCMLoader::ComputeInternalForces()` in `SCMTerrain.cpp`, contact-force section).
+2. List what **must stay on CPU** (ray casting, graph traversal, file I/O, virtual callbacks).
+3. List what **can move to GPU** (per-element math with no pointer chasing).
+
+**SCM split:**
+
+```text
+[CPU] Update active domains
+[CPU] OpenMP ray cast → hits + patch_oob
+[CPU] BFS contact patches
+[CPU] Pack batch (OpenMP parallel for)
+[GPU] scm_compute_forces_kernel
+[CPU] Reduce per-body forces → ChLoadBodyForce
+```
+
+### Step 1 — Standalone HIP library
+
+Before touching Chrono CMake, build and test a small HIP library:
+
+| Artifact | Role |
+|----------|------|
+| `*_types.h` | SoA structs (`HitInput`, `HitOutput`, `SoilParams`) |
+| `*_cpu_reference.cpp` | Copy of the CPU loop, no OpenMP inside the kernel path |
+| `*_kernels.hip.cpp` | `__global__` kernel, one thread per hit |
+| `*_host.cpp` | H2D, launch, D2H, buffer reuse |
+
+Configure with `hipcc`, set `CMAKE_HIP_ARCHITECTURES` to your GPU ISA (`gfx942`, `gfx90a`, …). Host code can stay on **g++**; device code uses the HIP language.
+
+### Step 2 — CPU reference parity
+
+1. Mirror the Chrono loop **literally** in `*_cpu_reference.cpp` (same formulas, same order).
+2. Write a parity test that feeds random SoA batches to CPU ref and HIP kernel.
+3. Gate: `rtol=1e-5`, `atol=1e-7` on forces.
+
+**Do not skip this.** OpenMP and HIP must agree on the **same math**, not “close enough.”
+
+### Step 3 — Keep OpenMP on the host (pack / reduce)
+
+OpenMP stays **outside** HIP kernels:
+
+- **Pack:** `#pragma omp parallel for` over hits → fill `HitInput[]`.
+- **Reduce:** per-thread partial sums of body forces on host; move reduction to device only if profiling justifies it.
+
+```cpp
+#pragma omp parallel for schedule(static)
+for (std::ptrdiff_t i = 0; i < n; ++i) {
+    out[i].vn = vn[i];
+    // ...
+}
+```
+
+Callbacks (e.g. `GetContactPointSpeed`) run on **host** before pack; store scalars in the batch.
+
+### Step 4 — SoA layout (host ↔ device)
+
+Use **Structure of Arrays** or one struct per hit with fixed size — no `std::vector` inside the kernel.
+
+| Principle | SCM |
+|-----------|-----|
+| Fixed-width fields | `level`, `sinkage_plastic`, `normal_z`, `fn`, `ft`, … |
+| Global params once | `SoilParams` (Bekker, Mohr, Janosi, `dt`, `area`) |
+| Optional per-body data | `body_id`, contactable cohesion/mu pre-filled on host |
+| Outputs | Updated node scalars + per-hit forces; host sums by `body_id` |
+
+### Step 5 — Chrono integration hook
+
+1. Add `ComputeContactForcesGpu()` (or equivalent) behind a **runtime or CMake gate** (`CH_ENABLE_VEHICLE_SCM_GPU`).
+2. In the CPU function, after ray cast + patch build: pack → external `scm_gpu` launch → scatter into body forces.
+3. Bridge implementation: `src/chrono_vehicle/terrain/SCMTerrainGpu.cpp`.
+
+**SCM runtime toggle:**
+
+```bash
+export CHRONO_SCM_GPU=1          # uniform soil, rigid ChBody contactables in v1
+export CHRONO_SCM_GPU_MIN_HITS=8192   # CPU fallback below this count
+```
+
+Build Chrono with `-DCH_ENABLE_VEHICLE_SCM_GPU=ON` and point `CHRONO_SCM_GPU_INCLUDE_DIR` / `CHRONO_SCM_GPU_LIB_DIR` at the external `scm_gpu` install. See [`docs/SCM_GPU_EXTERNAL.md`](docs/SCM_GPU_EXTERNAL.md).
+
+### Step 6 — Scaling benchmark
+
+1. **Kernel-only** benchmark with large `n_hits` (overhead excluded) — fair GPU test.
+2. **End-to-end** Chrono demo — may be slower on GPU if hits/step are small (launch + sync dominate).
+
+Target: meaningful wall-time reduction on the ported loop at **production** hit counts (SCM kernel reference: ~2.5× @ 65k hits on MI300X).
+
+---
+
+## 3. CUDA → HIP cheat sheet (other modules)
+
+| CUDA | HIP / ROCm |
+|------|------------|
+| `cudaMalloc` | `hipMalloc` |
+| `cudaMemcpy` | `hipMemcpy` |
+| `__shfl_sync` | `__shfl` (warp size **64** on gfx942) |
+| CUB | rocPRIM |
+| cuRAND | hipRAND |
+| `cudaMemcpyToSymbol` | `hipMemcpyToSymbol` + `HIP_SYMBOL(...)` |
+| texture loads | `__ldg` or explicit global loads |
+| `CUDA_VISIBLE_DEVICES` | **`ROCR_VISIBLE_DEVICES`** |
+
+For FSI/SPH modules that already ship CUDA sources, prefer upstream `CHRONO_GPU_BACKEND=HIP` and compile `.cu` with the HIP toolchain rather than duplicating host/device trees.
+
+---
+
+## 4. Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Hipifying OpenMP host loops | Extract inner math; keep OpenMP on pack/reduce |
+| Putting ray cast / BFS on GPU | Leave on CPU in first integration |
+| Sync every step with tiny batches | Profile hit count; pipeline H2D/kernel/D2H or batch more work |
+| `float` on GPU, `double` in Chrono | Use `double` in v1 for parity |
+| Setting `CMAKE_CXX_COMPILER=hipcc` for the whole tree | Keep host on g++; enable HIP language for device TUs only |
+
+---
+
+## 5. Milestone checklist (per module)
+
+| Gate | Criterion |
+|------|-----------|
+| M1 | Standalone HIP library builds for target arch |
+| M2 | CPU vs HIP parity test at rtol=1e-5, atol=1e-7 |
+| M3 | Chrono hook + smoke demo with runtime gate |
+| M4 | Scaling benchmark at realistic batch size |
+
+---
+
+## 6. SCM integration map (this repository)
+
+| Path | Role |
+|------|------|
+| `src/chrono_vehicle/terrain/SCMTerrain.cpp` | CPU path + GPU hook after ray cast |
+| `src/chrono_vehicle/terrain/SCMTerrainGpu.{h,cpp}` | Pack → `scm_gpu` → scatter |
+| `CMakeLists.txt` | `CH_ENABLE_VEHICLE_SCM_GPU` option |
+| External `scm_gpu` | HIP force kernel (built separately; see `SCM_GPU_EXTERNAL.md`) |
+
+---
+
+## 7. When to redesign before porting
+
+- Module has **no dense inner loop** → redesign split before writing kernels.
+- **Spatial soil callbacks** → host pre-fills per-hit params each step.
+- **FEA / UV contactables** → extend pack/scatter on host first; GPU v1 rigid bodies only (SCM).

--- a/docs/SCM_GPU_EXTERNAL.md
+++ b/docs/SCM_GPU_EXTERNAL.md
@@ -1,0 +1,33 @@
+# External `scm_gpu` HIP library
+
+Chrono does **not** vendor the `scm_gpu` contact-force kernel. Build it separately with ROCm (`hipcc`), then point CMake at the install prefix.
+
+## Build
+
+```bash
+cmake -S scm_gpu -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=hipcc \
+  -DCMAKE_HIP_COMPILER=hipcc \
+  -DCMAKE_HIP_ARCHITECTURES=gfx942 \
+  -DCMAKE_INSTALL_PREFIX=/path/to/scm_gpu_install
+
+ninja -C build install
+```
+
+Use `gfx90a` for MI210 / MI250X. Host Chrono code remains on **g++**; only the external library and Chrono HIP glue use the HIP toolchain.
+
+## Configure Chrono
+
+```bash
+cmake -S chrono -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCH_ENABLE_VEHICLE_SCM_GPU=ON \
+  -DCHRONO_SCM_GPU_INCLUDE_DIR=/path/to/scm_gpu_install/include \
+  -DCHRONO_SCM_GPU_LIB_DIR=/path/to/scm_gpu_install/lib \
+  -DCMAKE_HIP_ARCHITECTURES=gfx942
+```
+
+## Validation
+
+Run the parity and scaling tests shipped with your `scm_gpu` build before enabling `CHRONO_SCM_GPU=1` in production scenarios. Target: rtol `1e-5`, atol `1e-7` vs CPU reference at ≥ 65k hits.

--- a/src/chrono_vehicle/CMakeLists.txt
+++ b/src/chrono_vehicle/CMakeLists.txt
@@ -226,6 +226,12 @@ set(CV_TERRAIN_FILES
     terrain/GranularTerrain.h
     terrain/GranularTerrain.cpp
 )
+if(CH_ENABLE_VEHICLE_SCM_GPU)
+    list(APPEND CV_TERRAIN_FILES
+        terrain/SCMTerrainGpu.h
+        terrain/SCMTerrainGpu.cpp
+    )
+endif()
 if(CH_ENABLE_MODULE_FEA)
     set(CV_TERRAIN_FILES ${CV_TERRAIN_FILES}
         terrain/FEATerrain.h
@@ -899,6 +905,16 @@ endif()
 if(CH_ENABLE_MODULE_FSI_SPH)
   target_link_libraries(Chrono_vehicle PRIVATE Chrono_fsi)
   target_link_libraries(Chrono_vehicle PRIVATE Chrono_fsisph)
+endif()
+
+if(CH_ENABLE_VEHICLE_SCM_GPU)
+  target_compile_definitions(Chrono_vehicle PRIVATE CHRONO_VEHICLE_SCM_GPU)
+  target_include_directories(Chrono_vehicle PRIVATE ${CHRONO_SCM_GPU_INCLUDE_DIR})
+  target_link_directories(Chrono_vehicle PRIVATE ${CHRONO_SCM_GPU_LIB_DIR})
+  target_link_libraries(Chrono_vehicle PRIVATE scm_gpu_core)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER MATCHES "hipcc")
+    target_link_options(Chrono_vehicle PRIVATE -fopenmp)
+  endif()
 endif()
 
 target_compile_definitions(Chrono_vehicle INTERFACE 

--- a/src/chrono_vehicle/terrain/SCMTerrain.cpp
+++ b/src/chrono_vehicle/terrain/SCMTerrain.cpp
@@ -38,6 +38,11 @@
 #include "chrono_vehicle/ChVehicleDataPath.h"
 #include "chrono_vehicle/terrain/SCMTerrain.h"
 
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    #include "scm_gpu.h"
+#endif
+
+
 #include "chrono_thirdparty/stb/stb.h"
 
 namespace chrono {
@@ -1129,6 +1134,16 @@ void SCMLoader::ComputeInternalForces() {
     // -------------------------
 
     // Information of vertices with ray-cast hits
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    using HitRecord = scm_gpu::ScmHitRecord;
+#else
+    struct HitRecord {
+        ChContactable* contactable;  // pointer to hit object
+        ChVector3d abs_point;        // hit point, expressed in global frame
+        int patch_id;                // index of associated patch id
+    };
+#endif
     struct HitRecord {
         ChContactable* contactable;  // pointer to hit object
         ChVector3d abs_point;        // hit point, expressed in global frame
@@ -1356,6 +1371,26 @@ void SCMLoader::ComputeInternalForces() {
 
     m_timer_contact_forces.start();
 
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    bool scm_used_gpu = false;
+    if (scm_gpu::Enabled() && !m_soil_fun && hits.size() >= scm_gpu_min_hits()) {
+        std::vector<ChVector2i> keys;
+        std::vector<scm_gpu::ScmHitRecord> hit_vec;
+        keys.reserve(hits.size());
+        hit_vec.reserve(hits.size());
+        for (const auto& h : hits) {
+            keys.push_back(h.first);
+            hit_vec.push_back(h.second);
+        }
+        std::vector<double> patch_oob(contact_patches.size());
+        for (size_t ip = 0; ip < contact_patches.size(); ++ip)
+            patch_oob[ip] = contact_patches[ip].oob;
+        scm_used_gpu = ComputeContactForcesGpu(keys, hit_vec, patch_oob);
+    }
+    if (!scm_used_gpu) {
+#endif
+
+
     // Initialize local values for the soil parameters
     double Bekker_Kphi = m_Bekker_Kphi;
     double Bekker_Kc = m_Bekker_Kc;
@@ -1519,6 +1554,11 @@ void SCMLoader::ComputeInternalForces() {
         nr.level = nr.level_initial - nr.sinkage / ca;
 
     }  // end loop on ray hits
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    }  // end CPU contact-force path
+#endif
+
 
     // Create loads for bodies and nodes to apply the accumulated terrain force/torque for each of them
     if (!m_cosim_mode) {

--- a/src/chrono_vehicle/terrain/SCMTerrain.cpp
+++ b/src/chrono_vehicle/terrain/SCMTerrain.cpp
@@ -248,21 +248,41 @@ void SCMTerrain::RegisterSoilParametersCallback(std::shared_ptr<SoilParametersCa
 // Initialize the terrain as a flat grid.
 void SCMTerrain::Initialize(double sizeX, double sizeY, double delta) {
     m_loader->Initialize(sizeX, sizeY, delta);
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    scm_gpu::PrimeBuffers();
+#endif
+
 }
 
 // Initialize the terrain from a specified height map.
 void SCMTerrain::Initialize(const std::string& heightmap_file, double sizeX, double sizeY, double hMin, double hMax, double delta) {
     m_loader->Initialize(heightmap_file, sizeX, sizeY, hMin, hMax, delta);
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    scm_gpu::PrimeBuffers();
+#endif
+
 }
 
 // Initialize the terrain from a specified OBJ mesh file.
 void SCMTerrain::Initialize(const std::string& mesh_file, double delta) {
     m_loader->Initialize(mesh_file, delta);
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    scm_gpu::PrimeBuffers();
+#endif
+
 }
 
 // Initialize the terrain from a specified triangular mesh file.
 void SCMTerrain::Initialize(const ChTriangleMeshConnected& trimesh, double delta) {
     m_loader->Initialize(trimesh, delta);
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    scm_gpu::PrimeBuffers();
+#endif
+
 }
 
 // Get the heights of modified grid nodes.
@@ -1374,18 +1394,10 @@ void SCMLoader::ComputeInternalForces() {
 #ifdef CHRONO_VEHICLE_SCM_GPU
     bool scm_used_gpu = false;
     if (scm_gpu::Enabled() && !m_soil_fun && hits.size() >= scm_gpu_min_hits()) {
-        std::vector<ChVector2i> keys;
-        std::vector<scm_gpu::ScmHitRecord> hit_vec;
-        keys.reserve(hits.size());
-        hit_vec.reserve(hits.size());
-        for (const auto& h : hits) {
-            keys.push_back(h.first);
-            hit_vec.push_back(h.second);
-        }
         std::vector<double> patch_oob(contact_patches.size());
         for (size_t ip = 0; ip < contact_patches.size(); ++ip)
             patch_oob[ip] = contact_patches[ip].oob;
-        scm_used_gpu = ComputeContactForcesGpu(keys, hit_vec, patch_oob);
+        scm_used_gpu = ComputeContactForcesGpu(hits, patch_oob);
     }
     if (!scm_used_gpu) {
 #endif

--- a/src/chrono_vehicle/terrain/SCMTerrain.h
+++ b/src/chrono_vehicle/terrain/SCMTerrain.h
@@ -559,8 +559,7 @@ class CH_VEHICLE_API SCMLoader : public ChLoadContainer {
     void ComputeInternalForces();
 
 #ifdef CHRONO_VEHICLE_SCM_GPU
-    bool ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
-                                 const std::vector<scm_gpu::ScmHitRecord>& hits,
+    bool ComputeContactForcesGpu(const std::unordered_map<ChVector2i, scm_gpu::ScmHitRecord, CoordHash>& hits,
                                  const std::vector<double>& patch_oob);
 #endif
 

--- a/src/chrono_vehicle/terrain/SCMTerrain.h
+++ b/src/chrono_vehicle/terrain/SCMTerrain.h
@@ -37,6 +37,11 @@
 #endif
 
 #include "chrono_vehicle/ChApiVehicle.h"
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    #include <unordered_map>
+    #include <vector>
+#endif
+
 #include "chrono_vehicle/ChSubsysDefs.h"
 #include "chrono_vehicle/ChTerrain.h"
 #include "chrono_vehicle/ChWorldFrame.h"
@@ -45,6 +50,19 @@ namespace chrono {
 namespace vehicle {
 
 class SCMLoader;
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+namespace scm_gpu {
+bool Enabled();
+void PrimeBuffers();
+struct ScmHitRecord {
+    ChContactable* contactable = nullptr;
+    ChVector3d abs_point;
+    int patch_id = -1;
+};
+}  // namespace scm_gpu
+#endif
+
 
 /// @addtogroup vehicle_terrain
 /// @{
@@ -539,6 +557,13 @@ class CH_VEHICLE_API SCMLoader : public ChLoadContainer {
     // Reset the list of forces and fill it with forces from the soil contact model.
     // This is called automatically during timestepping (only at the beginning of each step).
     void ComputeInternalForces();
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+    bool ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
+                                 const std::vector<scm_gpu::ScmHitRecord>& hits,
+                                 const std::vector<double>& patch_oob);
+#endif
+
 
     // Override the ChLoadContainer method for computing the generalized force F term:
     virtual void IntLoadResidual_F(const unsigned int off,  // offset in R residual

--- a/src/chrono_vehicle/terrain/SCMTerrainGpu.cpp
+++ b/src/chrono_vehicle/terrain/SCMTerrainGpu.cpp
@@ -1,8 +1,11 @@
-// SCMTerrainGpu.cpp — SCMLoader::ComputeContactForcesGpu implementation.
+// SCMTerrainGpu.cpp — SCMLoader::ComputeContactForcesGpu (v2: fused pack/scatter, dense body reduce).
 
 #ifdef CHRONO_VEHICLE_SCM_GPU
 
+#include <chrono>
+#include <cstdio>
 #include <cstdlib>
+#include <unordered_map>
 #include <vector>
 
 #include "chrono/physics/ChBody.h"
@@ -21,25 +24,46 @@ bool Enabled() {
 
 static ScmGpuContext* GpuContext() {
     static ScmGpuContext* ctx = scm_gpu_create(0);
+    static bool primed = false;
+    if (!primed) {
+        scm_gpu_reserve(ctx, scm_gpu_reserve_hits());
+        scm_gpu_warmup(ctx);
+        primed = true;
+    }
     return ctx;
+}
+
+void PrimeBuffers() {
+    if (!Enabled())
+        return;
+    (void)GpuContext();
+}
+
+static int32_t BodySlot(std::vector<ChBody*>& bodies, ChBody* body) {
+    for (std::size_t i = 0; i < bodies.size(); ++i) {
+        if (bodies[i] == body)
+            return static_cast<int32_t>(i);
+    }
+    bodies.push_back(body);
+    return static_cast<int32_t>(bodies.size() - 1);
 }
 
 }  // namespace scm_gpu
 
-bool SCMLoader::ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
-                                        const std::vector<scm_gpu::ScmHitRecord>& hits,
-                                        const std::vector<double>& patch_oob) {
+bool SCMLoader::ComputeContactForcesGpu(
+    const std::unordered_map<ChVector2i, scm_gpu::ScmHitRecord, CoordHash>& hits,
+    const std::vector<double>& patch_oob) {
+    using Clock = std::chrono::steady_clock;
+
     const std::size_t n = hits.size();
-    if (n == 0 || keys.size() != n)
+    if (n == 0)
         return true;
 
     if (n < scm_gpu_min_hits())
         return false;
 
-    for (const auto& rec : hits) {
-        if (!dynamic_cast<ChBody*>(rec.contactable))
-            return false;
-    }
+    const bool profile = (std::getenv("CHRONO_SCM_GPU_PROFILE") && std::getenv("CHRONO_SCM_GPU_PROFILE")[0] == '1');
+    const auto t0 = Clock::now();
 
     ScmGpuContext* ctx = scm_gpu::GpuContext();
     scm::gpu::HitInput* batch_in = scm_gpu_prepare_input(ctx, n);
@@ -47,7 +71,10 @@ bool SCMLoader::ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
     if (!batch_in || !batch_out)
         return false;
 
-    std::vector<ChBody*> bodies(n);
+    std::vector<ChBody*> bodies;
+    bodies.reserve(64);
+    std::vector<ChVector2i> keys;
+    keys.reserve(n);
 
     scm::gpu::SoilParams soil{};
     soil.bekker_kphi = m_Bekker_Kphi;
@@ -61,20 +88,24 @@ bool SCMLoader::ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
     soil.area = m_area;
     soil.dt = GetSystem()->GetStep();
 
-    for (std::size_t idx = 0; idx < n; ++idx) {
-        const auto& rec = hits[idx];
-        const ChVector2i& ij = keys[idx];
+    std::size_t idx = 0;
+    for (const auto& h : hits) {
+        auto* body = dynamic_cast<ChBody*>(h.second.contactable);
+        if (!body)
+            return false;
+
+        const ChVector2i& ij = h.first;
+        keys.push_back(ij);
+        const int32_t bid = scm_gpu::BodySlot(bodies, body);
+
         auto& nr = m_grid_map.at(ij);
         const double ca = nr.normal.z();
 
-        ChBody* body = dynamic_cast<ChBody*>(rec.contactable);
-        bodies[idx] = body;
+        const auto hit_point_loc = m_frame.TransformPointParentToLocal(h.second.abs_point);
 
-        auto hit_point_loc = m_frame.TransformPointParentToLocal(rec.abs_point);
-
-        ChVector3d point_local(ij.x() * m_delta, ij.y() * m_delta, nr.level);
-        ChVector3d point_abs = m_frame.TransformPointLocalToParent(point_local);
-        ChVector3d speed_abs = rec.contactable->GetContactPointSpeed(point_abs);
+        const ChVector3d point_local(ij.x() * m_delta, ij.y() * m_delta, nr.level);
+        const ChVector3d point_abs = m_frame.TransformPointLocalToParent(point_local);
+        const ChVector3d speed_abs = h.second.contactable->GetContactPointSpeed(point_abs);
 
         ChVector3d N = m_frame.TransformDirectionLocalToParent(nr.normal);
         const double Vn = Vdot(speed_abs, N);
@@ -82,8 +113,8 @@ bool SCMLoader::ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
         T.Normalize();
 
         double patch_oob_val = 0.0;
-        if (rec.patch_id >= 0 && rec.patch_id < static_cast<int>(patch_oob.size()))
-            patch_oob_val = patch_oob[static_cast<std::size_t>(rec.patch_id)];
+        if (h.second.patch_id >= 0 && h.second.patch_id < static_cast<int>(patch_oob.size()))
+            patch_oob_val = patch_oob[static_cast<std::size_t>(h.second.patch_id)];
 
         scm::gpu::HitInput& in = batch_in[idx];
         in = {};
@@ -109,32 +140,43 @@ bool SCMLoader::ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
         in.bx = body->GetPos().x();
         in.by = body->GetPos().y();
         in.bz = body->GetPos().z();
-        in.body_id = static_cast<int32_t>(idx);
+        in.body_id = bid;
         in.active = 1;
 
-        if (auto cprops = rec.contactable->GetUserData<SCMContactableData>()) {
+        if (auto cprops = body->GetUserData<SCMContactableData>()) {
             in.c_cohesion = cprops->Mohr_cohesion;
             in.c_mu = cprops->Mohr_mu;
             in.c_janosi = cprops->Janosi_shear;
             in.area_ratio = cprops->area_ratio;
         }
+
+        ++idx;
     }
+
+    const auto t1 = Clock::now();
 
     const int gpu_rc = scm_gpu_compute_forces_staged(ctx, soil, n);
     if (gpu_rc != 0) {
-        std::fprintf(stderr, "SCM GPU: scm_gpu_compute_forces_staged failed rc=%d n=%zu\n", gpu_rc,
-                     static_cast<std::size_t>(n));
+        std::fprintf(stderr, "SCM GPU: scm_gpu_compute_forces_staged failed rc=%d n=%zu\n", gpu_rc, n);
         return false;
     }
 
+    const auto t2 = Clock::now();
+
+    const std::size_t n_bodies = bodies.size();
+    std::vector<ChVector3d> force_acc(n_bodies, ChVector3d(0, 0, 0));
+    std::vector<ChVector3d> moment_acc(n_bodies, ChVector3d(0, 0, 0));
+
     m_body_forces.clear();
+    m_modified_nodes.reserve(m_modified_nodes.size() + n);
 
     for (std::size_t i = 0; i < n; ++i) {
         const scm::gpu::HitOutput& o = batch_out[i];
         if (!o.active)
             continue;
 
-        auto& nr = m_grid_map.at(keys[i]);
+        const auto& ij = keys[i];
+        auto& nr = m_grid_map.at(ij);
         const double ca = nr.normal.z();
 
         nr.hit_level = batch_in[i].hit_level;
@@ -148,18 +190,37 @@ bool SCMLoader::ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
         nr.step_plastic_flow = o.step_plastic_flow;
         nr.level = nr.level_initial - nr.sinkage / ca;
 
-        m_modified_nodes.push_back(keys[i]);
+        m_modified_nodes.push_back(ij);
 
-        ChVector3d force(o.fn_x + o.ft_x, o.fn_y + o.ft_y, o.fn_z + o.ft_z);
-        ChVector3d moment = Vcross(ChVector3d(batch_in[i].px, batch_in[i].py, batch_in[i].pz) - bodies[i]->GetPos(),
-                                  force);
+        const int32_t bid = batch_in[i].body_id;
+        const ChVector3d force(o.fn_x + o.ft_x, o.fn_y + o.ft_y, o.fn_z + o.ft_z);
+        const ChVector3d moment =
+            Vcross(ChVector3d(batch_in[i].px - batch_in[i].bx, batch_in[i].py - batch_in[i].by,
+                              batch_in[i].pz - batch_in[i].bz),
+                   force);
 
-        auto itr = m_body_forces.find(bodies[i]);
-        if (itr == m_body_forces.end())
-            m_body_forces.insert(std::make_pair(bodies[i], std::make_pair(force, moment)));
-        else {
-            itr->second.first += force;
-            itr->second.second += moment;
+        force_acc[static_cast<std::size_t>(bid)] += force;
+        moment_acc[static_cast<std::size_t>(bid)] += moment;
+    }
+
+    for (std::size_t b = 0; b < n_bodies; ++b)
+        m_body_forces.emplace(bodies[b], std::make_pair(force_acc[b], moment_acc[b]));
+
+    const auto t3 = Clock::now();
+
+    if (profile) {
+        static int n_profile = 0;
+        if (n_profile < 8) {
+            const double pack_ms =
+                std::chrono::duration<double, std::milli>(t1 - t0).count();
+            const double gpu_ms =
+                std::chrono::duration<double, std::milli>(t2 - t1).count();
+            const double scatter_ms =
+                std::chrono::duration<double, std::milli>(t3 - t2).count();
+            std::fprintf(stderr,
+                         "SCM GPU profile n=%zu pack_ms=%.3f gpu_ms=%.3f scatter_ms=%.3f\n",
+                         n, pack_ms, gpu_ms, scatter_ms);
+            ++n_profile;
         }
     }
 

--- a/src/chrono_vehicle/terrain/SCMTerrainGpu.cpp
+++ b/src/chrono_vehicle/terrain/SCMTerrainGpu.cpp
@@ -1,4 +1,4 @@
-// SCMTerrainGpu.cpp — SCMLoader::ComputeContactForcesGpu (v2: fused pack/scatter, dense body reduce).
+// SCMTerrainGpu.cpp — SCMLoader::ComputeContactForcesGpu (v3: GPU body reduce, grid-only scatter).
 
 #ifdef CHRONO_VEHICLE_SCM_GPU
 
@@ -73,8 +73,6 @@ bool SCMLoader::ComputeContactForcesGpu(
 
     std::vector<ChBody*> bodies;
     bodies.reserve(64);
-    std::vector<ChVector2i> keys;
-    keys.reserve(n);
 
     scm::gpu::SoilParams soil{};
     soil.bekker_kphi = m_Bekker_Kphi;
@@ -95,7 +93,6 @@ bool SCMLoader::ComputeContactForcesGpu(
             return false;
 
         const ChVector2i& ij = h.first;
-        keys.push_back(ij);
         const int32_t bid = scm_gpu::BodySlot(bodies, body);
 
         auto& nr = m_grid_map.at(ij);
@@ -141,6 +138,8 @@ bool SCMLoader::ComputeContactForcesGpu(
         in.by = body->GetPos().y();
         in.bz = body->GetPos().z();
         in.body_id = bid;
+        in.grid_ix = ij.x();
+        in.grid_iy = ij.y();
         in.active = 1;
 
         if (auto cprops = body->GetUserData<SCMContactableData>()) {
@@ -154,18 +153,19 @@ bool SCMLoader::ComputeContactForcesGpu(
     }
 
     const auto t1 = Clock::now();
+    const std::size_t n_bodies = bodies.size();
 
-    const int gpu_rc = scm_gpu_compute_forces_staged(ctx, soil, n);
+    scm::gpu::BodyForceAccum* body_forces = scm_gpu_prepare_body_forces(ctx, n_bodies);
+    if (!body_forces)
+        return false;
+
+    const int gpu_rc = scm_gpu_compute_forces_staged(ctx, soil, n, n_bodies);
     if (gpu_rc != 0) {
         std::fprintf(stderr, "SCM GPU: scm_gpu_compute_forces_staged failed rc=%d n=%zu\n", gpu_rc, n);
         return false;
     }
 
     const auto t2 = Clock::now();
-
-    const std::size_t n_bodies = bodies.size();
-    std::vector<ChVector3d> force_acc(n_bodies, ChVector3d(0, 0, 0));
-    std::vector<ChVector3d> moment_acc(n_bodies, ChVector3d(0, 0, 0));
 
     m_body_forces.clear();
     m_modified_nodes.reserve(m_modified_nodes.size() + n);
@@ -175,7 +175,7 @@ bool SCMLoader::ComputeContactForcesGpu(
         if (!o.active)
             continue;
 
-        const auto& ij = keys[i];
+        const ChVector2i ij(batch_in[i].grid_ix, batch_in[i].grid_iy);
         auto& nr = m_grid_map.at(ij);
         const double ca = nr.normal.z();
 
@@ -191,35 +191,29 @@ bool SCMLoader::ComputeContactForcesGpu(
         nr.level = nr.level_initial - nr.sinkage / ca;
 
         m_modified_nodes.push_back(ij);
-
-        const int32_t bid = batch_in[i].body_id;
-        const ChVector3d force(o.fn_x + o.ft_x, o.fn_y + o.ft_y, o.fn_z + o.ft_z);
-        const ChVector3d moment =
-            Vcross(ChVector3d(batch_in[i].px - batch_in[i].bx, batch_in[i].py - batch_in[i].by,
-                              batch_in[i].pz - batch_in[i].bz),
-                   force);
-
-        force_acc[static_cast<std::size_t>(bid)] += force;
-        moment_acc[static_cast<std::size_t>(bid)] += moment;
     }
 
-    for (std::size_t b = 0; b < n_bodies; ++b)
-        m_body_forces.emplace(bodies[b], std::make_pair(force_acc[b], moment_acc[b]));
+    for (std::size_t b = 0; b < n_bodies; ++b) {
+        const scm::gpu::BodyForceAccum& bf = body_forces[b];
+        m_body_forces.emplace(bodies[b],
+                              std::make_pair(ChVector3d(bf.fx, bf.fy, bf.fz), ChVector3d(bf.mx, bf.my, bf.mz)));
+    }
 
     const auto t3 = Clock::now();
 
     if (profile) {
         static int n_profile = 0;
         if (n_profile < 8) {
-            const double pack_ms =
-                std::chrono::duration<double, std::milli>(t1 - t0).count();
-            const double gpu_ms =
-                std::chrono::duration<double, std::milli>(t2 - t1).count();
-            const double scatter_ms =
-                std::chrono::duration<double, std::milli>(t3 - t2).count();
+            const double pack_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            const double gpu_ms = std::chrono::duration<double, std::milli>(t2 - t1).count();
+            const double scatter_ms = std::chrono::duration<double, std::milli>(t3 - t2).count();
             std::fprintf(stderr,
-                         "SCM GPU profile n=%zu pack_ms=%.3f gpu_ms=%.3f scatter_ms=%.3f\n",
-                         n, pack_ms, gpu_ms, scatter_ms);
+                         "SCM GPU profile n=%zu bodies=%zu pack_ms=%.3f gpu_ms=%.3f scatter_ms=%.3f\n",
+                         n,
+                         n_bodies,
+                         pack_ms,
+                         gpu_ms,
+                         scatter_ms);
             ++n_profile;
         }
     }

--- a/src/chrono_vehicle/terrain/SCMTerrainGpu.cpp
+++ b/src/chrono_vehicle/terrain/SCMTerrainGpu.cpp
@@ -1,0 +1,172 @@
+// SCMTerrainGpu.cpp — SCMLoader::ComputeContactForcesGpu implementation.
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+
+#include <cstdlib>
+#include <vector>
+
+#include "chrono/physics/ChBody.h"
+#include "chrono_vehicle/terrain/SCMTerrain.h"
+
+#include "scm_gpu.h"
+
+namespace chrono {
+namespace vehicle {
+namespace scm_gpu {
+
+bool Enabled() {
+    const char* e = std::getenv("CHRONO_SCM_GPU");
+    return e && e[0] == '1' && e[1] == '\0';
+}
+
+static ScmGpuContext* GpuContext() {
+    static ScmGpuContext* ctx = scm_gpu_create(0);
+    return ctx;
+}
+
+}  // namespace scm_gpu
+
+bool SCMLoader::ComputeContactForcesGpu(const std::vector<ChVector2i>& keys,
+                                        const std::vector<scm_gpu::ScmHitRecord>& hits,
+                                        const std::vector<double>& patch_oob) {
+    const std::size_t n = hits.size();
+    if (n == 0 || keys.size() != n)
+        return true;
+
+    if (n < scm_gpu_min_hits())
+        return false;
+
+    for (const auto& rec : hits) {
+        if (!dynamic_cast<ChBody*>(rec.contactable))
+            return false;
+    }
+
+    ScmGpuContext* ctx = scm_gpu::GpuContext();
+    scm::gpu::HitInput* batch_in = scm_gpu_prepare_input(ctx, n);
+    scm::gpu::HitOutput* batch_out = scm_gpu_prepare_output(ctx, n);
+    if (!batch_in || !batch_out)
+        return false;
+
+    std::vector<ChBody*> bodies(n);
+
+    scm::gpu::SoilParams soil{};
+    soil.bekker_kphi = m_Bekker_Kphi;
+    soil.bekker_kc = m_Bekker_Kc;
+    soil.bekker_n = m_Bekker_n;
+    soil.mohr_cohesion = m_Mohr_cohesion;
+    soil.mohr_mu = m_Mohr_mu;
+    soil.janosi_shear = m_Janosi_shear;
+    soil.elastic_k = m_elastic_K;
+    soil.damping_r = m_damping_R;
+    soil.area = m_area;
+    soil.dt = GetSystem()->GetStep();
+
+    for (std::size_t idx = 0; idx < n; ++idx) {
+        const auto& rec = hits[idx];
+        const ChVector2i& ij = keys[idx];
+        auto& nr = m_grid_map.at(ij);
+        const double ca = nr.normal.z();
+
+        ChBody* body = dynamic_cast<ChBody*>(rec.contactable);
+        bodies[idx] = body;
+
+        auto hit_point_loc = m_frame.TransformPointParentToLocal(rec.abs_point);
+
+        ChVector3d point_local(ij.x() * m_delta, ij.y() * m_delta, nr.level);
+        ChVector3d point_abs = m_frame.TransformPointLocalToParent(point_local);
+        ChVector3d speed_abs = rec.contactable->GetContactPointSpeed(point_abs);
+
+        ChVector3d N = m_frame.TransformDirectionLocalToParent(nr.normal);
+        const double Vn = Vdot(speed_abs, N);
+        ChVector3d T = -(speed_abs - Vn * N);
+        T.Normalize();
+
+        double patch_oob_val = 0.0;
+        if (rec.patch_id >= 0 && rec.patch_id < static_cast<int>(patch_oob.size()))
+            patch_oob_val = patch_oob[static_cast<std::size_t>(rec.patch_id)];
+
+        scm::gpu::HitInput& in = batch_in[idx];
+        in = {};
+        in.level_initial = nr.level_initial;
+        in.level = nr.level;
+        in.sinkage_plastic = nr.sinkage_plastic;
+        in.kshear = nr.kshear;
+        in.sigma_yield = nr.sigma_yield;
+        in.normal_z = ca;
+        in.hit_level = hit_point_loc.z();
+        in.patch_oob = patch_oob_val;
+        in.vn = Vn;
+        in.vt = Vdot(speed_abs, -T);
+        in.nx = N.x();
+        in.ny = N.y();
+        in.nz = N.z();
+        in.tx = T.x();
+        in.ty = T.y();
+        in.tz = T.z();
+        in.px = point_abs.x();
+        in.py = point_abs.y();
+        in.pz = point_abs.z();
+        in.bx = body->GetPos().x();
+        in.by = body->GetPos().y();
+        in.bz = body->GetPos().z();
+        in.body_id = static_cast<int32_t>(idx);
+        in.active = 1;
+
+        if (auto cprops = rec.contactable->GetUserData<SCMContactableData>()) {
+            in.c_cohesion = cprops->Mohr_cohesion;
+            in.c_mu = cprops->Mohr_mu;
+            in.c_janosi = cprops->Janosi_shear;
+            in.area_ratio = cprops->area_ratio;
+        }
+    }
+
+    const int gpu_rc = scm_gpu_compute_forces_staged(ctx, soil, n);
+    if (gpu_rc != 0) {
+        std::fprintf(stderr, "SCM GPU: scm_gpu_compute_forces_staged failed rc=%d n=%zu\n", gpu_rc,
+                     static_cast<std::size_t>(n));
+        return false;
+    }
+
+    m_body_forces.clear();
+
+    for (std::size_t i = 0; i < n; ++i) {
+        const scm::gpu::HitOutput& o = batch_out[i];
+        if (!o.active)
+            continue;
+
+        auto& nr = m_grid_map.at(keys[i]);
+        const double ca = nr.normal.z();
+
+        nr.hit_level = batch_in[i].hit_level;
+        nr.sinkage = o.sinkage;
+        nr.sinkage_plastic = o.sinkage_plastic;
+        nr.sinkage_elastic = o.sinkage_elastic;
+        nr.sigma = o.sigma;
+        nr.sigma_yield = o.sigma_yield;
+        nr.kshear = o.kshear;
+        nr.tau = o.tau;
+        nr.step_plastic_flow = o.step_plastic_flow;
+        nr.level = nr.level_initial - nr.sinkage / ca;
+
+        m_modified_nodes.push_back(keys[i]);
+
+        ChVector3d force(o.fn_x + o.ft_x, o.fn_y + o.ft_y, o.fn_z + o.ft_z);
+        ChVector3d moment = Vcross(ChVector3d(batch_in[i].px, batch_in[i].py, batch_in[i].pz) - bodies[i]->GetPos(),
+                                  force);
+
+        auto itr = m_body_forces.find(bodies[i]);
+        if (itr == m_body_forces.end())
+            m_body_forces.insert(std::make_pair(bodies[i], std::make_pair(force, moment)));
+        else {
+            itr->second.first += force;
+            itr->second.second += moment;
+        }
+    }
+
+    return true;
+}
+
+}  // namespace vehicle
+}  // namespace chrono
+
+#endif  // CHRONO_VEHICLE_SCM_GPU

--- a/src/chrono_vehicle/terrain/SCMTerrainGpu.h
+++ b/src/chrono_vehicle/terrain/SCMTerrainGpu.h
@@ -1,0 +1,8 @@
+// SCMTerrainGpu.h — included when CHRONO_VEHICLE_SCM_GPU is defined.
+// Declarations live in SCMTerrain.h (ComputeContactForcesGpu, scm_gpu::Enabled).
+
+#pragma once
+
+#ifdef CHRONO_VEHICLE_SCM_GPU
+// Intentionally empty — see SCMTerrain.h
+#endif


### PR DESCRIPTION
### Summary

Follow-up perf PR for SCM HIP integration:

- `SCMTerrainGpu.cpp`: grid-only host scatter; body forces from device reduction
- Requires rebuilt external `scm_gpu` with `scm_reduce_body_forces_kernel` and `scm_gpu_compute_forces_staged(..., n_bodies)`

### Depends on

- **Merge first:** [#755](https://github.com/projectchrono/chrono/pull/755), then [#756](https://github.com/projectchrono/chrono/pull/756)
- Incremental diff on fork: `amd-pratmish:perf/scm-vehicle-hip-body-reduce` based on `perf/scm-vehicle-hip-e2e`

### Files in this PR

- `src/chrono_vehicle/terrain/SCMTerrainGpu.cpp`

### Test plan

- [ ] `scm_parity_test` PASS (per-hit + body-force parity)
- [ ] `scm_scaling_benchmark --n-hits 65536` kernel speedup ≥ 2×
- [ ] E2E `CHRONO_SCM_GPU_PROFILE=1` — scatter_ms ≤ v2