### PR TITLE
Report visual and collision shapes that a backend cannot handle

### DIFF
--- a/src/chrono/assets/ChVisualShape.cpp
+++ b/src/chrono/assets/ChVisualShape.cpp
@@ -12,6 +12,17 @@
 // Authors: Alessandro Tasora, Radu Serban
 // =============================================================================
 
+#include <iostream>
+#include <mutex>
+#include <set>
+#include <typeinfo>
+
+#if defined(__GNUC__) && __has_include(<cxxabi.h>)
+    #include <cstdlib>
+    #include <cxxabi.h>
+    #define CH_HAVE_CXA_DEMANGLE
+#endif
+
 #include "chrono/assets/ChVisualShape.h"
 #include "chrono/physics/ChPhysicsItem.h"
 
@@ -112,6 +123,37 @@ void ChVisualShape::ArchiveIn(ChArchiveIn& archive_in) {
     archive_in >> CHNVP(is_mutable);
     archive_in >> CHNVP(is_double_faced);
     archive_in >> CHNVP(material_list);
+}
+
+// Return a readable name for a type. MSVC already yields one; the Itanium ABI yields a mangled name, so demangle it.
+static std::string TypeName(const std::type_info& ti) {
+#ifdef CH_HAVE_CXA_DEMANGLE
+    int status = 0;
+    char* demangled = abi::__cxa_demangle(ti.name(), nullptr, nullptr, &status);
+    if (status == 0 && demangled) {
+        std::string name(demangled);
+        std::free(demangled);
+        return name;
+    }
+    std::free(demangled);
+#endif
+    return ti.name();
+}
+
+void ReportUnsupportedVisualShape(const ChVisualShape& shape, const std::string& backend) {
+    // Visual models can be populated from more than one thread, so guard the record of what has been reported.
+    static std::mutex mutex;
+    static std::set<std::string> reported;
+
+    std::string type_name = TypeName(typeid(shape));
+
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!reported.insert(backend + "/" + type_name).second)
+        return;
+
+    std::cerr << "Warning: " << backend << " cannot render a visual shape of type '" << type_name
+              << "'; the shape will not be drawn. Further occurrences of this shape type are not reported."
+              << std::endl;
 }
 
 }  // namespace chrono

--- a/src/chrono/assets/ChVisualShape.h
+++ b/src/chrono/assets/ChVisualShape.h
@@ -126,6 +126,13 @@ class ChApi ChVisualShape {
     friend class ChVisualModel;
 };
 
+/// Report that a run-time visualization system cannot render the given shape.
+/// A visualization system dispatches on the concrete shape type and simply skips any type it does not handle. Without
+/// a diagnostic, the shape is dropped silently, which the user cannot distinguish from a shape that is invisible,
+/// mispositioned, or scaled to nothing. The message is emitted only once per combination of shape type and rendering
+/// backend, so calling this from a per-shape dispatch loop does not flood the console.
+ChApi void ReportUnsupportedVisualShape(const ChVisualShape& shape, const std::string& backend);
+
 /// @} chrono_assets
 
 CH_CLASS_VERSION(ChVisualShape, 0)

--- a/src/chrono/collision/ChCollisionShape.cpp
+++ b/src/chrono/collision/ChCollisionShape.cpp
@@ -52,6 +52,53 @@ void ChCollisionShape::SetParentShape(std::shared_ptr<ChCollisionShape> parent) 
     m_parent = parent.get();
 }
 
