### PR TITLE
FSI-SPH: guard configuration setters against calls after Initialize()

### DIFF
--- a/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
@@ -178,18 +178,22 @@ void ChFsiFluidSystemSPH::InitParams() {
 //------------------------------------------------------------------------------
 
 void ChFsiFluidSystemSPH::SetBoundaryType(BoundaryMethod boundary_method) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->boundary_method = boundary_method;
 }
 
 void ChFsiFluidSystemSPH::SetViscosityType(ViscosityMethod viscosity_method) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->viscosity_method = viscosity_method;
 }
 
 void ChFsiFluidSystemSPH::SetArtificialViscosityCoefficient(double coefficient) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->artificial_viscosity = coefficient;
 }
 
 void ChFsiFluidSystemSPH::SetKernelType(KernelType kernel_type) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->kernel_type = kernel_type;
     switch (m_paramsH->kernel_type) {
         case KernelType::QUADRATIC:
@@ -208,23 +212,31 @@ void ChFsiFluidSystemSPH::SetKernelType(KernelType kernel_type) {
 }
 
 void ChFsiFluidSystemSPH::SetShiftingMethod(ShiftingMethod shifting_method) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->shifting_method = shifting_method;
 }
 
 void ChFsiFluidSystemSPH::SetSPHLinearSolver(SolverType lin_solver) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->LinearSolver = lin_solver;
 }
 
 void ChFsiFluidSystemSPH::SetIntegrationScheme(IntegrationScheme scheme) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->integration_scheme = scheme;
 }
 
 void ChFsiFluidSystemSPH::SetContainerDim(const ChVector3d& box_dim) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->boxDimX = box_dim.x();
     m_paramsH->boxDimY = box_dim.y();
     m_paramsH->boxDimZ = box_dim.z();
 }
 
+// Note: SetComputationalDomain is deliberately NOT guarded against post-Initialize calls:
+// CRMTerrain::Synchronize updates the computational domain mid-simulation (moving patch).
+// A post-initialization call currently updates only the host-side parameters; propagating
+// a mid-run domain change to the device parameters is addressed separately.
 void ChFsiFluidSystemSPH::SetComputationalDomain(const ChAABB& computational_AABB, BoundaryConditions bc_type) {
     m_paramsH->cMin = ToReal3(computational_AABB.min);
     m_paramsH->cMax = ToReal3(computational_AABB.max);
@@ -239,36 +251,43 @@ void ChFsiFluidSystemSPH::SetComputationalDomain(const ChAABB& computational_AAB
 }
 
 void ChFsiFluidSystemSPH::SetActiveDomain(const ChVector3d& box_dim) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->bodyActiveDomain = ToReal3(box_dim / 2);
     m_paramsH->use_active_domain = true;
 }
 
 void ChFsiFluidSystemSPH::SetActiveDomainDelay(double duration) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->settlingTime = duration;
 }
 
 void ChFsiFluidSystemSPH::SetNumBCELayers(int num_layers) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->num_bce_layers = num_layers;
 }
 
 void ChFsiFluidSystemSPH::SetInitPressure(const double height) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->pressure_height = height;
     m_paramsH->use_init_pressure = true;
 }
 
 void ChFsiFluidSystemSPH::SetGravitationalAcceleration(const ChVector3d& gravity) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->gravity.x = gravity.x();
     m_paramsH->gravity.y = gravity.y();
     m_paramsH->gravity.z = gravity.z();
 }
 
 void ChFsiFluidSystemSPH::SetBodyForce(const ChVector3d& force) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->bodyForce3.x = force.x();
     m_paramsH->bodyForce3.y = force.y();
     m_paramsH->bodyForce3.z = force.z();
 }
 
 void ChFsiFluidSystemSPH::SetInitialSpacing(double spacing) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->d0 = (Real)spacing;
     m_paramsH->ood0 = 1 / m_paramsH->d0;
     m_paramsH->volume0 = cube(m_paramsH->d0);
@@ -279,6 +298,7 @@ void ChFsiFluidSystemSPH::SetInitialSpacing(double spacing) {
 }
 
 void ChFsiFluidSystemSPH::SetKernelMultiplier(double multiplier) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->d0_multiplier = Real(multiplier);
 
     m_paramsH->h = m_paramsH->d0_multiplier * m_paramsH->d0;
