### PR TITLE
[MAINTENANCE] Build and run CRM terrain demos without Chrono::VSG

### DIFF
--- a/src/demos/vehicle/terrain/CMakeLists.txt
+++ b/src/demos/vehicle/terrain/CMakeLists.txt
@@ -2,47 +2,55 @@
 # CMake configuration file for demos of various Chrono::Vehicle terrain models.
 #=============================================================================
 
-if(NOT CH_ENABLE_MODULE_VSG)
+if(NOT CH_ENABLE_MODULE_VSG AND NOT CH_ENABLE_MODULE_FSI_SPH)
   return()
 endif()
 
 #--------------------------------------------------------------
 # List all demos
 
-set(DEMOS ${DEMOS}
-    demo_VEH_RigidTerrain_WheeledVehicle
-    demo_VEH_RigidSCMTerrain_MixedPatches
-    demo_VEH_SCMTerrain_WheeledVehicle
-    demo_VEH_SCMTerrain_RigidTire
-    demo_VEH_SCMTerrain_TrackedVehicle
-    demo_VEH_RigidTerrain_MovingPatch
-)
- 
-if(CH_USE_OPENCRG) 
+if(CH_ENABLE_MODULE_VSG)
+  set(DEMOS ${DEMOS}
+      demo_VEH_RigidTerrain_WheeledVehicle
+      demo_VEH_RigidSCMTerrain_MixedPatches
+      demo_VEH_SCMTerrain_WheeledVehicle
+      demo_VEH_SCMTerrain_RigidTire
+      demo_VEH_SCMTerrain_TrackedVehicle
+      demo_VEH_RigidTerrain_MovingPatch
+  )
+
+  if(CH_USE_OPENCRG)
       set(DEMOS ${DEMOS}
           demo_VEH_CRGTerrain_VSG
-    )
-endif()
+      )
+  endif()
 
-if(CH_ENABLE_MODULE_MULTICORE)
-    set(DEMOS ${DEMOS}
-        demo_VEH_GranularTerrain_RigidTire
-        demo_VEH_GranularTerrain_MovingPatch
-    )
+  if(CH_ENABLE_MODULE_MULTICORE)
+      set(DEMOS ${DEMOS}
+          demo_VEH_GranularTerrain_RigidTire
+          demo_VEH_GranularTerrain_MovingPatch
+      )
+  endif()
+
+  if(CH_ENABLE_MODULE_FEA AND CH_ENABLE_MODULE_PARDISO_MKL)
+      set(DEMOS ${DEMOS}
+          demo_VEH_SCMTerrain_FEATire
+      )
+  endif()
 endif()
 
 if(CH_ENABLE_MODULE_FSI_SPH)
+    # These CRM demos have a headless (no-VSG) code path.
     set(DEMOS ${DEMOS}
         demo_VEH_CRMTerrain_WheeledVehicle
         demo_VEH_CRMTerrain_TrackedVehicle
-        demo_VEH_CRMTerrain_MovingPatch
     )
-endif()
-
-if(CH_ENABLE_MODULE_FEA AND CH_ENABLE_MODULE_PARDISO_MKL)
-    set(DEMOS ${DEMOS}
-        demo_VEH_SCMTerrain_FEATire
-    )
+    # demo_VEH_CRMTerrain_MovingPatch includes VSG headers unconditionally.
+    if(CH_ENABLE_MODULE_VSG)
+        set(DEMOS ${DEMOS}
+            demo_VEH_CRMTerrain_MovingPatch
+        )
+    endif()
 endif()
 
 #--------------------------------------------------------------

--- a/src/demos/vehicle/terrain/demo_VEH_CRMTerrain_TrackedVehicle.cpp
+++ b/src/demos/vehicle/terrain/demo_VEH_CRMTerrain_TrackedVehicle.cpp
@@ -38,6 +38,7 @@
 #include "chrono_vehicle/tracked_vehicle/vehicle/TrackedVehicle.h"
 #include "chrono_vehicle/utils/ChVehicleUtilsJSON.h"
 #include "chrono_vehicle/terrain/CRMTerrain.h"
