### PR TITLE
Make the JSON and XML archives round trip floating point values exactly

### DIFF
--- a/src/chrono/serialization/ChArchiveJSON.cpp
+++ b/src/chrono/serialization/ChArchiveJSON.cpp
@@ -1,8 +1,18 @@
 #include "chrono/serialization/ChArchiveJSON.h"
 
+#include <limits>
+
 namespace chrono {
 
 ChArchiveOutJSON::ChArchiveOutJSON(std::ostream& stream_out) : m_ostream(stream_out) {
+    // Write floating point values with enough digits to be read back bit-exactly. The default
+    // ostream precision is 6 significant digits, which silently discards about ten digits of a
+    // double and makes a save/load cycle lossy. max_digits10 is the number of decimal digits that
+    // uniquely distinguishes every value of the type (17 for double).
+    // The caller owns the stream and may well be reusing it (std::cout, for instance), so the
+    // previous precision is recorded here and put back by the destructor.
+    m_precision_saved = m_ostream.precision(std::numeric_limits<double>::max_digits10);
+
     m_ostream << "{ ";
     ++tablevel;
 
@@ -17,6 +27,8 @@ ChArchiveOutJSON::~ChArchiveOutJSON() {
     is_array.pop();
 
     m_ostream << "\n}" << std::endl;
+
+    m_ostream.precision(m_precision_saved);
 }
 
 void ChArchiveOutJSON::indent() {
@@ -57,7 +69,12 @@ void ChArchiveOutJSON::out(ChNameValue<float> bVal) {
     if (is_array.top() == false)
         m_ostream << "\"" << bVal.name() << "\""
                   << "\t: ";
+    // The stream is set to double precision for the archive's lifetime, which would print a float
+    // with eight digits more than it actually carries, exposing binary noise: 0.6f would be written
+    // as 0.60000002384185791. Nine digits is what uniquely identifies a float.
+    const std::streamsize saved = m_ostream.precision(std::numeric_limits<float>::max_digits10);
     m_ostream << bVal.value();
+    m_ostream.precision(saved);
     ++nitems.top();
 }
 

--- a/src/chrono/serialization/ChArchiveJSON.cpp
+++ b/src/chrono/serialization/ChArchiveJSON.cpp
@@ -1,18 +1,11 @@
 #include "chrono/serialization/ChArchiveJSON.h"
 
 #include <limits>
+#include <charconv>
 
 namespace chrono {
 
-ChArchiveOutJSON::ChArchiveOutJSON(std::ostream& stream_out) : m_ostream(stream_out) {
-    // Write floating point values with enough digits to be read back bit-exactly. The default
-    // ostream precision is 6 significant digits, which silently discards about ten digits of a
-    // double and makes a save/load cycle lossy. max_digits10 is the number of decimal digits that
-    // uniquely distinguishes every value of the type (17 for double).
-    // The caller owns the stream and may well be reusing it (std::cout, for instance), so the
-    // previous precision is recorded here and put back by the destructor.
-    m_precision_saved = m_ostream.precision(std::numeric_limits<double>::max_digits10);
-
+ChArchiveOutJSON::ChArchiveOutJSON(std::ostream& stream_out, bool full_precision) : m_ostream(stream_out), m_full_precision(full_precision) {
     m_ostream << "{ ";
     ++tablevel;
 
@@ -25,15 +18,13 @@ ChArchiveOutJSON::~ChArchiveOutJSON() {
     --tablevel;
     nitems.pop();
     is_array.pop();
-
     m_ostream << "\n}" << std::endl;
-
-    m_ostream.precision(m_precision_saved);
 }
 
 void ChArchiveOutJSON::indent() {
-    for (int i = 0; i < tablevel; ++i)
+    for (int i = 0; i < tablevel; ++i) {
         m_ostream << "\t";
+    }
 }
 
 void ChArchiveOutJSON::comma_cr() {
@@ -47,8 +38,7 @@ void ChArchiveOutJSON::out(ChNameValue<unsigned int> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     m_ostream << bVal.value();
     ++nitems.top();
 }
@@ -57,8 +47,7 @@ void ChArchiveOutJSON::out(ChNameValue<char> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     m_ostream << (int)bVal.value();
     ++nitems.top();
 }
@@ -67,14 +56,14 @@ void ChArchiveOutJSON::out(ChNameValue<float> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
-    // The stream is set to double precision for the archive's lifetime, which would print a float
-    // with eight digits more than it actually carries, exposing binary noise: 0.6f would be written
-    // as 0.60000002384185791. Nine digits is what uniquely identifies a float.
-    const std::streamsize saved = m_ostream.precision(std::numeric_limits<float>::max_digits10);
-    m_ostream << bVal.value();
-    m_ostream.precision(saved);
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
+    if (m_full_precision) {
+        char buffer[32];
+        auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), bVal.value());
+        m_ostream.write(buffer, ptr - buffer);
+    } else {
+        m_ostream << bVal.value();
+    }
     ++nitems.top();
 }
 
@@ -82,9 +71,14 @@ void ChArchiveOutJSON::out(ChNameValue<double> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
-    m_ostream << bVal.value();
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
+    if (m_full_precision) {
+        char buffer[32];
+        auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), bVal.value());
+        m_ostream.write(buffer, ptr - buffer);
+    } else {
+        m_ostream << bVal.value();
+    }
     ++nitems.top();
 }
 
@@ -92,8 +86,7 @@ void ChArchiveOutJSON::out(ChNameValue<int> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     m_ostream << bVal.value();
     ++nitems.top();
 }
@@ -102,12 +95,8 @@ void ChArchiveOutJSON::out(ChNameValue<bool> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
-    if (bVal.value())
-        m_ostream << "true";
-    else
-        m_ostream << "false";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
+    bVal.value() ? m_ostream << "true" : m_ostream << "false";
     ++nitems.top();
 }
 
@@ -115,8 +104,7 @@ void ChArchiveOutJSON::out(ChNameValue<const char*> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     m_ostream << "\"" << bVal.value() << "\"";
     ++nitems.top();
 }
@@ -125,8 +113,7 @@ void ChArchiveOutJSON::out(ChNameValue<std::string> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     m_ostream << "\"" << bVal.value() << "\"";
     ++nitems.top();
 }
@@ -135,8 +122,7 @@ void ChArchiveOutJSON::out(ChNameValue<unsigned long> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     m_ostream << bVal.value();
     ++nitems.top();
 }
@@ -145,8 +131,7 @@ void ChArchiveOutJSON::out(ChNameValue<unsigned long long> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     m_ostream << bVal.value();
     ++nitems.top();
 }
@@ -155,8 +140,7 @@ void ChArchiveOutJSON::out(ChNameValue<ChEnumMapperBase> bVal) {
     comma_cr();
     indent();
     if (is_array.top() == false)
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     std::string mstr = bVal.value().GetValueAsString();
     m_ostream << "\"" << mstr << "\"";
     ++nitems.top();
@@ -166,8 +150,7 @@ void ChArchiveOutJSON::out_array_pre(ChValue& bVal, size_t msize) {
     comma_cr();
     if (is_array.top() == false) {
         indent();
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: ";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: ";
     }
     m_ostream << "\n";
     indent();
@@ -195,8 +178,7 @@ void ChArchiveOutJSON::out(ChValue& bVal, bool tracked, size_t obj_ID) {
     comma_cr();
     if (is_array.top() == false) {
         indent();
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: \n";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: \n";
     }
     indent();
     m_ostream << "{";
@@ -231,8 +213,7 @@ void ChArchiveOutJSON::out_ref(ChValue& bVal, bool already_inserted, size_t obj_
     comma_cr();
     if (is_array.top() == false) {
         indent();
-        m_ostream << "\"" << bVal.name() << "\""
-                  << "\t: \n";
+        m_ostream << "\"" << bVal.name() << "\"" << "\t: \n";
     }
     indent();
     m_ostream << "{ ";
@@ -244,8 +225,7 @@ void ChArchiveOutJSON::out_ref(ChValue& bVal, bool already_inserted, size_t obj_
     if (classname.length() > 0) {
         comma_cr();
         indent();
-        m_ostream << "\"_type\"\t: "
-                  << "\"" << classname.c_str() << "\"";
+        m_ostream << "\"_type\"\t: " << "\"" << classname.c_str() << "\"";
         ++nitems.top();
     }
 
@@ -284,25 +264,24 @@ void ChArchiveOutJSON::out_ref(ChValue& bVal, bool already_inserted, size_t obj_
 
 // =============================================================================
 
-ChArchiveInJSON::ChArchiveInJSON(std::istream& stream_in) 
-    : m_istream(stream_in) 
-{
+ChArchiveInJSON::ChArchiveInJSON(std::istream& stream_in, bool full_precision) : m_istream(stream_in) {
     std::stringstream buffer;
     buffer << m_istream.rdbuf();
     std::string mstr = buffer.str();
     const char* stringbuffer = mstr.c_str();
 
-    document.Parse<0>(stringbuffer);
+    full_precision ? document.Parse<rapidjson::kParseFullPrecisionFlag>(stringbuffer) : document.Parse<rapidjson::kParseDefaultFlags>(stringbuffer);
+
     if (document.HasParseError()) {
         std::string errstrA((const char*)(&stringbuffer[std::max((int)document.GetErrorOffset() - 10, 0)]));
         errstrA.resize(10);
         std::string errstrB((const char*)(&stringbuffer[document.GetErrorOffset()]));
         errstrB.resize(20);
-        throw std::invalid_argument("ERROR: the file has bad JSON syntax," + std::to_string(document.GetParseError()) +
-                                    " \n\n[...]" + errstrA + " <--- " + errstrB + "[...]");
+        throw std::invalid_argument("ERROR: the file has bad JSON syntax," + std::to_string(document.GetParseError()) + " \n\n[...]" + errstrA + " <--- " + errstrB + "[...]");
     }
-    if (!document.IsObject())
+    if (!document.IsObject()) {
         throw std::invalid_argument("ERROR: the file is not a valid JSON document");
+    }
 
     level = &document;
     levels.push(level);
@@ -349,7 +328,7 @@ bool ChArchiveInJSON::in(ChNameValue<char> bVal) {
     if (!mval->IsInt()) {
         throw std::runtime_error("Invalid char code after '" + std::string(bVal.name()) + "'");
     }
-    bVal.value() = (char)mval->GetInt();
+    bVal.value() = static_cast<char>(mval->GetInt());
     return true;
 }
 
@@ -360,7 +339,7 @@ bool ChArchiveInJSON::in(ChNameValue<float> bVal) {
     if (!mval->IsNumber()) {
         throw std::runtime_error("Invalid number after '" + std::string(bVal.name()) + "'");
     }
-    bVal.value() = (float)mval->GetDouble();
+    bVal.value() = static_cast<float>(mval->GetDouble());
     return true;
 }
 
@@ -371,6 +350,7 @@ bool ChArchiveInJSON::in(ChNameValue<double> bVal) {
     if (!mval->IsNumber()) {
         throw std::runtime_error("Invalid number after '" + std::string(bVal.name()) + "'");
     }
+
     bVal.value() = mval->GetDouble();
     return true;
 }
@@ -577,19 +557,15 @@ bool ChArchiveInJSON::in_ref(ChNameValue<ChFunctorArchiveIn> bVal, void** ptr, s
     } else {
         if (ref_ID) {
             if (this->internal_id_ptr.find(ref_ID) == this->internal_id_ptr.end()) {
-                throw std::runtime_error("In object '" + std::string(bVal.name()) + "' the _reference_ID " +
-                                         std::to_string((int)ref_ID) + " is not a valid number.");
+                throw std::runtime_error("In object '" + std::string(bVal.name()) + "' the _reference_ID " + std::to_string((int)ref_ID) + " is not a valid number.");
             }
-            bVal.value().SetRawPtr(
-                ChCastingMap::Convert(true_classname, bVal.value().GetObjectPtrTypeindex(), internal_id_ptr[ref_ID]));
+            bVal.value().SetRawPtr(ChCastingMap::Convert(true_classname, bVal.value().GetObjectPtrTypeindex(), internal_id_ptr[ref_ID]));
 
         } else if (ext_ID) {
             if (this->external_id_ptr.find(ext_ID) == this->external_id_ptr.end()) {
-                throw std::runtime_error("In object '" + std::string(bVal.name()) + "' the _external_ID " +
-                                         std::to_string((int)ext_ID) + " is not valid.");
+                throw std::runtime_error("In object '" + std::string(bVal.name()) + "' the _external_ID " + std::to_string((int)ext_ID) + " is not valid.");
             }
-            bVal.value().SetRawPtr(
-                ChCastingMap::Convert(true_classname, bVal.value().GetObjectPtrTypeindex(), external_id_ptr[ext_ID]));
+            bVal.value().SetRawPtr(ChCastingMap::Convert(true_classname, bVal.value().GetObjectPtrTypeindex(), external_id_ptr[ext_ID]));
 
         } else
             bVal.value().SetRawPtr(nullptr);

--- a/src/chrono/serialization/ChArchiveJSON.h
+++ b/src/chrono/serialization/ChArchiveJSON.h
@@ -64,6 +64,7 @@ class ChApi ChArchiveOutJSON : public ChArchiveOut {
     std::ostream& m_ostream;
     std::stack<int> nitems;
     std::stack<bool> is_array;
+    std::streamsize m_precision_saved;  ///< caller's stream precision, restored by the destructor
 };
 
 /// Deserialize objects using JSON format.

--- a/src/chrono/serialization/ChArchiveJSON.h
+++ b/src/chrono/serialization/ChArchiveJSON.h
@@ -15,6 +15,7 @@
 #include "chrono/serialization/ChArchive.h"
 
 #include "chrono_thirdparty/rapidjson/document.h"
+#include "chrono_thirdparty/rapidjson/reader.h"
 #include "chrono_thirdparty/rapidjson/prettywriter.h"
 #include "chrono_thirdparty/rapidjson/filereadstream.h"
 #include "chrono_thirdparty/rapidjson/filewritestream.h"
@@ -30,7 +31,7 @@ namespace chrono {
 /// Input stream should be kept valid for the entire lifespan of the archive class.
 class ChApi ChArchiveOutJSON : public ChArchiveOut {
   public:
-    ChArchiveOutJSON(std::ostream& stream_out);
+    ChArchiveOutJSON(std::ostream& stream_out, bool full_precision = true);
 
     virtual ~ChArchiveOutJSON();
 
@@ -60,18 +61,20 @@ class ChApi ChArchiveOutJSON : public ChArchiveOut {
     virtual void out_ref(ChValue& bVal, bool already_inserted, size_t obj_ID, size_t ext_ID);
 
   protected:
+    const bool m_full_precision;
     int tablevel;
     std::ostream& m_ostream;
     std::stack<int> nitems;
     std::stack<bool> is_array;
-    std::streamsize m_precision_saved;  ///< caller's stream precision, restored by the destructor
 };
 
 /// Deserialize objects using JSON format.
 /// Input stream should be kept valid for the entire lifespan of the archive class.
 class ChApi ChArchiveInJSON : public ChArchiveIn {
   public:
-    ChArchiveInJSON(std::istream& stream_in);
+    /// Deserialize from JSON stream.
+    /// Precision can be lowered (3 ULP) to achieve faster reading by setting full_precision = false.
+    ChArchiveInJSON(std::istream& stream_in, bool full_precision = true);
 
     virtual ~ChArchiveInJSON();
 

--- a/src/chrono/serialization/ChArchiveXML.cpp
+++ b/src/chrono/serialization/ChArchiveXML.cpp
@@ -1,5 +1,7 @@
 #include "chrono/serialization/ChArchiveXML.h"
 
+#include <limits>
+
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -10,6 +12,11 @@ namespace chrono {
 ///////////////////////// ChArchiveOutXML /////////////////////////
 
 ChArchiveOutXML::ChArchiveOutXML(std::ostream& stream_out) : m_ostream(stream_out) {
+    // See the note in ChArchiveOutJSON's constructor: the default ostream precision of 6 significant
+    // digits makes a save/load cycle lossy, so ask for enough digits to read a double back exactly,
+    // and restore the caller's setting in the destructor.
+    m_precision_saved = m_ostream.precision(std::numeric_limits<double>::max_digits10);
+
     tablevel = 0;
     nitems.push(0);
     is_array.push(false);
@@ -17,6 +24,8 @@ ChArchiveOutXML::ChArchiveOutXML(std::ostream& stream_out) : m_ostream(stream_ou
 ChArchiveOutXML::~ChArchiveOutXML() {
     nitems.pop();
     is_array.pop();
+
+    m_ostream.precision(m_precision_saved);
 }
 void ChArchiveOutXML::indent() {
     for (int i = 0; i < tablevel; ++i)
@@ -44,7 +53,11 @@ void ChArchiveOutXML::out(ChNameValue<float> bVal) {
     indent();
     // if (is_array.top() == false)
     m_ostream << "<" << bVal.name() << ">";
+    // See the note in ChArchiveOutJSON: a float needs nine digits, not the double's seventeen, so
+    // print it at its own precision rather than exposing eight digits of binary noise.
+    const std::streamsize saved = m_ostream.precision(std::numeric_limits<float>::max_digits10);
     m_ostream << bVal.value();
+    m_ostream.precision(saved);
     // if (is_array.top() == false)
     m_ostream << "</" << bVal.name() << ">\n";
     ++nitems.top();

--- a/src/chrono/serialization/ChArchiveXML.cpp
+++ b/src/chrono/serialization/ChArchiveXML.cpp
@@ -6,17 +6,13 @@
 #include <sstream>
 #include <string>
 #include <cstring>
+#include <charconv>
 
 namespace chrono {
 
 ///////////////////////// ChArchiveOutXML /////////////////////////
 
-ChArchiveOutXML::ChArchiveOutXML(std::ostream& stream_out) : m_ostream(stream_out) {
-    // See the note in ChArchiveOutJSON's constructor: the default ostream precision of 6 significant
-    // digits makes a save/load cycle lossy, so ask for enough digits to read a double back exactly,
-    // and restore the caller's setting in the destructor.
-    m_precision_saved = m_ostream.precision(std::numeric_limits<double>::max_digits10);
-
+ChArchiveOutXML::ChArchiveOutXML(std::ostream& stream_out, bool full_precision) : m_ostream(stream_out), m_full_precision(full_precision) {
     tablevel = 0;
     nitems.push(0);
     is_array.push(false);
@@ -24,8 +20,6 @@ ChArchiveOutXML::ChArchiveOutXML(std::ostream& stream_out) : m_ostream(stream_ou
 ChArchiveOutXML::~ChArchiveOutXML() {
     nitems.pop();
     is_array.pop();
-
-    m_ostream.precision(m_precision_saved);
 }
 void ChArchiveOutXML::indent() {
     for (int i = 0; i < tablevel; ++i)
@@ -53,11 +47,13 @@ void ChArchiveOutXML::out(ChNameValue<float> bVal) {
     indent();
     // if (is_array.top() == false)
     m_ostream << "<" << bVal.name() << ">";
-    // See the note in ChArchiveOutJSON: a float needs nine digits, not the double's seventeen, so
-    // print it at its own precision rather than exposing eight digits of binary noise.
-    const std::streamsize saved = m_ostream.precision(std::numeric_limits<float>::max_digits10);
-    m_ostream << bVal.value();
-    m_ostream.precision(saved);
+    if (m_full_precision) {
+        char buffer[32];
+        auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), bVal.value());
+        m_ostream.write(buffer, ptr - buffer);
+    } else {
+        m_ostream << bVal.value();
+    }
     // if (is_array.top() == false)
     m_ostream << "</" << bVal.name() << ">\n";
     ++nitems.top();
@@ -66,7 +62,13 @@ void ChArchiveOutXML::out(ChNameValue<double> bVal) {
     indent();
     // if (is_array.top() == false)
     m_ostream << "<" << bVal.name() << ">";
-    m_ostream << bVal.value();
+    if (m_full_precision) {
+        char buffer[32];
+        auto [ptr, ec] = std::to_chars(buffer, buffer + sizeof(buffer), bVal.value());
+        m_ostream.write(buffer, ptr - buffer);
+    } else {
+        m_ostream << bVal.value();
+    }
     // if (is_array.top() == false)
     m_ostream << "</" << bVal.name() << ">\n";
     ++nitems.top();
@@ -245,6 +247,9 @@ void ChArchiveOutXML::out_ref(ChValue& bVal, bool already_inserted, size_t obj_I
     m_ostream << "</" << bVal.name() << ">\n";
     //}
 }
+
+///////////////////////// ChArchiveInXML /////////////////////////
+
 ChArchiveInXML::ChArchiveInXML(std::istream& stream_in) : m_istream(stream_in) {
     buffer.assign((std::istreambuf_iterator<char>(m_istream)), std::istreambuf_iterator<char>());
     buffer.push_back('\0');
@@ -268,9 +273,8 @@ ChArchiveInXML::ChArchiveInXML(std::istream& stream_in) : m_istream(stream_in) {
     try_tolerate_missing_tokens = false;
 }
 
-///////////////////////// ChArchiveInXML /////////////////////////
-
 ChArchiveInXML::~ChArchiveInXML() {}
+
 rapidxml::xml_node<>* ChArchiveInXML::GetValueFromNameOrArray(const std::string& mname) {
     rapidxml::xml_node<>* mnode = level->first_node(mname.c_str());
     if (!mnode)
@@ -303,22 +307,24 @@ bool ChArchiveInXML::in(ChNameValue<float> bVal) {
     rapidxml::xml_node<>* mval = GetValueFromNameOrArray(bVal.name());
     if (!mval)
         return false;
-    try {
-        bVal.value() = std::stof(mval->value());
-    } catch (...) {
+
+    auto [ptr, ec] = std::from_chars(mval->value(), mval->value() + mval->value_size(), bVal.value());
+
+    if (ec != std::errc())
         throw std::runtime_error("Invalid number after '" + std::string(bVal.name()) + "'");
-    }
+
     return true;
 }
 bool ChArchiveInXML::in(ChNameValue<double> bVal) {
     rapidxml::xml_node<>* mval = GetValueFromNameOrArray(bVal.name());
     if (!mval)
         return false;
-    try {
-        bVal.value() = std::stod(mval->value());
-    } catch (...) {
+
+    auto [ptr, ec] = std::from_chars(mval->value(), mval->value() + mval->value_size(), bVal.value());
+
+    if (ec != std::errc())
         throw std::runtime_error("Invalid number after '" + std::string(bVal.name()) + "'");
-    }
+
     return true;
 }
 bool ChArchiveInXML::in(ChNameValue<int> bVal) {
@@ -510,19 +516,15 @@ bool ChArchiveInXML::in_ref(ChNameValue<ChFunctorArchiveIn> bVal, void** ptr, st
         } else {
             if (ref_ID) {
                 if (this->internal_id_ptr.find(ref_ID) == this->internal_id_ptr.end()) {
-                    throw std::runtime_error("In object '" + std::string(bVal.name()) + "' the _reference_ID " +
-                                             std::to_string((int)ref_ID) + " is not a valid number.");
+                    throw std::runtime_error("In object '" + std::string(bVal.name()) + "' the _reference_ID " + std::to_string((int)ref_ID) + " is not a valid number.");
                 }
 
-                bVal.value().SetRawPtr(ChCastingMap::Convert(true_classname, bVal.value().GetObjectPtrTypeindex(),
-                                                             internal_id_ptr[ref_ID]));
+                bVal.value().SetRawPtr(ChCastingMap::Convert(true_classname, bVal.value().GetObjectPtrTypeindex(), internal_id_ptr[ref_ID]));
             } else if (ext_ID) {
                 if (this->external_id_ptr.find(ext_ID) == this->external_id_ptr.end()) {
-                    throw std::runtime_error("In object '" + std::string(bVal.name()) + "' the _external_ID " +
-                                             std::to_string((int)ext_ID) + " is not valid.");
+                    throw std::runtime_error("In object '" + std::string(bVal.name()) + "' the _external_ID " + std::to_string((int)ext_ID) + " is not valid.");
                 }
-                bVal.value().SetRawPtr(ChCastingMap::Convert(true_classname, bVal.value().GetObjectPtrTypeindex(),
-                                                             external_id_ptr[ext_ID]));
+                bVal.value().SetRawPtr(ChCastingMap::Convert(true_classname, bVal.value().GetObjectPtrTypeindex(), external_id_ptr[ext_ID]));
             } else
                 bVal.value().SetRawPtr(nullptr);
         }

--- a/src/chrono/serialization/ChArchiveXML.h
+++ b/src/chrono/serialization/ChArchiveXML.h
@@ -60,6 +60,7 @@ class ChApi ChArchiveOutXML : public ChArchiveOut {
     std::ostream& m_ostream;
     std::stack<int> nitems;
     std::stack<bool> is_array;
+    std::streamsize m_precision_saved;  ///< caller's stream precision, restored by the destructor
 };
 
 ///

--- a/src/chrono/serialization/ChArchiveXML.h
+++ b/src/chrono/serialization/ChArchiveXML.h
@@ -24,10 +24,10 @@
 
 namespace chrono {
 
-/// Serialize objects using JSON format.
+/// Class for serializing objects into XML archives.
 class ChApi ChArchiveOutXML : public ChArchiveOut {
   public:
-    ChArchiveOutXML(std::ostream& stream_out);
+    ChArchiveOutXML(std::ostream& stream_out, bool full_precision = true);
 
     virtual ~ChArchiveOutXML();
 
@@ -50,29 +50,25 @@ class ChApi ChArchiveOutXML : public ChArchiveOut {
     virtual void out_array_between(ChValue& bVal, size_t msize);
     virtual void out_array_end(ChValue& bVal, size_t msize);
 
-    // for custom c++ objects:
+    /// For custom c++ objects:
     virtual void out(ChValue& bVal, bool tracked, size_t obj_ID);
 
     virtual void out_ref(ChValue& bVal, bool already_inserted, size_t obj_ID, size_t ext_ID);
 
   protected:
+    const bool m_full_precision;
     int tablevel;
     std::ostream& m_ostream;
     std::stack<int> nitems;
     std::stack<bool> is_array;
-    std::streamsize m_precision_saved;  ///< caller's stream precision, restored by the destructor
 };
 
-///
-/// This is a class for deserializing from XML archives
-///
-
+/// Class for deserializing from XML archives.
 class ChApi ChArchiveInXML : public ChArchiveIn {
   public:
     ChArchiveInXML(std::istream& stream_in);
 
     virtual ~ChArchiveInXML();
-    ;
 
     rapidxml::xml_node<>* GetValueFromNameOrArray(const std::string& mname);
 
@@ -87,16 +83,16 @@ class ChApi ChArchiveInXML : public ChArchiveIn {
     virtual bool in(ChNameValue<unsigned long long> bVal) override;
     virtual bool in(ChNameValue<ChEnumMapperBase> bVal) override;
 
-    // for wrapping arrays and lists
+    /// For wrapping arrays and lists
     virtual bool in_array_pre(const std::string& name, size_t& msize) override;
     virtual void in_array_between(const std::string& name) override;
 
     virtual void in_array_end(const std::string& name) override;
 
-    //  for custom c++ objects:
+    /// For custom c++ objects:
     virtual bool in(ChNameValue<ChFunctorArchiveIn> bVal) override;
 
-    // for objects to construct, return non-null ptr if new object, return null ptr if just reused obj
+    /// For objects to construct, return non-null ptr if new object, return null ptr if just reused obj
     virtual bool in_ref(ChNameValue<ChFunctorArchiveIn> bVal, void** ptr, std::string& true_classname) override;
 
     virtual bool TryTolerateMissingTokens(bool try_tolerate) override;

--- a/src/tests/unit_tests/core/CMakeLists.txt
+++ b/src/tests/unit_tests/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 SET(TESTS
     utest_CH_archive
+    utest_CH_archive_precision
     utest_CH_ChFunctions
     utest_CH_ChVector
     utest_CH_ChQuaternion

--- a/src/tests/unit_tests/core/utest_CH_archive_precision.cpp
+++ b/src/tests/unit_tests/core/utest_CH_archive_precision.cpp
@@ -1,0 +1,192 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2014 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+//
+// Floating point fidelity of the archive backends.
+//
+// The text backends used to write floating point values at the default ostream precision, which is
+// 6 significant digits, while a double needs 17 to be recovered exactly. Saving a model to JSON or
+// XML and loading it back therefore returned different numbers, with no warning: 1.0/3.0 came back
+// as 0.333333, and 12345.678901234567 came back as 12345.7, an absolute error of about 0.022.
+//
+// Nothing caught this because the existing round-trip tests compare with a tolerance of 1e-5 on
+// states of magnitude near 1, where 6 significant digits happens to be good enough. Six digits is a
+// relative budget, so the absolute error grows with the magnitude of the value.
+//
+// The binary backend was never affected: it writes the raw bytes instead of printing them. It is
+// used here as a control, so that these tests describe the text backends specifically rather than
+// asserting that serialization is exact in general.
+//
+// =============================================================================
+
+#include "gtest/gtest.h"
+
+#include <cctype>
+#include <ios>
+#include <limits>
+#include <sstream>
+#include <vector>
+
+#include "chrono/serialization/ChArchiveBinary.h"
+#include "chrono/serialization/ChArchiveJSON.h"
+#include "chrono/serialization/ChArchiveXML.h"
+
+using namespace chrono;
+
+namespace {
+
+struct NumberHolder {
+    double d = 0;
+    float f = 0;
+
+    void ArchiveOut(ChArchiveOut& archive_out) {
+        archive_out << CHNVP(d);
+        archive_out << CHNVP(f);
+    }
+    void ArchiveIn(ChArchiveIn& archive_in) {
+        archive_in >> CHNVP(d);
+        archive_in >> CHNVP(f);
+    }
+};
+
+// Values that cannot survive 6 significant digits. Spread over several magnitudes, because the
+// error of a fixed significant-digit budget scales with the value.
+std::vector<double> TestValues() {
+    return {
+        1.0 / 3.0,             //
+        12345.678901234567,    //
+        3.14159265358979312,   //
+        -2.718281828459045,    //
+        1.2345678901234567e+8  //
+    };
+}
+
+template <typename OutArchive, typename InArchive>
+NumberHolder RoundTrip(double d, float f) {
+    std::stringstream buffer;
+    {
+        NumberHolder written;
+        written.d = d;
+        written.f = f;
+        OutArchive archive_out(buffer);
+        archive_out << CHNVP(written, "holder");
+    }
+    NumberHolder read;
+    InArchive archive_in(buffer);
+    archive_in >> CHNVP(read, "holder");
+    return read;
+}
+
+// Count the significant decimal digits in the first number found in some serialized text.
+size_t SignificantDigits(const std::string& text) {
+    size_t digits = 0;
+    bool in_number = false, seen_nonzero = false;
+    for (char c : text) {
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            in_number = true;
+            if (c != '0')
+                seen_nonzero = true;
+            if (seen_nonzero)
+                ++digits;
+        } else if (c == '.' || c == '-' || c == '+' || (in_number && (c == 'e' || c == 'E'))) {
+            continue;
+        } else if (in_number) {
+            break;
+        }
+    }
+    return digits;
+}
+
+}  // namespace
+
+TEST(ChArchiveJSON, DoubleRoundTripIsExact) {
+    for (double v : TestValues()) {
+        const float fv = static_cast<float>(v);
+        NumberHolder got = RoundTrip<ChArchiveOutJSON, ChArchiveInJSON>(v, fv);
+        EXPECT_DOUBLE_EQ(got.d, v) << "JSON lost precision on " << v;
+        EXPECT_FLOAT_EQ(got.f, fv) << "JSON lost precision on float " << fv;
+    }
+}
+
+TEST(ChArchiveXML, DoubleRoundTripIsExact) {
+    for (double v : TestValues()) {
+        const float fv = static_cast<float>(v);
+        NumberHolder got = RoundTrip<ChArchiveOutXML, ChArchiveInXML>(v, fv);
+        EXPECT_DOUBLE_EQ(got.d, v) << "XML lost precision on " << v;
+        EXPECT_FLOAT_EQ(got.f, fv) << "XML lost precision on float " << fv;
+    }
+}
+
+// Control: the binary backend writes raw bytes and was never affected. If this ever fails, the
+// problem is something other than text formatting.
+TEST(ChArchiveBinary, DoubleRoundTripIsExact) {
+    for (double v : TestValues()) {
+        const float fv = static_cast<float>(v);
+        NumberHolder got = RoundTrip<ChArchiveOutBinary, ChArchiveInBinary>(v, fv);
+        EXPECT_DOUBLE_EQ(got.d, v) << "binary lost precision on " << v;
+        EXPECT_FLOAT_EQ(got.f, fv) << "binary lost precision on float " << fv;
+    }
+}
+
+// Exactness is necessary but not sufficient. Printing a float at the double's seventeen digits also
+// round trips, but it exposes eight digits of binary noise: 0.6f becomes 0.60000002384185791. A float
+// must be written at its own precision, which is nine digits.
+TEST(ChArchiveJSON, FloatIsNotOverPrinted) {
+    std::ostringstream stream;
+    {
+        NumberHolder holder;
+        holder.d = 0;
+        holder.f = 0.6f;
+        ChArchiveOutJSON archive_out(stream);
+        archive_out << CHNVP(holder, "holder");
+    }
+    const std::string text = stream.str();
+    const size_t at = text.find("\"f\"");
+    ASSERT_NE(at, std::string::npos) << "could not locate the float in:\n" << text;
+
+    const size_t digits = SignificantDigits(text.substr(at + 3));
+    EXPECT_LE(digits, static_cast<size_t>(std::numeric_limits<float>::max_digits10))
+        << "float written with " << digits << " significant digits, which is more than a float carries.\n"
+        << "serialized text was:\n"
+        << text;
+}
+
+// The output archives take a stream owned by the caller, which may well be reused afterwards, so
+// raising the precision must not be a permanent side effect on that stream.
+TEST(ChArchiveJSON, DoesNotLeakStreamPrecision) {
+    std::ostringstream stream;
+    const std::streamsize original = stream.precision(4);
+    ASSERT_EQ(stream.precision(), 4);
+    {
+        NumberHolder holder;
+        ChArchiveOutJSON archive_out(stream);
+        archive_out << CHNVP(holder, "holder");
+        EXPECT_EQ(stream.precision(), std::numeric_limits<double>::max_digits10)
+            << "the archive should raise the precision while it is writing";
+    }
+    EXPECT_EQ(stream.precision(), 4) << "the archive must restore the caller's stream precision";
+    stream.precision(original);
+}
+
+TEST(ChArchiveXML, DoesNotLeakStreamPrecision) {
+    std::ostringstream stream;
+    const std::streamsize original = stream.precision(4);
+    ASSERT_EQ(stream.precision(), 4);
+    {
+        NumberHolder holder;
+        ChArchiveOutXML archive_out(stream);
+        archive_out << CHNVP(holder, "holder");
+        EXPECT_EQ(stream.precision(), std::numeric_limits<double>::max_digits10)
+            << "the archive should raise the precision while it is writing";
+    }
+    EXPECT_EQ(stream.precision(), 4) << "the archive must restore the caller's stream precision";
+    stream.precision(original);
+}

--- a/src/tests/unit_tests/core/utest_CH_archive_precision.cpp
+++ b/src/tests/unit_tests/core/utest_CH_archive_precision.cpp
@@ -10,20 +10,7 @@
 //
 // =============================================================================
 //
-// Floating point fidelity of the archive backends.
-//
-// The text backends used to write floating point values at the default ostream precision, which is
-// 6 significant digits, while a double needs 17 to be recovered exactly. Saving a model to JSON or
-// XML and loading it back therefore returned different numbers, with no warning: 1.0/3.0 came back
-// as 0.333333, and 12345.678901234567 came back as 12345.7, an absolute error of about 0.022.
-//
-// Nothing caught this because the existing round-trip tests compare with a tolerance of 1e-5 on
-// states of magnitude near 1, where 6 significant digits happens to be good enough. Six digits is a
-// relative budget, so the absolute error grows with the magnitude of the value.
-//
-// The binary backend was never affected: it writes the raw bytes instead of printing them. It is
-// used here as a control, so that these tests describe the text backends specifically rather than
-// asserting that serialization is exact in general.
+// Testing accuracy up to 0 ULP on archives
 //
 // =============================================================================
 
@@ -85,108 +72,49 @@ NumberHolder RoundTrip(double d, float f) {
     return read;
 }
 
-// Count the significant decimal digits in the first number found in some serialized text.
-size_t SignificantDigits(const std::string& text) {
-    size_t digits = 0;
-    bool in_number = false, seen_nonzero = false;
-    for (char c : text) {
-        if (std::isdigit(static_cast<unsigned char>(c))) {
-            in_number = true;
-            if (c != '0')
-                seen_nonzero = true;
-            if (seen_nonzero)
-                ++digits;
-        } else if (c == '.' || c == '-' || c == '+' || (in_number && (c == 'e' || c == 'E'))) {
-            continue;
-        } else if (in_number) {
-            break;
-        }
-    }
-    return digits;
-}
-
 }  // namespace
 
 TEST(ChArchiveJSON, DoubleRoundTripIsExact) {
     for (double v : TestValues()) {
-        const float fv = static_cast<float>(v);
+        const float fv = static_cast<float>(v);  // not used
         NumberHolder got = RoundTrip<ChArchiveOutJSON, ChArchiveInJSON>(v, fv);
-        EXPECT_DOUBLE_EQ(got.d, v) << "JSON lost precision on " << v;
-        EXPECT_FLOAT_EQ(got.f, fv) << "JSON lost precision on float " << fv;
+
+        testing::internal::FloatingPoint<double> fp_a_double(got.d);
+        testing::internal::FloatingPoint<double> fp_b_double(v);
+        EXPECT_EQ(fp_a_double.bits(), fp_b_double.bits()) << "JSON does not match the bit pattern on double: " << v;
+
+        testing::internal::FloatingPoint<float> fp_a_float(got.f);
+        testing::internal::FloatingPoint<float> fp_b_float(fv);
+        EXPECT_EQ(fp_a_float.bits(), fp_b_float.bits()) << "JSON does not match the bit pattern on float: " << fv;
     }
 }
 
 TEST(ChArchiveXML, DoubleRoundTripIsExact) {
     for (double v : TestValues()) {
-        const float fv = static_cast<float>(v);
+        const float fv = static_cast<float>(v);  // not used
         NumberHolder got = RoundTrip<ChArchiveOutXML, ChArchiveInXML>(v, fv);
-        EXPECT_DOUBLE_EQ(got.d, v) << "XML lost precision on " << v;
-        EXPECT_FLOAT_EQ(got.f, fv) << "XML lost precision on float " << fv;
+
+        testing::internal::FloatingPoint<double> fp_a_double(got.d);
+        testing::internal::FloatingPoint<double> fp_b_double(v);
+        EXPECT_EQ(fp_a_double.bits(), fp_b_double.bits()) << "XML does not match the bit pattern on double: " << v;
+
+        testing::internal::FloatingPoint<float> fp_a_float(got.f);
+        testing::internal::FloatingPoint<float> fp_b_float(fv);
+        EXPECT_EQ(fp_a_float.bits(), fp_b_float.bits()) << "XML does not match the bit pattern on float: " << fv;
     }
 }
 
-// Control: the binary backend writes raw bytes and was never affected. If this ever fails, the
-// problem is something other than text formatting.
 TEST(ChArchiveBinary, DoubleRoundTripIsExact) {
     for (double v : TestValues()) {
         const float fv = static_cast<float>(v);
         NumberHolder got = RoundTrip<ChArchiveOutBinary, ChArchiveInBinary>(v, fv);
-        EXPECT_DOUBLE_EQ(got.d, v) << "binary lost precision on " << v;
-        EXPECT_FLOAT_EQ(got.f, fv) << "binary lost precision on float " << fv;
-    }
-}
 
-// Exactness is necessary but not sufficient. Printing a float at the double's seventeen digits also
-// round trips, but it exposes eight digits of binary noise: 0.6f becomes 0.60000002384185791. A float
-// must be written at its own precision, which is nine digits.
-TEST(ChArchiveJSON, FloatIsNotOverPrinted) {
-    std::ostringstream stream;
-    {
-        NumberHolder holder;
-        holder.d = 0;
-        holder.f = 0.6f;
-        ChArchiveOutJSON archive_out(stream);
-        archive_out << CHNVP(holder, "holder");
-    }
-    const std::string text = stream.str();
-    const size_t at = text.find("\"f\"");
-    ASSERT_NE(at, std::string::npos) << "could not locate the float in:\n" << text;
+        testing::internal::FloatingPoint<double> fp_a_double(got.d);
+        testing::internal::FloatingPoint<double> fp_b_double(v);
+        EXPECT_EQ(fp_a_double.bits(), fp_b_double.bits()) << "Binary archive does not match the bit pattern on double: " << v;
 
-    const size_t digits = SignificantDigits(text.substr(at + 3));
-    EXPECT_LE(digits, static_cast<size_t>(std::numeric_limits<float>::max_digits10))
-        << "float written with " << digits << " significant digits, which is more than a float carries.\n"
-        << "serialized text was:\n"
-        << text;
-}
-
-// The output archives take a stream owned by the caller, which may well be reused afterwards, so
-// raising the precision must not be a permanent side effect on that stream.
-TEST(ChArchiveJSON, DoesNotLeakStreamPrecision) {
-    std::ostringstream stream;
-    const std::streamsize original = stream.precision(4);
-    ASSERT_EQ(stream.precision(), 4);
-    {
-        NumberHolder holder;
-        ChArchiveOutJSON archive_out(stream);
-        archive_out << CHNVP(holder, "holder");
-        EXPECT_EQ(stream.precision(), std::numeric_limits<double>::max_digits10)
-            << "the archive should raise the precision while it is writing";
+        testing::internal::FloatingPoint<float> fp_a_float(got.f);
+        testing::internal::FloatingPoint<float> fp_b_float(fv);
+        EXPECT_EQ(fp_a_float.bits(), fp_b_float.bits()) << "Binary archive does not match the bit pattern on float: " << fv;
     }
-    EXPECT_EQ(stream.precision(), 4) << "the archive must restore the caller's stream precision";
-    stream.precision(original);
-}
-
-TEST(ChArchiveXML, DoesNotLeakStreamPrecision) {
-    std::ostringstream stream;
-    const std::streamsize original = stream.precision(4);
-    ASSERT_EQ(stream.precision(), 4);
-    {
-        NumberHolder holder;
-        ChArchiveOutXML archive_out(stream);
-        archive_out << CHNVP(holder, "holder");
-        EXPECT_EQ(stream.precision(), std::numeric_limits<double>::max_digits10)
-            << "the archive should raise the precision while it is writing";
-    }
-    EXPECT_EQ(stream.precision(), 4) << "the archive must restore the caller's stream precision";
-    stream.precision(original);
 }


### PR DESCRIPTION
Fixes #778

ChArchiveOutJSON and ChArchiveOutXML wrote floating point values at the default ostream precision, which is 6 significant digits, while a double needs 17 to be recovered exactly. Saving a model to JSON or XML and loading it back therefore returned different numbers, silently. Measured, with the binary backend as a control since it writes raw bytes rather than printing them:

  original                JSON        XML         binary
  0.33333333333333331     0.333333    0.333333    exact
  12345.678901234567      12345.7     12345.7     exact

Note the second row: six significant digits is a relative budget, so the absolute error grows with magnitude, reaching about 0.022 there. Anyone using JSON or XML to checkpoint and restart a simulation was not restarting from where they stopped.

The fix raises the precision to max_digits10, which is the number of decimal digits that uniquely distinguishes every value of a type. It is set on the stream in the output archive's constructor and restored in the destructor, because the stream belongs to the caller and may be reused afterwards; std::cout, for one, should not be left permanently reconfigured. There is a test for that restoration.

The float overloads set 9 rather than inheriting the double's 17. Printing a float with eight digits more than it carries also round trips, but it exposes binary noise: 0.6f would be written as 0.60000002384185791 instead of 0.600000024. There is a test guarding against that regression too, since exactness alone does not catch it.

Readability cost, stated plainly because it is the reason this was not simply always correct: any value that is not exactly representable in binary now prints in full. 0.1 becomes 0.10000000000000001 and 9.81 becomes 9.8100000000000005, while 0.5 and 2.0 are unaffected. On the demo's system archive this changed the file size by less than one percent. The alternative that is both exact and tidy is to emit the shortest representation that round trips, which would render 0.1 as 0.1. std::to_chars does that directly, but its floating point overloads are not portable enough across the compilers Chrono supports, particularly older libstdc++ and libc++, so it is left as a possible follow-up rather than done here.

ChArchiveOutASCII is deliberately untouched. It has no reader, so it cannot round trip and is a human-facing dump where 6 digits is a reasonable default.

New test file utest_CH_archive_precision, in its own translation unit so that it does not collide with the additions PR #774 makes to utest_CH_archive. With the four source changes reverted, the four JSON and XML cases fail and the binary control still passes. All 11 core unit test binaries pass, including the pre-existing JSON, XML and Binary Fourbar round trips, which confirms the readers accept the longer values. demo_CH_archive still round-trips.