@@ -286,27 +306,32 @@ void ChFsiFluidSystemSPH::SetKernelMultiplier(double multiplier) {
 }
 
 void ChFsiFluidSystemSPH::SetDensity(double rho0) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->rho0 = rho0;
     m_paramsH->invrho0 = 1 / m_paramsH->rho0;
     m_paramsH->markerMass = m_paramsH->volume0 * m_paramsH->rho0;
 }
 
 void ChFsiFluidSystemSPH::SetShiftingPPSTParameters(double push, double pull) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->shifting_ppst_push = push;
     m_paramsH->shifting_ppst_pull = pull;
 }
 
 void ChFsiFluidSystemSPH::SetShiftingXSPHParameters(double eps) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->shifting_xsph_eps = eps;
 }
 
 void ChFsiFluidSystemSPH::SetShiftingDiffusionParameters(double A, double AFSM, double AFST) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->shifting_diffusion_A = A;
     m_paramsH->shifting_diffusion_AFSM = AFSM;
     m_paramsH->shifting_diffusion_AFST = AFST;
 }
 
 void ChFsiFluidSystemSPH::SetConsistentDerivativeDiscretization(bool consistent_gradient, bool consistent_Laplacian) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->use_consistent_gradient_discretization = consistent_gradient;
     m_paramsH->use_consistent_laplacian_discretization = consistent_Laplacian;
 }
@@ -316,14 +341,17 @@ void ChFsiFluidSystemSPH::SetOutputLevel(OutputLevel output_level) {
 }
 
 void ChFsiFluidSystemSPH::SetCohesionForce(double Fc) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->Coh_coeff = Fc;
 }
 
 void ChFsiFluidSystemSPH::SetNumProximitySearchSteps(int steps) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->num_proximity_search_steps = steps;
 }
 
 void ChFsiFluidSystemSPH::SetUseVariableTimeStep(bool use_variable_time_step) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->use_variable_time_step = use_variable_time_step;
 }
 
