### PR TITLE
Remove Explicit Setting for CMAKE_MACOSX_RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,6 @@ message(STATUS "The host processor is ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 message(STATUS "Building for a ${CMAKE_SYSTEM_NAME} system")
 message(STATUS "The target processor is ${CMAKE_SYSTEM_PROCESSOR}")
 
-# Get rid of cmake RPATH warning on OSX
-if(APPLE)
-    set(CMAKE_MACOSX_RPATH OFF)
-endif()
-
 #-----------------------------------------------------------------------------
 # Location of additional CMake scripts
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
I'd like for this setting to be default so that "@rpath/" is prefixed to installed libraries' install name.

Without this, if I have a library or executable that depends on `Chrono::Chrono_core`, then
```cmake
install(TARGETS MyLibOrExe RUNTIME_DEPENDENCIES)
```
will ultimately fail with
```
file Resolved path is not absolute
```
because the install name is a relative path of just the library name.

I'm not sure what the original comment about the warning on MacOS meant, but in my build I don't see a warning.  Perhaps this is dependent on the CMake version.  It seems this stuff has changed since that comment was left.

From https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_RPATH.html#prop_tgt:MACOSX_RPATH:
"When this property is set to TRUE, the directory portion of the install_name field of this shared library will be `@rpath` unless overridden by [INSTALL_NAME_DIR](https://cmake.org/cmake/help/latest/prop_tgt/INSTALL_NAME_DIR.html#prop_tgt:INSTALL_NAME_DIR)"

See https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html for details on MacOS install names, `@rpath`, `@loader_path`, and `@executable_path`.