+#include "chrono_vehicle/ChVehicleVisualSystem.h"
 
 #include "chrono_thirdparty/cxxopts/ChCLI.h"
 
@@ -364,7 +365,8 @@ int main(int argc, char* argv[]) {
         // Synchronize systems
         driver.Synchronize(time);
         terrain.Synchronize(time);
-        vis->Synchronize(time, driver_inputs);
+        if (vis)
+            vis->Synchronize(time, driver_inputs);
         vehicle->Synchronize(time, driver_inputs, shoe_forces_left, shoe_forces_right);
 
         // Write vehicle stats to CSV
@@ -383,12 +385,14 @@ int main(int argc, char* argv[]) {
         // Note: CRMTerrain::Advance also performs the vehicle dynamics
         if (sph_params.use_variable_time_step) {
             driver.Advance(meta_step_size);
-            vis->Advance(meta_step_size);
+            if (vis)
+                vis->Advance(meta_step_size);
             terrain.Advance(meta_step_size);
             time += meta_step_size;
         } else {
             driver.Advance(step_size);
-            vis->Advance(step_size);
+            if (vis)
+                vis->Advance(step_size);
             terrain.Advance(step_size);
             time += step_size;
         }

--- a/src/demos/vehicle/terrain/demo_VEH_CRMTerrain_WheeledVehicle.cpp
+++ b/src/demos/vehicle/terrain/demo_VEH_CRMTerrain_WheeledVehicle.cpp
@@ -363,13 +363,15 @@ int main(int argc, char* argv[]) {
 
         // Synchronize systems
         driver.Synchronize(time);
-        vis->Synchronize(time, driver_inputs);
+        if (vis)
+            vis->Synchronize(time, driver_inputs);
         terrain.Synchronize(time);
         vehicle->Synchronize(time, driver_inputs, terrain);
 
         // Advance system state
         driver.Advance(step_size);
-        vis->Advance(step_size);
+        if (vis)
+            vis->Advance(step_size);
         // Coupled FSI problem (CRM terrain + vehicle)
         terrain.Advance(step_size);
 


### PR DESCRIPTION
**Summary**

`src/demos/vehicle/terrain/` returned early unless `CH_ENABLE_MODULE_VSG` was enabled, so the CRM terrain demos could not be built headless even though `demo_VEH_CRMTerrain_WheeledVehicle` and `demo_VEH_CRMTerrain_TrackedVehicle` have complete no-VSG code paths (guarded includes, `render = false` fallback). In addition, both demos unconditionally dereferenced the (null) visualization system inside the simulation loop, so a headless build would have crashed at the first step.

Changes:

1. Build the two headless-capable CRM demos whenever `CH_ENABLE_MODULE_FSI_SPH` is enabled, with or without VSG. With VSG enabled, the built demo set is unchanged. `demo_VEH_CRMTerrain_MovingPatch` includes VSG headers unconditionally and remains gated on VSG (possible follow-up).
2. Guard the `vis->Synchronize()` / `vis->Advance()` calls with `if (vis)` in both demos, and include `chrono_vehicle/ChVehicleVisualSystem.h` directly in the tracked demo (previously reached only transitively through the VSG headers).

**Related Issue(s)**

None open. The null dereference was unreachable before, precisely because the CMake gate made headless builds of these demos impossible.

**Author(s)**

Dan Negrut, University of Wisconsin-Madison (negrut@wisc.edu)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and redistributed under the BSD-3-Clause License.

**Backward Compatibility**

None affected. With `CH_ENABLE_MODULE_VSG=ON`, the demo list and runtime behavior are identical to before; the `if (vis)` guards are no-ops when a visualization system exists.

**Detailed Description**

Verified headless (no VSG/Irrlicht/OpenGL modules) on Windows 11 building with the AMD HIP SDK 7.1.1 on a Radeon 8060S (gfx1151): both demos build and run; the wheeled demo drives the full CRM patch to completion, and the tracked demo advances with per-step RTF telemetry and CSV output. The underlying null dereference is platform-independent; any headless CUDA/Linux build of these demos would crash the same way.

**Post Submission Checklist**

- [ ] The pull request is complete
- [ ] The feature has been verified to work with the CMake based build system