+std::string ChCollisionShape::GetTypeAsString(Type type) {
+    switch (type) {
+        case Type::SPHERE:
+            return "SPHERE";
+        case Type::ELLIPSOID:
+            return "ELLIPSOID";
+        case Type::BOX:
+            return "BOX";
+        case Type::CYLINDER:
+            return "CYLINDER";
+        case Type::CYLSHELL:
+            return "CYLSHELL";
+        case Type::CONVEXHULL:
+            return "CONVEXHULL";
+        case Type::TRIANGLEMESH:
+            return "TRIANGLEMESH";
+        case Type::BARREL:
+            return "BARREL";
+        case Type::POINT:
+            return "POINT";
+        case Type::SEGMENT:
+            return "SEGMENT";
+        case Type::TRIANGLE:
+            return "TRIANGLE";
+        case Type::CONNECTEDTRIANGLE:
+            return "CONNECTEDTRIANGLE";
+        case Type::CAPSULE:
+            return "CAPSULE";
+        case Type::CONE:
+            return "CONE";
+        case Type::ROUNDEDBOX:
+            return "ROUNDEDBOX";
+        case Type::ROUNDEDCYL:
+            return "ROUNDEDCYL";
+        case Type::TETRAHEDRON:
+            return "TETRAHEDRON";
+        case Type::PATH2D:
+            return "PATH2D";
+        case Type::SEGMENT2D:
+            return "SEGMENT2D";
+        case Type::ARC2D:
+            return "ARC2D";
+        default:
+            return "UNKNOWN_SHAPE";
+    }
+}
+
 void ChCollisionShape::ArchiveOut(ChArchiveOut& archive_out) {
     // version number
     archive_out.VersionWrite<ChCollisionShape>();

--- a/src/chrono/collision/ChCollisionShape.h
+++ b/src/chrono/collision/ChCollisionShape.h
@@ -58,6 +58,9 @@ class ChApi ChCollisionShape {
 
     Type GetType() const { return m_type; }
 
+    /// Return a human-readable name for the given shape type (mainly for diagnostic messages).
+    static std::string GetTypeAsString(Type type);
+
     std::shared_ptr<ChContactMaterial> GetMaterial() const { return m_material; }
     ChContactMethod GetContactMethod() const { return m_material->GetContactMethod(); }
 

--- a/src/chrono/collision/bullet/ChCollisionModelBullet.cpp
+++ b/src/chrono/collision/bullet/ChCollisionModelBullet.cpp
@@ -15,6 +15,9 @@
 #include <memory>
 #include <array>
 #include <algorithm>
+#include <iostream>
+#include <mutex>
+#include <set>
 
 #include "chrono/collision/bullet/ChCollisionSystemBullet.h"
 #include "chrono/collision/bullet/ChCollisionUtilsBullet.h"
@@ -228,9 +231,22 @@ void ChCollisionModelBullet::Populate() {
                 InjectTriangleProxy(shape_triangle);
                 break;
             }
-            default:
-                // Shape type not supported
+            default: {
+                // Shape type not supported by the Bullet collision system (see the notes on ChCollisionShape::Type).
+                // Report it once per type: dropping the shape silently leaves a body that simply never collides, with
+                // nothing to indicate why.
+                static std::mutex mutex;
+                static std::set<ChCollisionShape::Type> reported;
+                std::lock_guard<std::mutex> lock(mutex);
+                if (reported.insert(shape->GetType()).second) {
+                    std::cerr << "Warning: the Bullet collision system does not support collision shapes of type "
+                              << ChCollisionShape::GetTypeAsString(shape->GetType())
+                              << "; the shape is excluded from the collision model. Further occurrences of this shape "
+                                 "type are not reported."
+                              << std::endl;
+                }
                 break;
+            }
         }
     }
 }

--- a/src/chrono_irrlicht/ChVisualSystemIrrlicht.cpp
+++ b/src/chrono_irrlicht/ChVisualSystemIrrlicht.cpp
@@ -1011,6 +1011,8 @@ void ChVisualSystemIrrlicht::PopulateIrrNode(ISceneNode* node, std::shared_ptr<C
                 SetVisualMaterial(mchildnode, cone);
                 mchildnode->setMaterialFlag(video::EMF_NORMALIZE_NORMALS, true);
             }
+        } else {
+            ReportUnsupportedVisualShape(*shape, "Chrono::Irrlicht");
         }
     }
 }

