### PR TITLE
 Add precompiled header to `Chrono_core`  (~14% faster clean rebuilds)

### DIFF
--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -1502,6 +1502,30 @@ target_include_directories(Chrono_core PUBLIC
 
 target_link_libraries(Chrono_core PUBLIC Eigen3::Eigen)
 
+# -----------------------------------------------------------------------------
+# Precompiled header
+#
+# Chrono_core has ~500 translation units, the vast majority of which include the
+# core linear-algebra headers (and therefore Eigen) plus the STL stream and
+# container headers. Build-Insights profiling shows these dominate the front-end
+# parse and template-instantiation cost (Eigen alone accounts for the top
+# template-instantiation entries, and ChMatrix.h is the single most included
+# header). Parsing them once into a PCH and reusing the result across every TU
+# eliminates that repeated work.
+#
+# ChMatrix.h (not a bare Eigen include) is used as the anchor on purpose: it
+# defines EIGEN_MATRIXBASE_PLUGIN / EIGEN_SPARSEMATRIX_PLUGIN before pulling in
+# Eigen/Dense and Eigen/Sparse, so precompiling it reproduces Chrono's exact
+# Eigen configuration. It also transitively precompiles ChArchive.h /
+# ChArchiveASCII.h, two other widely included, expensive headers.
+#
+# Scope is PRIVATE so the PCH is used only when compiling Chrono_core itself and
+# is not forced onto consumers of the library. The header list lives in
+# ChCorePCH.h, which is guarded by __cplusplus so the precompiled header is empty
+# for the target's C sources.
+target_precompile_headers(Chrono_core PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/ChCorePCH.h")
+# -----------------------------------------------------------------------------
+
 if(CHRONO_THRUST_FOUND)
   target_link_libraries(Chrono_core PRIVATE Thrust::Thrust)
 

--- a/src/chrono/ChCorePCH.h
+++ b/src/chrono/ChCorePCH.h
@@ -1,0 +1,50 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+//
+// Precompiled header for the Chrono_core library.
+//
+// Chrono_core has ~500 translation units, almost all of which include the core
+// linear-algebra headers (and therefore Eigen) together with the STL stream and
+// container headers. Build-Insights profiling shows these dominate front-end
+// parse and template-instantiation cost, so parsing them once here and reusing
+// the result across every TU removes a large amount of repeated work.
+//
+// ChMatrix.h (rather than a bare Eigen include) is the anchor on purpose: it
+// defines EIGEN_MATRIXBASE_PLUGIN / EIGEN_SPARSEMATRIX_PLUGIN before including
+// Eigen/Dense and Eigen/Sparse, so pulling it in reproduces Chrono's exact Eigen
+// configuration and also transitively precompiles ChArchive.h / ChArchiveASCII.h.
+//
+// The __cplusplus guard keeps this header empty when the precompiled header is
+// generated for the handful of C sources in the target.
+// =============================================================================
+
+#ifndef CHRONO_CORE_PCH_H
+#define CHRONO_CORE_PCH_H
+
+#ifdef __cplusplus
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "chrono/core/ChMatrix.h"
+
+#endif  // __cplusplus
+
+#endif  // CHRONO_CORE_PCH_H


### PR DESCRIPTION
## Summary

Adds a precompiled header (PCH) to the `Chrono_core` target to eliminate
redundant front-end parsing and template instantiation. Build-Insights / vcperf
profiling showed that a small set of core linear-algebra headers (which
transitively pull in Eigen) plus STL stream/container headers are included in
300–430 of `Chrono_core`'s 518 translation units — so every TU re-parses and
re-instantiates the same Eigen machinery. A PCH parses that work **once** and
reuses it across all TUs.

### Changes

- **New:** `src/chrono/ChCorePCH.h` — a `__cplusplus`-guarded header including
  the heavy STL headers (`<algorithm> <cmath> <fstream> <iostream> <map>
  <memory> <sstream> <string> <unordered_map> <vector>`) plus
  `chrono/core/ChMatrix.h`.
- **`src/chrono/CMakeLists.txt`:**
  `target_precompile_headers(Chrono_core PRIVATE .../ChCorePCH.h)` added right
  after the Eigen link.

### Why `ChMatrix.h` is the anchor (not bare Eigen)

`ChMatrix.h` defines `EIGEN_MATRIXBASE_PLUGIN` / `EIGEN_SPARSEMATRIX_PLUGIN`
**before** including `Eigen/Dense` and `Eigen/Sparse`. Precompiling bare Eigen
would parse it *without* Chrono's plugins and break every TU. Anchoring on
`ChMatrix.h` reproduces Chrono's exact Eigen configuration and also transitively
precompiles `ChArchive.h` / `ChArchiveASCII.h` (also top-15 headers). Scope is
`PRIVATE` so the PCH is used only when compiling `Chrono_core` itself and is not
forced onto consumers of the library.

## Results & impact

Measured on MSVC 14.51, Ninja generator, `Release`, core-only configuration
(all optional `CH_ENABLE_MODULE_*` off, demos/tests/benchmarks off), Eigen
3.4.0. Full clean rebuilds, uninstrumented, 5 samples per variant, identical
machine parallelism and power state.

| Variant           | Mean       | StdDev    |
| ----------------- | ---------- | --------- |
| Baseline (no PCH) | 589.00 s   | 29.46 s   |
| With PCH          | **507.18 s** | 15.70 s |

- **~13.9% faster** clean rebuilds — **81.8 s** saved per build.
- **Statistically significant:** post-change mean (507.18 s) is below
  baseline − 1σ (559.54 s).
- **More consistent:** build-time variance nearly halved (σ 29.46 s → 15.70 s).

### Diagnostic evidence (vcperf `/level3`)

Top time-responsible headers (WCTR = wall-clock time responsibility, aggregated
across TUs):

| Header                          | WCTR (s)   | Included in (of 518 TUs) |
| ------------------------------- | ---------- | ------------------------ |
| ChMatrix.h                      | 24.4       | 383                      |
| ChQuaternion.h                  | 18.0       | 315                      |
| ChCoordsys.h                    | 17.7       | 304                      |
| ChFrame.h                       | 17.6       | 301                      |
| Eigen/Dense                     | 10.4       | 383                      |
| ChArchive.h                     | 5.9        | 392                      |
| STL streams (istream/ios/iostream) | ~5.5–5.9 each | ~427                |

Top templates were all Eigen (`MatrixBase`, `DenseBase`, `PlainObjectBase`,
`Matrix`, `MapBase`). Per-function back-end codegen hotspots (FEA
`LoadKRMMatrices` / `ComputeInternalJacobian*`) are **not** amortizable across
TUs and were intentionally left out of scope.

## Compatibility

- PCH scope is `PRIVATE` — no effect on consumers of `Chrono_core`.
- The `#ifdef __cplusplus` guard keeps the PCH empty for the handful of C
  sources in the target.
- Verified to compile with **0 errors**.

## How AI was used

This change was produced with GitHub Copilot CLI (Claude Opus 4.8) driving a
build-performance-analysis workflow:

- **Profiling & diagnosis:** ran a one-time instrumented vcperf trace and
  analyzed the JSON output to rank headers/templates by wall-clock time
  responsibility, identifying the Eigen + STL front-end cost as the amortizable
  bottleneck.
- **Solution design:** selected a PCH strategy and specifically chose
  `ChMatrix.h` as the anchor after reasoning about Eigen's plugin-macro ordering
  (bare-Eigen precompilation would have broken the build).
- **Implementation & debugging:** wrote `ChCorePCH.h` and the CMake wiring, then
  diagnosed and fixed two build breaks — C sources being fed C++ STL headers
  (fixed with the `__cplusplus` guard) and a CMake angle-bracket
  generator-expression leak emitting `#include ">"` (fixed by moving the include
  list into a dedicated header).
- **Measurement:** ran 5× clean-rebuild baseline and post-change samples and
  computed mean / σ / significance.
- All AI-generated changes were validated by a clean compile and the timed A/B
  benchmark above.

## Files changed

- `src/chrono/CMakeLists.txt` (+24 lines)
- `src/chrono/ChCorePCH.h` (new)
