### PR TITLE
FSI-SPH: propagate post-initialization computational-domain updates to the device

### DIFF
--- a/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
@@ -225,7 +225,19 @@ void ChFsiFluidSystemSPH::SetContainerDim(const ChVector3d& box_dim) {
     m_paramsH->boxDimZ = box_dim.z();
 }
 
+// Note: SetComputationalDomain may be called after Initialize: CRMTerrain::Synchronize
+// updates the computational domain mid-simulation (moving patch). A post-initialization
+// update is applied to the device parameters; it must be a pure translation of the domain
+// (same extents, same boundary condition types), since BCE walls and grid-sized device
+// arrays are fixed at Initialize.
 void ChFsiFluidSystemSPH::SetComputationalDomain(const ChAABB& computational_AABB, BoundaryConditions bc_type) {
+    if (m_is_initialized) {
+        ChAssertAlways(bc_type.x == m_paramsH->bc_type.x && bc_type.y == m_paramsH->bc_type.y &&
+                       bc_type.z == m_paramsH->bc_type.z);
+        m_paramsH->use_default_limits = false;
+        ApplyComputationalDomain(computational_AABB);
+        return;
+    }
     m_paramsH->cMin = ToReal3(computational_AABB.min);
     m_paramsH->cMax = ToReal3(computational_AABB.max);
     m_paramsH->use_default_limits = false;
@@ -233,6 +245,11 @@ void ChFsiFluidSystemSPH::SetComputationalDomain(const ChAABB& computational_AAB
 }
 
 void ChFsiFluidSystemSPH::SetComputationalDomain(const ChAABB& computational_AABB) {
+    if (m_is_initialized) {
+        m_paramsH->use_default_limits = false;
+        ApplyComputationalDomain(computational_AABB);
+        return;
+    }
     m_paramsH->cMin = ToReal3(computational_AABB.min);
     m_paramsH->cMax = ToReal3(computational_AABB.max);
     m_paramsH->use_default_limits = false;
@@ -1330,6 +1347,70 @@ void ChFsiFluidSystemSPH::AddBCEFsiBody(const FsiSphBody& fsisph_body) {
 
 //// TODO - eliminate code duplication in the two versions of Initialize()
 
+// Derive the domain-dependent grid quantities (periodic flags, bin sizes, grid
+// dimensions, world origin, grid bounds) from the current computational domain
+// limits in m_paramsH. Called during Initialize and for post-initialization
+// computational-domain updates.
+void ChFsiFluidSystemSPH::DeriveDomainGridQuantities() {
+    m_paramsH->x_periodic = m_paramsH->bc_type.x == BCType::PERIODIC;
+    m_paramsH->y_periodic = m_paramsH->bc_type.y == BCType::PERIODIC;
+    m_paramsH->z_periodic = m_paramsH->bc_type.z == BCType::PERIODIC;
+
+    // Set up subdomains for faster neighbor particle search
+    m_paramsH->Apply_BC_U = false;
+    int3 side0 = mI3((int)floor((m_paramsH->cMax.x - m_paramsH->cMin.x) / (m_paramsH->h_multiplier * m_paramsH->h)),
+                     (int)floor((m_paramsH->cMax.y - m_paramsH->cMin.y) / (m_paramsH->h_multiplier * m_paramsH->h)),
+                     (int)floor((m_paramsH->cMax.z - m_paramsH->cMin.z) / (m_paramsH->h_multiplier * m_paramsH->h)));
+    Real3 binSize3 = mR3((m_paramsH->cMax.x - m_paramsH->cMin.x) / side0.x, (m_paramsH->cMax.y - m_paramsH->cMin.y) / side0.y, (m_paramsH->cMax.z - m_paramsH->cMin.z) / side0.z);
+    // Bin size is derived from the x extent (the ternary max(x,y) previously computed
+    // here was dead code: it was immediately overwritten by binSize3.x).
+    m_paramsH->binSize0 = binSize3.x;
+    m_paramsH->boxDims = m_paramsH->cMax - m_paramsH->cMin;
+    m_paramsH->delta_pressure = mR3(0);
+    int3 SIDE = mI3(int((m_paramsH->cMax.x - m_paramsH->cMin.x) / m_paramsH->binSize0 + .1), int((m_paramsH->cMax.y - m_paramsH->cMin.y) / m_paramsH->binSize0 + .1),
+                    int((m_paramsH->cMax.z - m_paramsH->cMin.z) / m_paramsH->binSize0 + .1));
+    Real mBinSize = m_paramsH->binSize0;
+    m_paramsH->gridSize = SIDE;
+    m_paramsH->worldOrigin = m_paramsH->cMin;
+    m_paramsH->cellSize = mR3(mBinSize, mBinSize, mBinSize);
+
+    // Precompute grid min and max bounds considering whether we have periodic boundaries or not
+    m_paramsH->minBounds = make_int3(m_paramsH->x_periodic ? INT_MIN : 0, m_paramsH->y_periodic ? INT_MIN : 0, m_paramsH->z_periodic ? INT_MIN : 0);
+
+    m_paramsH->maxBounds = make_int3(m_paramsH->x_periodic ? INT_MAX : m_paramsH->gridSize.x - 1, m_paramsH->y_periodic ? INT_MAX : m_paramsH->gridSize.y - 1,
+                                     m_paramsH->z_periodic ? INT_MAX : m_paramsH->gridSize.z - 1);
+}
+
+// Apply a computational-domain update on an initialized system. Only a pure TRANSLATION
+// of the domain is accepted: the per-axis extents must be unchanged (to within a relative
+// tolerance that absorbs floating-point drift of translated bounds but is far below any
+// real size change), because the neighbor-search grid dimensions, cell size, and BCE
+// walls are fixed at Initialize. An accepted update touches only the origin-dependent
+// quantities (cMin, cMax, worldOrigin, boxDims) - the size-derived grid quantities are
+// deliberately NOT re-derived, so a legitimate translation can never be rejected (or
+// altered) by floor()/rounding jitter - and uploads the parameters to all device
+// translation units. A rejected update leaves the previous domain fully intact.
+void ChFsiFluidSystemSPH::ApplyComputationalDomain(const ChAABB& computational_AABB) {
+    Real3 new_cMin = ToReal3(computational_AABB.min);
+    Real3 new_cMax = ToReal3(computational_AABB.max);
+    Real3 old_ext = m_paramsH->cMax - m_paramsH->cMin;
+    Real3 new_ext = new_cMax - new_cMin;
+
+    const Real rtol = Real(1e-5);
+    bool same_size = (std::abs(new_ext.x - old_ext.x) <= rtol * old_ext.x) &&
+                     (std::abs(new_ext.y - old_ext.y) <= rtol * old_ext.y) &&
+                     (std::abs(new_ext.z - old_ext.z) <= rtol * old_ext.z);
+    if (!same_size)
+        ChAssertAlways(!"post-initialization SetComputationalDomain supports pure translation only");
+
+    m_paramsH->cMin = new_cMin;
+    m_paramsH->cMax = new_cMax;
+    m_paramsH->worldOrigin = new_cMin;
+    m_paramsH->boxDims = new_cMax - new_cMin;
+
+    CopyParametersToDevice(m_paramsH, m_data_mgr->countersH);
+}
+
 void ChFsiFluidSystemSPH::Initialize(const std::vector<FsiBodyState>& body_states) {
     assert(body_states.size() == m_bodies.size());
 
@@ -1414,32 +1495,7 @@ void ChFsiFluidSystemSPH::Initialize(const std::vector<FsiBodyState>& body_state
         m_paramsH->bc_type = BC_NONE;
     }
 
-    m_paramsH->x_periodic = m_paramsH->bc_type.x == BCType::PERIODIC;
-    m_paramsH->y_periodic = m_paramsH->bc_type.y == BCType::PERIODIC;
-    m_paramsH->z_periodic = m_paramsH->bc_type.z == BCType::PERIODIC;
-
-    // Set up subdomains for faster neighbor particle search
-    m_paramsH->Apply_BC_U = false;
-    int3 side0 = mI3((int)floor((m_paramsH->cMax.x - m_paramsH->cMin.x) / (m_paramsH->h_multiplier * m_paramsH->h)),
-                     (int)floor((m_paramsH->cMax.y - m_paramsH->cMin.y) / (m_paramsH->h_multiplier * m_paramsH->h)),
-                     (int)floor((m_paramsH->cMax.z - m_paramsH->cMin.z) / (m_paramsH->h_multiplier * m_paramsH->h)));
-    Real3 binSize3 = mR3((m_paramsH->cMax.x - m_paramsH->cMin.x) / side0.x, (m_paramsH->cMax.y - m_paramsH->cMin.y) / side0.y, (m_paramsH->cMax.z - m_paramsH->cMin.z) / side0.z);
-    m_paramsH->binSize0 = (binSize3.x > binSize3.y) ? binSize3.x : binSize3.y;
-    m_paramsH->binSize0 = binSize3.x;
-    m_paramsH->boxDims = m_paramsH->cMax - m_paramsH->cMin;
-    m_paramsH->delta_pressure = mR3(0);
-    int3 SIDE = mI3(int((m_paramsH->cMax.x - m_paramsH->cMin.x) / m_paramsH->binSize0 + .1), int((m_paramsH->cMax.y - m_paramsH->cMin.y) / m_paramsH->binSize0 + .1),
-                    int((m_paramsH->cMax.z - m_paramsH->cMin.z) / m_paramsH->binSize0 + .1));
-    Real mBinSize = m_paramsH->binSize0;
-    m_paramsH->gridSize = SIDE;
-    m_paramsH->worldOrigin = m_paramsH->cMin;
-    m_paramsH->cellSize = mR3(mBinSize, mBinSize, mBinSize);
-
-    // Precompute grid min and max bounds considering whether we have periodic boundaries or not
-    m_paramsH->minBounds = make_int3(m_paramsH->x_periodic ? INT_MIN : 0, m_paramsH->y_periodic ? INT_MIN : 0, m_paramsH->z_periodic ? INT_MIN : 0);
-
-    m_paramsH->maxBounds = make_int3(m_paramsH->x_periodic ? INT_MAX : m_paramsH->gridSize.x - 1, m_paramsH->y_periodic ? INT_MAX : m_paramsH->gridSize.y - 1,
-                                     m_paramsH->z_periodic ? INT_MAX : m_paramsH->gridSize.z - 1);
+    DeriveDomainGridQuantities();
     // Update the speed of sound
     if (m_paramsH->elastic_SPH) {
         m_paramsH->Cs = sqrt(m_paramsH->K_bulk / m_paramsH->rho0);
@@ -1591,32 +1647,7 @@ void ChFsiFluidSystemSPH::Initialize(const std::vector<FsiBodyState>& body_state
         m_paramsH->bc_type = BC_NONE;
     }
 
-    m_paramsH->x_periodic = m_paramsH->bc_type.x == BCType::PERIODIC;
-    m_paramsH->y_periodic = m_paramsH->bc_type.y == BCType::PERIODIC;
-    m_paramsH->z_periodic = m_paramsH->bc_type.z == BCType::PERIODIC;
-
-    // Set up subdomains for faster neighbor particle search
-    m_paramsH->Apply_BC_U = false;
-    int3 side0 = mI3((int)floor((m_paramsH->cMax.x - m_paramsH->cMin.x) / (m_paramsH->h_multiplier * m_paramsH->h)),
-                     (int)floor((m_paramsH->cMax.y - m_paramsH->cMin.y) / (m_paramsH->h_multiplier * m_paramsH->h)),
-                     (int)floor((m_paramsH->cMax.z - m_paramsH->cMin.z) / (m_paramsH->h_multiplier * m_paramsH->h)));
-    Real3 binSize3 = mR3((m_paramsH->cMax.x - m_paramsH->cMin.x) / side0.x, (m_paramsH->cMax.y - m_paramsH->cMin.y) / side0.y, (m_paramsH->cMax.z - m_paramsH->cMin.z) / side0.z);
-    m_paramsH->binSize0 = (binSize3.x > binSize3.y) ? binSize3.x : binSize3.y;
-    m_paramsH->binSize0 = binSize3.x;
-    m_paramsH->boxDims = m_paramsH->cMax - m_paramsH->cMin;
-    m_paramsH->delta_pressure = mR3(0);
-    int3 SIDE = mI3(int((m_paramsH->cMax.x - m_paramsH->cMin.x) / m_paramsH->binSize0 + .1), int((m_paramsH->cMax.y - m_paramsH->cMin.y) / m_paramsH->binSize0 + .1),
-                    int((m_paramsH->cMax.z - m_paramsH->cMin.z) / m_paramsH->binSize0 + .1));
-    Real mBinSize = m_paramsH->binSize0;
-    m_paramsH->gridSize = SIDE;
-    m_paramsH->worldOrigin = m_paramsH->cMin;
-    m_paramsH->cellSize = mR3(mBinSize, mBinSize, mBinSize);
-
-    // Precompute grid min and max bounds considering whether we have periodic boundaries or not
-    m_paramsH->minBounds = make_int3(m_paramsH->x_periodic ? INT_MIN : 0, m_paramsH->y_periodic ? INT_MIN : 0, m_paramsH->z_periodic ? INT_MIN : 0);
-
-    m_paramsH->maxBounds = make_int3(m_paramsH->x_periodic ? INT_MAX : m_paramsH->gridSize.x - 1, m_paramsH->y_periodic ? INT_MAX : m_paramsH->gridSize.y - 1,
-                                     m_paramsH->z_periodic ? INT_MAX : m_paramsH->gridSize.z - 1);
+    DeriveDomainGridQuantities();
     // Update the speed of sound
     if (m_paramsH->elastic_SPH) {
         m_paramsH->Cs = sqrt(m_paramsH->K_bulk / m_paramsH->rho0);

--- a/src/chrono_fsi/sph/ChFsiFluidSystemSPH.h
+++ b/src/chrono_fsi/sph/ChFsiFluidSystemSPH.h
@@ -155,10 +155,20 @@ class CH_FSI_API ChFsiFluidSystemSPH : public ChFsiFluidSystem {
     /// Set computational domain and boundary conditions on its sides.
     /// `bc_type` indicates the types of BCs imposed in the three directions of the computational domain.
     /// By default, no special boundary conditions are imposed in any direction (BCType::NONE).
+    /// \note After Initialize(), only a pure TRANSLATION of the domain is accepted
+    /// (same extents; the 2-argument overload additionally requires unchanged BC
+    /// types); the update propagates to the device (used by the CRMTerrain moving
+    /// patch). A size- or BC-changing post-initialization call throws and leaves the
+    /// previous domain intact.
     void SetComputationalDomain(const ChAABB& computational_AABB, BoundaryConditions bc_type);
 
     /// Set computational domain.
     /// Note that this version leaves the setting for BC type unchanged.
+    /// \note After Initialize(), only a pure TRANSLATION of the domain is accepted
+    /// (same extents; the 2-argument overload additionally requires unchanged BC
+    /// types); the update propagates to the device (used by the CRMTerrain moving
+    /// patch). A size- or BC-changing post-initialization call throws and leaves the
+    /// previous domain intact.
     void SetComputationalDomain(const ChAABB& computational_AABB);
 
     /// Set dimensions of the active domain AABB.
@@ -566,6 +576,13 @@ class CH_FSI_API ChFsiFluidSystemSPH : public ChFsiFluidSystem {
     virtual void OnExchangeSolidStates() override;
 
   private:
+    /// Derive the domain-dependent grid quantities from the current computational domain.
+    void DeriveDomainGridQuantities();
+
+    /// Apply a post-initialization computational-domain update (translation only) and
+    /// upload the new parameters to the device.
+    void ApplyComputationalDomain(const ChAABB& computational_AABB);
+
     /// SPH specification of an FSI rigid solid.
     struct FsiSphBody {
         std::shared_ptr<FsiBody> fsi_body;   ///< underlying FSI solid

--- a/src/tests/unit_tests/fsi/sph/CMakeLists.txt
+++ b/src/tests/unit_tests/fsi/sph/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TESTS
     utest_FSI-SPH_Poiseuille_flow
+    utest_FSI-SPH_domain_update
 )
 
 list(APPEND LIBS Chrono_core)

--- a/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_domain_update.cpp
+++ b/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_domain_update.cpp
@@ -1,0 +1,223 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+//
+// Unit test for post-initialization computational-domain updates (the mechanism
+// used by the CRMTerrain moving patch). A domain update issued after
+// Initialize() must reach the DEVICE parameters, not only the host copy.
+//
+// Setup: a static periodic fluid box. After Initialize(), the computational
+// domain is translated along +x. Fluid particles that fall below the new lower
+// x-boundary must be wrapped by the periodic-boundary kernel to the far end of
+// the NEW domain within a few steps. That wrap is executed on the device using
+// paramsD.cMin/cMax, so observing it proves the update propagated to the GPU.
+//
+// Also checks the safety rails: a post-init domain update that changes the
+// domain SIZE (grid dimensions) must throw and leave the domain unchanged, and
+// a post-init update that changes the boundary-condition types must throw.
+//
+// =============================================================================
+
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "chrono/physics/ChSystemSMC.h"
+
+#include "chrono_fsi/sph/ChFsiProblemSPH.h"
+
+using namespace chrono;
+using namespace chrono::fsi;
+using namespace chrono::fsi::sph;
+
+double bxDim = 0.1;
+double byDim = 0.1;
+double bzDim = 0.1;
+double initial_spacing = 0.01;
+double dt = 2e-4;
+
+int num_failures = 0;
+
+void ExpectThrow(const std::string& name, std::function<void()> f) {
+    try {
+        f();
+        std::cout << "FAIL (no throw): " << name << std::endl;
+        num_failures++;
+    } catch (const std::runtime_error&) {
+        std::cout << "  ok (rejected): " << name << std::endl;
+    }
+}
+
+void Check(const std::string& name, bool cond) {
+    if (cond) {
+        std::cout << "  ok:            " << name << std::endl;
+    } else {
+        std::cout << "FAIL:           " << name << std::endl;
+        num_failures++;
+    }
+}
+
+int main(int argc, char* argv[]) {
+    ChSystemSMC sysMBS;
+    ChFsiProblemCartesian fsi(initial_spacing, &sysMBS);
+    fsi.SetVerbose(false);
+    auto sysSPH = fsi.GetFluidSystemSPH();
+
+    fsi.SetGravitationalAcceleration(ChVector3d(0, 0, 0));
+
+    ChFsiFluidSystemSPH::FluidProperties fluid_props;
+    fluid_props.density = 1000;
+    fluid_props.viscosity = 1;
+    fsi.SetCfdSPH(fluid_props);
+
+    ChFsiFluidSystemSPH::SPHParameters sph_params;
+    sph_params.integration_scheme = IntegrationScheme::RK2;
+    sph_params.num_bce_layers = 3;
+    sph_params.initial_spacing = initial_spacing;
+    sph_params.d0_multiplier = 1;
+    sph_params.max_velocity = 0.1;
+    sph_params.shifting_method = ShiftingMethod::NONE;
+    sph_params.density_reinit_steps = 10000;
+    sph_params.viscosity_method = ViscosityMethod::LAMINAR;
+    sph_params.use_delta_sph = false;
+    sph_params.eos_type = EosType::ISOTHERMAL;
+    sph_params.use_consistent_gradient_discretization = true;
+    sph_params.use_consistent_laplacian_discretization = true;
+    fsi.SetSPHParameters(sph_params);
+
+    fsi.SetStepSizeCFD(dt);
+    fsi.SetStepsizeMBD(dt);
+
+    // Fluid box with bottom and top walls, periodic laterally
+    ChVector3d fsize(bxDim, byDim, bzDim - 2 * initial_spacing);
+    fsi.Construct(fsize, ChVector3d(0, 0, initial_spacing), BoxSide::Z_NEG | BoxSide::Z_POS);
+
+    ChVector3d c_min(-bxDim / 2 - initial_spacing / 2, -byDim / 2 - initial_spacing / 2, -10 * initial_spacing);
+    ChVector3d c_max(+bxDim / 2 + initial_spacing / 2, +byDim / 2 + initial_spacing / 2, bzDim + 10 * initial_spacing);
+    ChAABB domain(c_min, c_max);
+    fsi.SetComputationalDomain(domain, BC_ALL_PERIODIC);
+
+    fsi.Initialize();
+
+    for (int step = 0; step < 5; step++)
+        fsi.DoStepDynamics(dt);
+
+    // Scan only the SPH fluid particles: GetParticlePositions returns all markers with
+    // the fluid particles first, and the boundary BCE markers must not wrap.
+    size_t num_fluid = fsi.GetNumSPHParticles();
+    auto pos0 = sysSPH->GetParticlePositions();
+    double min_x0 = 1e9, max_x0 = -1e9;
+    for (size_t i = 0; i < num_fluid; i++) {
+        min_x0 = std::min(min_x0, pos0[i].x());
+        max_x0 = std::max(max_x0, pos0[i].x());
+    }
+    std::cout << "before update: fluid x in [" << min_x0 << ", " << max_x0 << "]" << std::endl;
+
+    // ------------------------------------------------------------------------
+    // Translate the domain by +0.04 in x (pure translation, same size, same BCs).
+    double shift = 0.04;
+    ChAABB shifted(ChVector3d(c_min.x() + shift, c_min.y(), c_min.z()),
+                   ChVector3d(c_max.x() + shift, c_max.y(), c_max.z()));
+    double Lx = c_max.x() - c_min.x();
+
+    sysSPH->SetComputationalDomain(shifted);  // fluid-system API, the CRMTerrain path; must reach the device
+
+    for (int step = 0; step < 5; step++)
+        fsi.DoStepDynamics(dt);
+
+    auto pos1 = sysSPH->GetParticlePositions();
+    double min_x1 = 1e9, max_x1 = -1e9;
+    size_t n_wrapped = 0;
+    for (size_t i = 0; i < num_fluid; i++) {
+        min_x1 = std::min(min_x1, pos1[i].x());
+        max_x1 = std::max(max_x1, pos1[i].x());
+        if (pos1[i].x() > max_x0 + shift / 2)
+            n_wrapped++;
+    }
+    std::cout << "after  update: fluid x in [" << min_x1 << ", " << max_x1 << "], wrapped particles: " << n_wrapped
+              << std::endl;
+
+    const double tol = 1e-3;
+    // Particles below the new lower boundary must have wrapped to the far end of the
+    // NEW domain: this happens in the device periodic-wrap kernel using paramsD, so it
+    // proves the post-init update reached the GPU.
+    Check("particles wrapped to the far end of the new domain (device saw the update)", n_wrapped > 0);
+    Check("no fluid particle below the new lower x-boundary", min_x1 >= shifted.min.x() - tol);
+    Check("no fluid particle beyond the new upper x-boundary", max_x1 <= shifted.max.x() + tol);
+    Check("wrap distance equals the domain period", max_x1 <= max_x0 + Lx + tol);
+
+    // ------------------------------------------------------------------------
+    // Safety rails
+    ChAABB scaled_x(shifted.min, ChVector3d(shifted.max.x() + 3 * bxDim, shifted.max.y(), shifted.max.z()));
+    ExpectThrow("post-init domain update that changes the domain size in x",
+                [&] { sysSPH->SetComputationalDomain(scaled_x); });
+
+    // Small y/z size changes that would preserve the integer grid counts must ALSO be
+    // rejected (the extent comparison is direct, not grid-derived).
+    ChAABB scaled_y(shifted.min, ChVector3d(shifted.max.x(), shifted.max.y() + bxDim / 10, shifted.max.z()));
+    ExpectThrow("post-init domain update that changes the domain size in y",
+                [&] { sysSPH->SetComputationalDomain(scaled_y); });
+    ChAABB scaled_z(shifted.min, ChVector3d(shifted.max.x(), shifted.max.y(), shifted.max.z() + bxDim / 10));
+    ExpectThrow("post-init domain update that changes the domain size in z",
+                [&] { sysSPH->SetComputationalDomain(scaled_z); });
+
+    ExpectThrow("post-init domain update that changes the BC types",
+                [&] { sysSPH->SetComputationalDomain(shifted, BC_NONE); });
+
+    // The rejected updates must not have corrupted the working domain: stepping continues.
+    try {
+        for (int step = 0; step < 3; step++)
+            fsi.DoStepDynamics(dt);
+        std::cout << "  ok:            stepping continues after rejected updates" << std::endl;
+    } catch (const std::exception& e) {
+        std::cout << "FAIL:           stepping after rejected updates - " << e.what() << std::endl;
+        num_failures++;
+    }
+
+    // ------------------------------------------------------------------------
+    // Repeated small translations (the moving-patch traverse pattern): none may be
+    // falsely rejected by floating-point jitter, and stepping must continue throughout.
+    try {
+        ChAABB dom = shifted;
+        for (int k = 0; k < 25; k++) {
+            dom = ChAABB(ChVector3d(dom.min.x() + 0.005, dom.min.y(), dom.min.z()),
+                         ChVector3d(dom.max.x() + 0.005, dom.max.y(), dom.max.z()));
+            sysSPH->SetComputationalDomain(dom);
+            fsi.DoStepDynamics(dt);
+            fsi.DoStepDynamics(dt);
+        }
+        std::cout << "  ok:            25 successive translations accepted, stepping continues" << std::endl;
+    } catch (const std::exception& e) {
+        std::cout << "FAIL:           repeated translations - " << e.what() << std::endl;
+        num_failures++;
+    }
+    auto pos2 = sysSPH->GetParticlePositions();
+    double min_x2 = 1e9, max_x2 = -1e9;
+    for (size_t i = 0; i < num_fluid; i++) {
+        min_x2 = std::min(min_x2, pos2[i].x());
+        max_x2 = std::max(max_x2, pos2[i].x());
+    }
+    double final_cmin_x = shifted.min.x() + 25 * 0.005;
+    double final_cmax_x = shifted.max.x() + 25 * 0.005;
+    std::cout << "after traverse: fluid x in [" << min_x2 << ", " << max_x2 << "], domain ["
+              << final_cmin_x << ", " << final_cmax_x << "]" << std::endl;
+    Check("fluid inside the final domain after the traverse",
+          min_x2 >= final_cmin_x - tol && max_x2 <= final_cmax_x + tol);
+
+    if (num_failures > 0) {
+        std::cout << "\n" << num_failures << " failure(s)" << std::endl;
+        return 1;
+    }
+    std::cout << "\nAll domain-update checks passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Part of #781. This is the fix for the CRMTerrain moving patch.

`CRMTerrain::Synchronize` shifts the computational domain mid-run through
`SetComputationalDomain`. Device parameters are uploaded only during `Initialize()`, so the
shift never reached the GPU: the neighbor-search grid kept using the initial domain, and
`calcHashD` aborts the run once the patch travels about 40 kernel lengths past it. The
domain-dependent grid quantities were also derived from the domain limits only inside the
two `Initialize` overloads, in duplicated code, so even the host-side values went stale.

Demonstration: a headless port of `demo_VEH_CRMTerrain_MovingPatch` (same terrain, same
tracked body at 5 km/h, driven farther) dies at about 1.5 m of travel with
`Error flag intercepted in .../SphCollisionSystem.cu:344 from calcHashD`. The bundled demo
does not surface this because its body never travels that far. With this PR the same test
completes 4.17 m with 34 patch relocations.

## Change

- Factor the duplicated derivation into `DeriveDomainGridQuantities()`, used by both
  `Initialize` overloads.
- On an initialized system, `SetComputationalDomain` validates the request by comparing the
  per-axis domain extents directly (relative tolerance 1e-5), then updates `cMin`, `cMax`,
  `worldOrigin` and `boxDims` and uploads the parameters to every device translation unit.
  Only pure translations are accepted: the extents and the boundary-condition types must not
  change, since BCE walls and grid-sized device arrays are fixed at `Initialize`. Nothing is
  mutated before validation, so a rejected update leaves the previous domain intact.
- The size-derived grid quantities are deliberately **not** re-derived after initialization.
  Validating by re-deriving and comparing `gridSize` would let `floor()` rounding jitter
  reject a legitimate translation part-way through a long traverse.
- Pre-initialization behavior is unchanged.
- Drive-by in the factored block: removed a dead assignment where `binSize0` was set to
  `max(x, y)` and then immediately overwritten by `binSize3.x`.

## Test

New `utest_FSI-SPH_domain_update`: a static periodic fluid box whose domain is translated
after `Initialize()`. Fluid particles below the new lower boundary must be wrapped to the
far end of the **new** domain by the device periodic-wrap kernel, which can only happen if
the update reached the GPU. The test also covers size-changing updates on all three axes and
a BC-changing update (both rejected, with the system still able to step), and 25 successive
translations, which is the traverse pattern the moving patch produces.

## Validation

gcc 12.2 / ROCm 7.2, MI350X (gfx950), Release, both `CH_USE_SPH_DOUBLE=OFF` and `ON`; the
new unit test passes in both precisions, and a geostatic settling benchmark is unchanged.

Not tested: a full vehicle-on-CRM traverse (the test above drives a tracked body, as the
upstream demo does), the interaction with active domains, and the CUDA backend. A run of
your own moving-patch demo over a longer distance would be a good independent confirmation.

Merge note: PR-A touches the comment immediately above `SetComputationalDomain`, so
whichever of the two lands second needs a trivial merge there. The two are otherwise
independent, and either order is safe: for a fluid system used through `ChFsiSystem` (which
is how CRMTerrain uses it) this PR works on its own, while for a standalone
`ChFsiFluidSystemSPH` the post-init path needs PR-A's `m_is_initialized` assignment.
