### PR TITLE
[UPDATE] Enable building the HIP backend on native Windows

### DIFF
--- a/docs/README_AMD_GPU.md
+++ b/docs/README_AMD_GPU.md
@@ -27,10 +27,11 @@ If you only need **simulation + Python bindings** next to a **ROCm** ML stack, *
 ### Workflow B (HIP / FSI)
 
 - **ROCm** with **HIP** so `hipcc` works.
-- **`hipify-perl`** on `PATH` only if you use a mechanical CUDA→HIP pass while developing (see §5).
+- **`hipify-perl`** on `PATH` only if you use a mechanical CUDA→HIP pass while developing (see §6).
 - Set **`CMAKE_HIP_COMPILER=hipcc`** and **`CHRONO_HIP_ARCHITECTURES`** (or **`CMAKE_HIP_ARCHITECTURES`**) to your GPU ISA, for example:
   - **gfx942** — AMD Instinct MI300-class
-  - **gfx90a** — MI200-class  
+  - **gfx90a** — MI200-class
+  - **gfx1151** — Ryzen AI Max integrated GPU (Radeon 8060S-class)  
   Use `rocminfo` or vendor documentation for other ASICs.
 
 ### Multi-GPU hosts (runtime)
@@ -85,7 +86,65 @@ See also the [FSI module installation](https://api.projectchrono.org/module_fsi_
 
 ---
 
-## 5. Contributing: CUDA sources and `hipify-perl`
+## 5. Build on Windows (native HIP SDK)
+
+The HIP backend also builds **natively on Windows** (no WSL) using the [AMD HIP SDK](https://rocm.docs.amd.com/projects/install-on-windows/en/latest/), version **7.1.1 or newer**. Validated on Windows 11 with a Radeon 8060S (**gfx1151**, Ryzen AI Max): FSI-SPH, CRM terrain, and DEM demos all run on the GPU.
+
+### Prerequisites
+
+- **AMD HIP SDK >= 7.1.1**: provides ROCm clang, the HIP runtime, and the rocThrust / hipCUB / rocPRIM headers.
+- **Visual Studio 2022 Build Tools** (C++ workload): supplies the MSVC STL and Windows SDK.
+- **CMake >= 3.30** and **Ninja** (both bundled with VS Build Tools).
+- **Eigen3**: extract a release and pass `EIGEN3_INCLUDE_DIR`.
+
+### Key differences from Linux
+
+- **One compiler family for everything.** CMake on Windows rejects mixing MSVC `cl` for C++ with clang for HIP. Set `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`, and `CMAKE_HIP_COMPILER` all to the SDK's `clang++.exe`. It targets the MSVC ABI and uses the MSVC STL, so the result is still a native Windows build.
+- **`-DCH_ENABLE_OPENMP=OFF`**: the Windows HIP SDK ships no `libomp`; without this flag the build fails to link with undefined `__kmpc_*` symbols. The GPU modules are unaffected; CPU-side loops run single-threaded.
+- Configure and build **inside a VS x64 developer shell**, so that clang and `lld-link` find the MSVC headers and libraries.
+
+### Configure and build (PowerShell, x64 dev shell)
+
+```powershell
+& 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Launch-VsDevShell.ps1' -Arch amd64 -SkipAutomaticLocation
+$ROCM = 'C:/Program Files/AMD/ROCm/7.1'
+cmake -S . -B build -G Ninja `
+  -DCMAKE_BUILD_TYPE=Release `
+  -DCMAKE_C_COMPILER="$ROCM/bin/clang.exe" `
+  -DCMAKE_CXX_COMPILER="$ROCM/bin/clang++.exe" `
+  -DCMAKE_HIP_COMPILER="$ROCM/bin/clang++.exe" `
+  -DCMAKE_HIP_PLATFORM=amd `
+  -DCMAKE_HIP_COMPILER_ROCM_ROOT="$ROCM" `
+  -DCMAKE_HIP_ARCHITECTURES=gfx1151 `
+  -DCHRONO_GPU_BACKEND=HIP `
+  -DCHRONO_HIP_ARCHITECTURES=gfx1151 `
+  -DCHRONO_ROCM_ROOT="$ROCM" `
+  -DEIGEN3_INCLUDE_DIR='C:/libs/eigen-3.4.0' `
+  -DCH_ENABLE_OPENMP=OFF `
+  -DCH_ENABLE_MODULE_FSI=ON `
+  -DCH_ENABLE_MODULE_DEM=ON `
+  -DBUILD_DEMOS=ON
+cmake --build build -j 16
+```
+
+Change `gfx1151` to your GPU ISA and adjust module flags as needed (e.g. `CH_ENABLE_MODULE_VEHICLE=ON` for the CRM terrain demos).
+
+### Running
+
+- Add the SDK's `bin` directory (e.g. `C:\Program Files\AMD\ROCm\7.1\bin`) to `PATH` so the HIP runtime DLLs resolve.
+- Run demos from `<build>\bin`; the Chrono data directory is resolved relative to it.
+
+### Troubleshooting (Windows)
+
+| Symptom | Hint |
+|---------|------|
+| CMake error "mixes Clang and MSVC or some other CL compatible compiler tool" | Set the C, CXX, and HIP compilers all to the SDK's `clang++.exe` (see above). |
+| Link errors with undefined `__kmpc_*` / `omp_*` symbols | Configure with `-DCH_ENABLE_OPENMP=OFF`; the Windows HIP SDK ships no libomp. |
+| `lld-link` cannot find MSVC libraries | Configure and build inside a VS x64 developer shell. |
+
+---
+
+## 6. Contributing: CUDA sources and `hipify-perl`
 
 FSI / SPH device code lives under **`src/chrono_fsi/sph/`** (for example **`src/chrono_fsi/sph/physics/*.cu`**). For a **mechanical** pass on one file:
 
@@ -99,7 +158,7 @@ Use the diff as a **checklist**; this repository may compile existing **`.cu`** 
 
 ---
 
-## 6. Troubleshooting
+## 7. Troubleshooting
 
 | Symptom | Hint |
 |---------|------|
@@ -109,7 +168,7 @@ Use the diff as a **checklist**; this repository may compile existing **`.cu`** 
 
 ---
 
-## 7. Further reading
+## 8. Further reading
 
 - [Installation guides](https://api.projectchrono.org/install_guides.html) (all modules).
 - [Install PyChrono](https://api.projectchrono.org/pychrono_installation.html) (conda vs build from source).

--- a/doxygen/documentation/installation/install_chrono.md
+++ b/doxygen/documentation/installation/install_chrono.md
@@ -70,6 +70,8 @@ The minimum HIP version required by Chrono is 5.7.0.
 
 Install the [AMD ROCm](https://rocm.docs.amd.com/) stack for your distribution so that `hipcc` and the HIP runtime are available. Set `CHRONO_GPU_BACKEND=HIP` during CMake configuration (or use `AUTO` on a machine where ROCm is detected before CUDA). Set `CHRONO_HIP_ARCHITECTURES` to your GPU ISA (for example `gfx942` on AMD Instinct MI300-class accelerators, or `gfx90a` on MI200-class); alternatively set `CMAKE_HIP_ARCHITECTURES` as appropriate for your CMake version.
 
+The HIP backend can also be built **natively on Windows** using the AMD HIP SDK; see the Windows section of the repository guide [docs/README_AMD_GPU.md](../../../docs/README_AMD_GPU.md) for the required toolchain configuration.
+
 For **CPU-only PyChrono** next to a ROCm PyTorch stack, you do **not** need the NVIDIA CUDA toolkit; see the repository guide [docs/README_AMD_GPU.md](../../../docs/README_AMD_GPU.md) (workflow summaries, Eigen3/SWIG notes, and `ROCR_VISIBLE_DEVICES` for multi-GPU hosts).
 
 #### Thrust support {#thrust}

--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -1554,14 +1554,9 @@ if(CHRONO_YAML_ENABLED)
 endif()
 
 # Add the 'socket' library to the linking, depending on platform.
+# On Windows, Winsock is needed regardless of the compiler (MSVC, clang, GCC/MinGW).
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-	if("${CH_COMPILER}" STREQUAL "COMPILER_MSVC")
-        target_link_libraries(Chrono_core PUBLIC Ws2_32.lib)
-	elseif("${CH_COMPILER}" STREQUAL "COMPILER_MSVC_X64")
-        target_link_libraries(Chrono_core PUBLIC Ws2_32.lib)
-	elseif("${CH_COMPILER}" STREQUAL "COMPILER_GCC")
-	elseif("${CH_COMPILER}" STREQUAL "COMPILER_GCC_X64")
-	endif()
+    target_link_libraries(Chrono_core PUBLIC Ws2_32.lib)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()

--- a/src/chrono/gpu/ChGpuRuntime.h
+++ b/src/chrono/gpu/ChGpuRuntime.h
@@ -274,7 +274,15 @@ inline gpuError gpuGetDeviceProperties(gpuDeviceProp* prop, int device) {
 }
 
 inline gpuError gpuMemAdvise(const void* ptr, std::size_t bytes, gpuMemoryAdvise advice, int device) {
-    return hipMemAdvise(ptr, bytes, advice, device);
+    // Memory advice is a performance hint only. On some HIP platforms (e.g. Windows,
+    // or APUs without full managed-memory support) hipMemAdvise is not implemented and
+    // fails with hipErrorInvalidValue / hipErrorNotSupported; treat that as benign.
+    hipError_t err = hipMemAdvise(ptr, bytes, advice, device);
+    if (err == hipErrorInvalidValue || err == hipErrorNotSupported) {
+        (void)hipGetLastError();  // clear the sticky error state
+        return hipSuccess;
+    }
+    return err;
 }
 
 inline gpuError gpuStreamCreate(gpuStream* stream) {


### PR DESCRIPTION
**Summary**

Two small fixes that unblock building and running Chrono's HIP backend (Chrono::FSI-SPH and Chrono::DEM) natively on Windows with the AMD HIP SDK, plus documentation of the Windows build recipe. This builds on the AMD/HIP port merged in #731/#743 (created independently of, but validated against, that work).

1. `src/chrono/CMakeLists.txt`: `Ws2_32.lib` was linked into `Chrono_core` only when `CH_COMPILER` is `COMPILER_MSVC` or `COMPILER_MSVC_X64`. On Windows, CMake requires a single compiler family across CXX and HIP, so HIP builds must compile everything with ROCm clang; those builds failed to link with unresolved Winsock symbols. Winsock is now linked on Windows regardless of compiler.
2. `src/chrono/gpu/ChGpuRuntime.h`: `hipMemAdvise` is not implemented for managed memory on some HIP platforms (native Windows, APUs) and returns `hipErrorInvalidValue`, which the DEM error-check macro escalated to a fatal abort during solver initialization (`ChSystemDem_impl.cpp`, `initializeSpheres`). Memory advice is a performance hint, so the HIP `gpuMemAdvise` wrapper now treats the unsupported-advice error codes (`hipErrorInvalidValue`, `hipErrorNotSupported`) as benign and clears the sticky error state. The CUDA path is untouched.
3. `docs/README_AMD_GPU.md`: new section "Build on Windows (native HIP SDK)" covering the single-compiler-family requirement, `CH_ENABLE_OPENMP=OFF` (the Windows HIP SDK ships no libomp), a reference CMake configuration, run notes, and Windows-specific troubleshooting; `gfx1151` added to the ISA examples; one-line pointer added to the install guide's HIP subsection.

**Related Issue(s)**

None open; follows up on the AMD/HIP port (#731, #743, #744) and the AMD docs PR (#753).

**Author(s)**

Dan Negrut, University of Wisconsin-Madison (negrut@wisc.edu)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and redistributed under the BSD-3-Clause License.

**Backward Compatibility**

No breaking changes. MSVC builds link Ws2_32 exactly as before (the change is a superset of the previous condition). `gpuMemAdvise` behavior on CUDA is unchanged; on HIP, only the two "advice not supported" error codes are tolerated, and all other errors still propagate.

**Implementation Notes**

Validated end to end on Windows 11 with the AMD HIP SDK 7.1.1 (HIP 7.1.51803, ROCm clang 21 targeting the MSVC ABI, VS 2022 Build Tools, Ninja) on a Radeon 8060S (gfx1151, Ryzen AI Max+ 395):

1. FSI: `demo_FSI-SPH_Poiseuille_flow` (10 simulated s in 13.9 s wall) and `demo_FSI-SPH_DamBreak` (`--t_end 1 --no_vis --output`, particle CSV output verified).
2. CRM terrain: `demo_VEH_CRMTerrain_WheeledVehicle` headless (vehicle traverses the CRM patch; CFD RTF approx. 5).
3. DEM: `demo_DEM_ballCosim`, both phases (622,713-particle settling and the ball-drop co-simulation restarted from the checkpoint). Without the `hipMemAdvise` change, every Chrono::DEM run on this platform aborts at initialization.

The NVIDIA/CUDA path is unaffected by inspection (no CUDA code touched); Linux HIP behavior is unchanged except that unsupported memory advice no longer aborts.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] Suitable updates to the existing docs are included
- [ ] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

AMD HIP SDK for Windows system requirements: https://rocm.docs.amd.com/projects/install-on-windows/en/latest/reference/system-requirements.html