### PR TITLE
[UPDATE] Fix Chrono::VSG with the HIP backend and repair the VSG build scripts

### DIFF
--- a/contrib/build-scripts/linux/buildVSG.sh
+++ b/contrib/build-scripts/linux/buildVSG.sh
@@ -121,9 +121,15 @@ mkdir ${VSG_INSTALL_DIR}
 # --- glslang ------------------------------------------------------------
 
 echo "\n------------------------ Configure glslang\n"
+# Note: ENABLE_OPT=0 is required when building glslang from a plain clone: its default
+# (ENABLE_OPT=1) requires SPIRV-Tools sources that are not present, and the configure
+# step fails, silently leaving VSG without runtime shader compilation
+# ("FATAL: VulkanSceneGraph not compiled with GLSLang" in every VSG application).
+# The glslang build also requires a Python 3 interpreter.
 rm -rf build_glslang
 cmake -G "${BUILDSYSTEM}" -B build_glslang -S ${GLSLANG_SOURCE_DIR} \
       -DBUILD_SHARED_LIBS:BOOL=${BUILDSHARED} \
+      -DENABLE_OPT=0 \
       -DCMAKE_DEBUG_POSTFIX="_d"
 
 echo "\n------------------------ Build and install glslang\n"

--- a/contrib/build-scripts/windows/buildVSG.bat
+++ b/contrib/build-scripts/windows/buildVSG.bat
@@ -101,10 +101,18 @@ rmdir /S/Q %VSG_INSTALL_DIR% 2>nul
 
 @rem --- glslang ------------------------------------------------------------
 
+@rem Notes:
+@rem - ENABLE_OPT=0 is required when building glslang from a plain clone: its default
+@rem   (ENABLE_OPT=1) requires SPIRV-Tools sources that are not present, and the
+@rem   configure step fails, silently leaving VSG without runtime shader compilation
+@rem   ("FATAL: VulkanSceneGraph not compiled with GLSLang" in every VSG application).
+@rem - The glslang build requires a Python 3 interpreter on the PATH (or pass
+@rem   -DPython3_EXECUTABLE=<path to python.exe>).
 rmdir /S/Q build_glslang 2>nul
 cmake -B build_glslang -S %GLSLANG_SOURCE_DIR% ^
       -DBUILD_SHARED_LIBS:BOOL=%BUILDSHARED% ^
-      -DCMAKE_DEBUG_POSTFIX="_d" 
+      -DENABLE_OPT=0 ^
+      -DCMAKE_DEBUG_POSTFIX="_d"
 
 cmake --build build_glslang --config Release
 cmake --install build_glslang --config Release --prefix %VSG_INSTALL_DIR%

--- a/src/chrono_fsi/sph/CMakeLists.txt
+++ b/src/chrono_fsi/sph/CMakeLists.txt
@@ -348,6 +348,10 @@ if(CH_ENABLE_MODULE_VSG)
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA")
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
     elseif(CHRONO_HIP_FOUND)
+      # Compile the VSG plugin source with the HIP compiler: it includes FSI
+      # data-manager headers that reference rocThrust/rocPRIM device types,
+      # which do not compile as plain C++ (same treatment as FSISPH_GPU_SOURCE_FILES).
+      set_source_files_properties(visualization/ChSphVisualizationVSG.cpp PROPERTIES LANGUAGE HIP)
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE CHRONO_USE_HIP)
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP")
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")


### PR DESCRIPTION
**Summary**

Two fixes discovered while bringing up run-time visualization (Chrono::VSG) on a machine using the HIP GPU backend — a combination that had not been built before:

1. `src/chrono_fsi/sph/CMakeLists.txt`: with `CHRONO_GPU_BACKEND=HIP` and `CH_ENABLE_MODULE_VSG=ON`, `Chrono_fsisph_vsg` failed to compile: `ChSphVisualizationVSG.cpp` includes the FSI data-manager headers, whose rocThrust/rocPRIM device types do not compile as plain C++ (`error: use of undeclared identifier '__builtin_amdgcn_wavefrontsize'`). The file is now compiled with the HIP compiler under `CHRONO_HIP_FOUND`, the same treatment the main FSI library applies to its own sources.
2. `contrib/build-scripts/windows/buildVSG.bat` and `contrib/build-scripts/linux/buildVSG.sh`: building glslang from a plain clone fails to configure with its default `ENABLE_OPT=1` (SPIRV-Tools sources are not present in the clone), and since the scripts do not check for errors, VSG silently builds without runtime shader compilation. Every Chrono::VSG application then aborts at startup with `FATAL: VulkanSceneGraph not compiled with GLSLang, unable to compile shaders.` The scripts now configure glslang with `ENABLE_OPT=0` (the SPIR-V optimizer is not needed for VSG's GLSL-to-SPIR-V compilation) and document glslang's Python 3 build requirement.

**Related Issue(s)**

Follows up on #758 and #759 (native Windows HIP support and headless CRM demos).

**Author(s)**

Dan Negrut, University of Wisconsin-Madison (negrut@wisc.edu)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and redistributed under the BSD-3-Clause License.

**Backward Compatibility**

None affected. The CUDA + VSG path is untouched (the new `set_source_files_properties` call is inside the `CHRONO_HIP_FOUND` branch). For the build scripts, `ENABLE_OPT=0` changes glslang from "fails to configure" to "configures and builds"; VSG does not use the SPIR-V optimizer.

**Implementation Notes**

Validated on Windows 11, AMD HIP SDK 7.1.1, Radeon 8060S (gfx1151), with VulkanSceneGraph 1.1.15 built via the fixed `buildVSG.bat` and Chrono configured with `CHRONO_GPU_BACKEND=HIP` + `CH_ENABLE_MODULE_VSG=ON`:

1. `demo_VEH_CRMTerrain_WheeledVehicle` with run-time visualization: 266,532 SPH particles simulated on HIP while rendering at ~28 FPS through Vulkan on the same GPU; runs to completion.
2. `demo_ROBOT_Viper_CRM`: 364,509 SPH particles, interactive visualization with the full VSG/ImGui HUD.

The `buildVSG.sh` change is the same one-flag fix as the Windows script; it has not been exercised on a Linux host as part of this PR.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The feature has been verified to work with the CMake based build system