@@ -419,6 +447,7 @@ void ChFsiFluidSystemSPH::CheckSPHParameters() {
 ChFsiFluidSystemSPH::FluidProperties::FluidProperties() : density(1000), viscosity(0.1), char_length(1) {}
 
 void ChFsiFluidSystemSPH::SetCfdSPH(const FluidProperties& fluid_props) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->elastic_SPH = false;
 
     SetDensity(fluid_props.density);
@@ -443,6 +472,7 @@ ChFsiFluidSystemSPH::ElasticMaterialProperties::ElasticMaterialProperties()
       mcc_v_lambda(2.0) {}
 
 void ChFsiFluidSystemSPH::SetElasticSPH(const ElasticMaterialProperties& mat_props) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->elastic_SPH = true;
 
     SetDensity(mat_props.density);
@@ -505,6 +535,7 @@ ChFsiFluidSystemSPH::SPHParameters::SPHParameters()
       use_variable_time_step(false) {}
 
 void ChFsiFluidSystemSPH::SetSPHParameters(const SPHParameters& sph_params) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->integration_scheme = sph_params.integration_scheme;
 
     m_paramsH->eos_type = sph_params.eos_type;
@@ -552,6 +583,7 @@ void ChFsiFluidSystemSPH::SetSPHParameters(const SPHParameters& sph_params) {
 ChFsiFluidSystemSPH::LinSolverParameters::LinSolverParameters() : type(SolverType::JACOBI), atol(0.0), rtol(0.0), max_num_iters(1000) {}
 
 void ChFsiFluidSystemSPH::SetLinSolverParameters(const LinSolverParameters& linsolv_params) {
+    ChAssertAlways(!m_is_initialized);
     m_paramsH->LinearSolver = linsolv_params.type;
     m_paramsH->LinearSolver_Abs_Tol = linsolv_params.atol;
     m_paramsH->LinearSolver_Rel_Tol = linsolv_params.rtol;
@@ -1489,6 +1521,10 @@ void ChFsiFluidSystemSPH::Initialize(const std::vector<FsiBodyState>& body_state
     }
 
     CheckSPHParameters();
+
+    // Mark the fluid system as initialized. This arms the configuration-setter guards
+    // also for standalone use (without a ChFsiSystem wrapper, which sets this flag too).
+    m_is_initialized = true;
 }
 
 #ifdef CHRONO_FEA
@@ -1680,6 +1716,10 @@ void ChFsiFluidSystemSPH::Initialize(const std::vector<FsiBodyState>& body_state
     }
 
     CheckSPHParameters();
+
+    // Mark the fluid system as initialized. This arms the configuration-setter guards
+    // also for standalone use (without a ChFsiSystem wrapper, which sets this flag too).
+    m_is_initialized = true;
 }
 
 void ChFsiFluidSystemSPH::AddBCEFsiMesh1D(const FsiSphMesh1D& fsisph_mesh) {

--- a/src/tests/unit_tests/fsi/sph/CMakeLists.txt
+++ b/src/tests/unit_tests/fsi/sph/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TESTS
     utest_FSI-SPH_Poiseuille_flow
+    utest_FSI-SPH_setter_guard
 )
 
 list(APPEND LIBS Chrono_core)

--- a/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_setter_guard.cpp
+++ b/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_setter_guard.cpp
@@ -1,0 +1,195 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+//
+// Unit test for the initialization guard on ChFsiFluidSystemSPH configuration
+// setters. These setters write only the host-side parameter structure; device
+// parameters are uploaded once during Initialize(). A call after Initialize()
+// therefore cannot take effect and must fail loudly instead of silently.
+//
+// Checks:
+// 1. The documented pattern (configure, then Initialize) works unchanged.
+// 2. Every guarded setter throws std::runtime_error after Initialize().
+// 3. SetComputationalDomain and SetOutputLevel remain callable after
+//    Initialize() (the CRMTerrain moving patch updates the computational
+//    domain mid-simulation; the output level is a host-only setting).
+// 4. The system still advances after the rejected calls (no partial state
+//    mutation).
+//
+// =============================================================================
+
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "chrono/physics/ChSystemSMC.h"
+
+#include "chrono_fsi/sph/ChFsiProblemSPH.h"
+
+using namespace chrono;
+using namespace chrono::fsi;
+using namespace chrono::fsi::sph;
+
+// Dimensions of the fluid box and initial spacing
+double bxDim = 0.1;
+double byDim = 0.1;
+double bzDim = 0.1;
+double initial_spacing = 0.01;
+double dt = 2e-4;
+
+int num_failures = 0;
+
+void ExpectThrow(const std::string& name, std::function<void()> f) {
+    try {
+        f();
+        std::cout << "FAIL (no throw): " << name << std::endl;
+        num_failures++;
+    } catch (const std::runtime_error&) {
+        std::cout << "  ok (guarded):  " << name << std::endl;
+    }
+}
+
+void ExpectNoThrow(const std::string& name, std::function<void()> f) {
+    try {
+        f();
+        std::cout << "  ok (allowed):  " << name << std::endl;
+    } catch (const std::exception& e) {
+        std::cout << "FAIL (threw):   " << name << " - " << e.what() << std::endl;
+        num_failures++;
+    }
+}
+
+int main(int argc, char* argv[]) {
+    // Create the FSI problem (same minimal setup as utest_FSI-SPH_Poiseuille_flow)
+    ChSystemSMC sysMBS;
+    ChFsiProblemCartesian fsi(initial_spacing, &sysMBS);
+    fsi.SetVerbose(false);
+    auto sysSPH = fsi.GetFluidSystemSPH();
+
+    fsi.SetGravitationalAcceleration(ChVector3d(0, 0, 0));
+
+    ChFsiFluidSystemSPH::FluidProperties fluid_props;
+    fluid_props.density = 1000;
+    fluid_props.viscosity = 1;
+    fsi.SetCfdSPH(fluid_props);
+
+    ChFsiFluidSystemSPH::SPHParameters sph_params;
+    sph_params.integration_scheme = IntegrationScheme::RK2;
+    sph_params.num_bce_layers = 3;
+    sph_params.initial_spacing = initial_spacing;
+    sph_params.d0_multiplier = 1;
+    sph_params.max_velocity = 0.1;
+    sph_params.shifting_method = ShiftingMethod::NONE;
+    sph_params.density_reinit_steps = 10000;
+    sph_params.viscosity_method = ViscosityMethod::LAMINAR;
+    sph_params.use_delta_sph = false;
+    sph_params.eos_type = EosType::ISOTHERMAL;
+    sph_params.use_consistent_gradient_discretization = true;
+    sph_params.use_consistent_laplacian_discretization = true;
+    fsi.SetSPHParameters(sph_params);
+
+    fsi.SetStepSizeCFD(dt);
+    fsi.SetStepsizeMBD(dt);
+
+    // Pre-initialization setter calls must be accepted (documented pattern)
+    std::cout << "Before Initialize():" << std::endl;
+    ExpectNoThrow("SetArtificialViscosityCoefficient (pre-init)",
+                  [&] { sysSPH->SetArtificialViscosityCoefficient(0.02); });
+    ExpectNoThrow("SetBodyForce (pre-init)", [&] { sysSPH->SetBodyForce(ChVector3d(0, 0, 0)); });
+
+    ChVector3d fsize(bxDim, byDim, bzDim - 2 * initial_spacing);
+    fsi.Construct(fsize, ChVector3d(0, 0, initial_spacing), BoxSide::Z_NEG | BoxSide::Z_POS);
+
+    ChVector3d c_min(-bxDim / 2 - initial_spacing / 2, -byDim / 2 - initial_spacing / 2, -10 * initial_spacing);
+    ChVector3d c_max(+bxDim / 2 + initial_spacing / 2, +byDim / 2 + initial_spacing / 2, bzDim + 10 * initial_spacing);
+    ChAABB domain(c_min, c_max);
+    fsi.SetComputationalDomain(domain, BC_ALL_PERIODIC);
+
+    fsi.Initialize();
+
+    // Prove the system advances before any post-init setter calls
+    for (int step = 0; step < 5; step++)
+        fsi.DoStepDynamics(dt);
+
+    // Every device-parameter setter must be rejected after Initialize()
+    std::cout << "After Initialize():" << std::endl;
+
+    ChFsiFluidSystemSPH::ElasticMaterialProperties mat_props;
+    ChFsiFluidSystemSPH::LinSolverParameters linsolv_params;
+
+    ExpectThrow("SetBoundaryType", [&] { sysSPH->SetBoundaryType(BoundaryMethod::ADAMI); });
+    ExpectThrow("SetViscosityType", [&] { sysSPH->SetViscosityType(ViscosityMethod::LAMINAR); });
+    ExpectThrow("SetArtificialViscosityCoefficient", [&] { sysSPH->SetArtificialViscosityCoefficient(0.5); });
+    ExpectThrow("SetKernelType", [&] { sysSPH->SetKernelType(KernelType::CUBIC_SPLINE); });
+    ExpectThrow("SetShiftingMethod", [&] { sysSPH->SetShiftingMethod(ShiftingMethod::NONE); });
+    ExpectThrow("SetSPHLinearSolver", [&] { sysSPH->SetSPHLinearSolver(SolverType::JACOBI); });
+    ExpectThrow("SetIntegrationScheme", [&] { sysSPH->SetIntegrationScheme(IntegrationScheme::RK2); });
+    ExpectThrow("SetContainerDim", [&] { sysSPH->SetContainerDim(ChVector3d(1, 1, 1)); });
+    ExpectThrow("SetActiveDomain", [&] { sysSPH->SetActiveDomain(ChVector3d(1, 1, 1)); });
+    ExpectThrow("SetActiveDomainDelay", [&] { sysSPH->SetActiveDomainDelay(1.0); });
+    ExpectThrow("SetNumBCELayers", [&] { sysSPH->SetNumBCELayers(3); });
+    ExpectThrow("SetInitPressure", [&] { sysSPH->SetInitPressure(0.1); });
+    ExpectThrow("SetGravitationalAcceleration", [&] { sysSPH->SetGravitationalAcceleration(ChVector3d(0, 0, -9.8)); });
+    ExpectThrow("SetBodyForce", [&] { sysSPH->SetBodyForce(ChVector3d(0.1, 0, 0)); });
+    ExpectThrow("SetInitialSpacing", [&] { sysSPH->SetInitialSpacing(0.02); });
+    ExpectThrow("SetKernelMultiplier", [&] { sysSPH->SetKernelMultiplier(1.2); });
+    ExpectThrow("SetDensity", [&] { sysSPH->SetDensity(1200); });
+    ExpectThrow("SetShiftingPPSTParameters", [&] { sysSPH->SetShiftingPPSTParameters(3.0, 0.0); });
+    ExpectThrow("SetShiftingXSPHParameters", [&] { sysSPH->SetShiftingXSPHParameters(0.5); });
+    ExpectThrow("SetShiftingDiffusionParameters", [&] { sysSPH->SetShiftingDiffusionParameters(1.0, 1.0, 1.0); });
+    ExpectThrow("SetConsistentDerivativeDiscretization",
+                [&] { sysSPH->SetConsistentDerivativeDiscretization(false, false); });
+    ExpectThrow("SetCohesionForce", [&] { sysSPH->SetCohesionForce(0.0); });
+    ExpectThrow("SetNumProximitySearchSteps", [&] { sysSPH->SetNumProximitySearchSteps(4); });
+    ExpectThrow("SetUseVariableTimeStep", [&] { sysSPH->SetUseVariableTimeStep(false); });
+    ExpectThrow("SetCfdSPH", [&] { sysSPH->SetCfdSPH(fluid_props); });
+    ExpectThrow("SetElasticSPH", [&] { sysSPH->SetElasticSPH(mat_props); });
+    ExpectThrow("SetSPHParameters", [&] { sysSPH->SetSPHParameters(sph_params); });
+    ExpectThrow("SetLinSolverParameters", [&] { sysSPH->SetLinSolverParameters(linsolv_params); });
+
+    // These must remain callable after Initialize()
+    ExpectNoThrow("SetComputationalDomain (post-init)", [&] { sysSPH->SetComputationalDomain(domain); });
+    ExpectNoThrow("SetOutputLevel (post-init)", [&] { sysSPH->SetOutputLevel(OutputLevel::STATE); });
+
+    // The rejected calls must not have altered any state: the system still advances
+    ExpectNoThrow("DoStepDynamics after rejected calls", [&] {
+        for (int step = 0; step < 5; step++)
+            fsi.DoStepDynamics(dt);
+    });
+
+    // ------------------------------------------------------------------------
+    // Standalone fluid system (no ChFsiSystem wrapper): the guards must arm here
+    // too, i.e. Initialize() itself must set the initialization flag.
+    std::cout << "Standalone ChFsiFluidSystemSPH (no FSI wrapper):" << std::endl;
+    ChFsiFluidSystemSPH sph2;
+    sph2.SetVerbose(false);
+    ExpectNoThrow("standalone pre-init configuration", [&] {
+        sph2.SetInitialSpacing(initial_spacing);
+        sph2.SetCfdSPH(fluid_props);
+        sph2.SetSPHParameters(sph_params);
+        sph2.SetStepSize(dt);
+        sph2.SetGravitationalAcceleration(ChVector3d(0, 0, 0));
+        sph2.SetComputationalDomain(domain, BC_ALL_PERIODIC);
+    });
+    sph2.AddBoxSPH(ChVector3d(0, 0, bzDim / 2), ChVector3d(bxDim / 2, byDim / 2, bzDim / 4));
+    ExpectNoThrow("standalone Initialize()", [&] { sph2.ChFsiFluidSystem::Initialize(); });  // base entry point (derived overloads hide it)
+    ExpectThrow("standalone SetDensity (post-init)", [&] { sph2.SetDensity(1200); });
+    ExpectThrow("standalone SetArtificialViscosityCoefficient (post-init)",
+                [&] { sph2.SetArtificialViscosityCoefficient(0.3); });
+
+    if (num_failures > 0) {
+        std::cout << "\n" << num_failures << " failure(s)" << std::endl;
+        return 1;
+    }
+    std::cout << "\nAll setter-guard checks passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Part of #781.

`ChFsiFluidSystemSPH`'s configuration setters write only the host-side `m_paramsH`. Device
kernels read `__constant__ paramsD`, which is uploaded only during `Initialize()`, so a
setter called afterwards is silently ignored: the call is accepted, nothing changes, and
the simulation continues with the old values. Requesting gravity after `Initialize()`
leaves particle positions bit-identical to never requesting it (details in #781).

## Change

- `ChAssertAlways(!m_is_initialized)` on the 28 setters that write device parameters,
  matching the guard idiom already used in this file (`OnAddFsiBody`,
  `OnAddFsiMesh1D/2D`).
- `m_is_initialized` is now set at the end of both `ChFsiFluidSystemSPH::Initialize`
  overloads. Previously only `ChFsiSystem::Initialize` set it, so the guards would not have
  armed for a fluid system used standalone.
- New unit test `utest_FSI-SPH_setter_guard`.

Deliberately not guarded: `SetComputationalDomain` (called mid-run by the CRMTerrain moving
patch; see PR-C), and `SetOutputLevel` / `SetBcePattern1D/2D`, which write host-only
members consumed at initialization.

A tree-wide sweep (library, demos, unit tests, python tests) found no post-`Initialize`
caller of any guarded setter other than the `SetComputationalDomain` case above.

## Compatibility

Intentional behavior change: code that called a guarded setter after `Initialize()`
previously got a silent no-op and now gets a `std::runtime_error`. Code that follows the
documented configure-then-initialize order is unaffected. No signature or ABI changes.

## Validation

gcc 12.2 / ROCm 7.2, MI350X (gfx950), Release, both `CH_USE_SPH_DOUBLE=OFF` and `ON`. The
new unit test passes in both precisions. A geostatic settling benchmark (106k particles,
stress-vs-depth slope/gamma gate) is unchanged to every printed digit before and after
(0.991).

Not tested: the CUDA backend (this change is host-only C++ with no backend-specific code),
and MSVC.

Merge note: PR-C touches the comment immediately above `SetComputationalDomain`, so
whichever of the two lands second needs a trivial merge there. Happy to rebase.