--- a/src/chrono_vsg/ChVisualSystemVSG.cpp
+++ b/src/chrono_vsg/ChVisualSystemVSG.cpp
@@ -2383,6 +2383,11 @@ void ChVisualSystemVSG::PopulateVisualShapesFixed(vsg::ref_ptr<vsg::Group> group
             transform->matrix = vsg::dmat4CH(X_SM, 1.0);
             auto grp = m_shapeBuilder->CreatePbrSurfaceShape(geometry, material, transform, resolution_u, resolution_v, double_faced, wireframe);
             group->addChild(grp);
+        } else {
+            // Every shape this backend can draw has matched above, mutable or not: a mutable triangle mesh is caught
+            // by the trimesh branch and skipped there for the deformable pass to handle. So anything reaching here is
+            // drawn by no VSG pass at all.
+            ReportUnsupportedVisualShape(*shape, "Chrono::VSG");
         }
     }
 }


### PR DESCRIPTION
Relates to #768.

## Problem

The run-time visualization systems and the Bullet collision system dispatch on the concrete shape type and quietly skip any type they do not handle. `ChVisualSystemIrrlicht::PopulateIrrNode` and
`ChVisualSystemVSG::PopulateVisualShapesFixed` fall off the end of a chain of `dynamic_pointer_cast` tests, and `ChCollisionModelBullet::Populate` ends in a bare `default: break`. Nothing is logged, so the user sees a body that does not draw or never collides, which is indistinguishable from a shape that is invisible, mispositioned, scaled to nothing, or filtered out by collision families.

Issue #768 is exactly this: `ChVisualShapeRoundedCylinder` and `ChCollisionShapeRoundedCylinder` produce no output at all, with no indication of why.

## What this does and does not do

This does **not** implement the missing shapes. It removes the silence.

The underlying gaps are real and, for collision, already documented in the `ChCollisionShape::Type` enum, which annotates ROUNDEDBOX, ROUNDEDCYL, CONE and TETRAHEDRON as not implemented in Bullet. Note that the multicore collision system does support the rounded shapes
(`ChCollisionModelMulticore.cpp:183/198`, `ChCollisionSystemMulticore.cpp:150/154`, `ChCollisionUtilsMPR.cpp:49/52`); only the Bullet backend does not.

## Change

* Add `chrono::ReportUnsupportedVisualShape()`, which reports once per combination of shape type and rendering backend, so calling it from a per-shape dispatch loop cannot flood the console. Type names are demangled where the Itanium ABI applies, so the message is readable on Linux and macOS as well as on Windows.
* Call it from the terminal `else` of the Irrlicht and VSG dispatch chains.
* Report unsupported types once each in the Bullet `Populate` switch.
* Add `ChCollisionShape::GetTypeAsString()` so that message names the shape type instead of an integer.

On false positives: `ChVisualShapeSpring`, `ChVisualShapeSegment`, `ChVisualShapeRotSpring` and `ChVisualShapePointPoint` all derive from `ChVisualShapeLine`, and both backends have a `ChVisualShapeLine` branch, so they are consumed before the terminal `else`. `ChVisualShapeFEA` does not derive from `ChVisualShape` at all. In the VSG fixed pass the report is deliberately not guarded on `IsMutable()`: a mutable triangle mesh is caught by the trimesh branch and skipped there for the deformable pass, and every other drawable shape matches its own branch regardless of mutability, so anything reaching the `else` is drawn by no VSG pass at all.

## Verification

`Chrono_core`, `Chrono_vsg` and `Chrono_irrlicht` all build and link clean.

The #768 reproducer, run headless, now prints instead of doing nothing:

```
Warning: the Bullet collision system does not support collision shapes of type
ROUNDEDCYL; the shape is excluded from the collision model. Further occurrences
of this shape type are not reported.
```

emitted once on the first step and not repeated on the second.

Confirmed through a live Irrlicht render (initialize, bind, render one frame) with three bodies: a rounded cylinder, a box, and a spring on a `ChLinkTSDA`. Exactly one warning appeared, for the rounded cylinder; the box and the spring were silent, which is the no-false-positive property above.

Regression: of the 66 unit tests that build in this configuration, 62 pass and the 4 SMC failures reproduce identically on unmodified main.

## Gaps this surfaces

Two previously invisible gaps will now emit warnings, which is the point but is worth knowing before merge: Irrlicht and VSG both drop `ChVisualShapeRoundedBox` in addition to the rounded cylinder, and VSG drops `ChGlyphs` in the fixed-shape pass, where the code already carries a "process glyphs" TODO.

No committed regression test covers the warning itself.