### PR TITLE
FSI-SPH: make the rheology-failure error flag actually work

### DIFF
--- a/src/chrono_fsi/sph/physics/SphFluidDynamics.cu
+++ b/src/chrono_fsi/sph/physics/SphFluidDynamics.cu
@@ -41,7 +41,7 @@ void CopyParametersToDevice_SphFluidDynamics(std::shared_ptr<ChFsiParamsSPH> par
 }
 
 SphFluidDynamics::SphFluidDynamics(FsiDataManager& data_mgr, SphBceManager& bce_mgr, bool verbose, bool check_errors)
-    : m_data_mgr(data_mgr), m_verbose(verbose), m_check_errors(check_errors) {
+    : m_data_mgr(data_mgr), m_verbose(verbose), m_check_errors(check_errors), m_errflagD(nullptr) {
     collisionSystem = chrono_types::make_shared<SphCollisionSystem>(data_mgr);
 
     if (m_data_mgr.paramsH->integration_scheme == IntegrationScheme::IMPLICIT_SPH)
@@ -50,10 +50,12 @@ SphFluidDynamics::SphFluidDynamics(FsiDataManager& data_mgr, SphBceManager& bce_
         forceSystem = chrono_types::make_shared<SphForceWCSPH>(data_mgr, bce_mgr, verbose, m_check_errors);
 
     gpuStreamCreate(&m_copy_stream);
+    gpuMallocErrorFlag(m_errflagD);
 }
 
 SphFluidDynamics::~SphFluidDynamics() {
     gpuStreamDestroy(m_copy_stream);
+    gpuFreeErrorFlag(m_errflagD);
 }
 
 // -----------------------------------------------------------------------------
@@ -338,7 +340,7 @@ __device__ void TauEulerStep(Real dT,
                              Real3& tau_offdiag,
                              Real4& rho_p,
                              Real3& pcEvSv,
-                             bool& error_occurred) {
+                             volatile bool* error_flag) {
     if (paramsD.rheology_model_crm == RheologyCRM::MU_OF_I) {
         Real3 new_tau_diag = tau_diag + dT * deriv_tau_diag;
         Real3 new_tau_offdiag = tau_offdiag + dT * deriv_tau_offdiag;
@@ -566,6 +568,21 @@ __device__ void TauEulerStep(Real dT,
         // Set min to prevent collapse of the specific volume
         pcEvSv.z = fmax(Real(1.0), pcEvSv.z);
     }
+
+    // Flag a rheology failure (non-finite updated stress state) so the host can abort.
+    // This complements the host-side position/density NaN scans, which do not cover stress.
+    // Nothing is evaluated when error checking is disabled (error_flag is then null).
+    // Check only state the active rheology model integrates: mu(I) neither reads nor
+    // updates the consolidation state (pcEvSv), which can legitimately be non-finite
+    // straight out of default initialization (AddSphParticle derives the specific volume
+    // with log(pc / p1), which is not finite for the default zero initial pressure).
+    if (error_flag) {
+        bool rheology_failed = !IsFinite(tau_diag) || !IsFinite(tau_offdiag) || !IsFinite(rho_p);
+        if (paramsD.rheology_model_crm == RheologyCRM::MCC)
+            rheology_failed = rheology_failed || !IsFinite(pcEvSv);
+        if (rheology_failed)
+            *error_flag = true;
+    }
 }
 
 // Kernel to update the fluid properties of a particle, using an explicit Euler step.
@@ -591,7 +608,7 @@ __global__ void EulerStep_D(Real4* posRadD,
                             const int32_t* activityIdentifierSortedD,
                             const uint numActive,
                             Real dT,
-                            bool& error_occurred) {
+                            volatile bool* error_flag) {
     uint index = blockIdx.x * blockDim.x + threadIdx.x;
     if (index >= numActive)
         return;
@@ -609,7 +626,7 @@ __global__ void EulerStep_D(Real4* posRadD,
     if (paramsD.elastic_SPH) {
         // Euler step for tau and pressure update
         TauEulerStep(dT, derivTauXxYyZzD[index], derivTauXyXzYzD[index], derivVelRhoD[index].w, freeSurfaceIdD[index], tauXxYyZzD[index], tauXyXzYzD[index], rhoPresMuD[index],
-                     pcEvSvD[index], error_occurred);
+                     pcEvSvD[index], error_flag);
     } else {
         // Euler step for density and pressure update from EOS
         DensityEulerStep(dT, derivVelRhoD[index].w, paramsD.eos_type, rhoPresMuD[index]);
@@ -640,7 +657,7 @@ __global__ void MidpointStep_D(Real4* posRadD,
                                const int32_t* activityIdentifierSortedD,
                                const uint numActive,
                                Real dT,
-                               bool& error_occurred) {
+                               volatile bool* error_flag) {
     uint index = blockIdx.x * blockDim.x + threadIdx.x;
     if (index >= numActive)
         return;
@@ -659,7 +676,7 @@ __global__ void MidpointStep_D(Real4* posRadD,
     if (paramsD.elastic_SPH) {
         // Euler step for tau and pressure update
         TauEulerStep(dT, derivTauXxYyZzD[index], derivTauXyXzYzD[index], derivVelRhoD[index].w, freeSurfaceIdD[index], tauXxYyZzD[index], tauXyXzYzD[index], rhoPresMuD[index],
-                     pcEvSvD[index], error_occurred);
+                     pcEvSvD[index], error_flag);
     } else {
         // Euler step for density and pressure update from EOS
         DensityEulerStep(dT, derivVelRhoD[index].w, paramsD.eos_type, rhoPresMuD[index]);
@@ -674,13 +691,18 @@ struct check_infinite {
 void SphFluidDynamics::EulerStep(std::shared_ptr<SphMarkerDataD> sortedMarkers, Real dT) {
     uint numActive = (uint)m_data_mgr.countersH->numExtendedParticles;
     uint numBlocks, numThreads;
-    bool error_occurred = false;
     computeGridSize(numActive, 256, numBlocks, numThreads);
+
+    bool* error_flagD = nullptr;
+    if (m_check_errors) {
+        gpuResetErrorFlag(m_errflagD);
+        error_flagD = m_errflagD;
+    }
 
     EulerStep_D<<<numBlocks, numThreads>>>(mR4CAST(sortedMarkers->posRadD), mR3CAST(sortedMarkers->velMasD), mR4CAST(sortedMarkers->rhoPresMuD), mR3CAST(sortedMarkers->tauXxYyZzD),
                                            mR3CAST(sortedMarkers->tauXyXzYzD), mR3CAST(sortedMarkers->pcEvSvD), mR3CAST(m_data_mgr.vel_XSPH_D), mR4CAST(m_data_mgr.derivVelRhoD),
                                            mR3CAST(m_data_mgr.derivTauXxYyZzD), mR3CAST(m_data_mgr.derivTauXyXzYzD), U1CAST(m_data_mgr.freeSurfaceIdD),
-                                           INT_32CAST(m_data_mgr.activityIdentifierSortedD), numActive, dT, error_occurred);
+                                           INT_32CAST(m_data_mgr.activityIdentifierSortedD), numActive, dT, error_flagD);
 
     if (m_check_errors) {
         gpuCheckError();
@@ -689,8 +711,7 @@ void SphFluidDynamics::EulerStep(std::shared_ptr<SphMarkerDataD> sortedMarkers, 
         if (thrust::any_of(sortedMarkers->rhoPresMuD.begin(), sortedMarkers->rhoPresMuD.begin() + numActive, check_infinite<Real4>()))
             gpuThrowError("A particle density is NaN");
         // Even if one particle has this problem, we can't proceed
-        if (error_occurred)
-            gpuThrowError("Rheology model failed");
+        gpuCheckErrorFlag(error_flagD, "TauEulerStep (rheology model failure)");
     }
 }
 
@@ -698,21 +719,25 @@ void SphFluidDynamics::MidpointStep(std::shared_ptr<SphMarkerDataD> sortedMarker
     uint numActive = (uint)m_data_mgr.countersH->numExtendedParticles;
     uint numBlocks, numThreads;
     computeGridSize(numActive, 256, numBlocks, numThreads);
-    bool error_occurred = false;
+
+    bool* error_flagD = nullptr;
+    if (m_check_errors) {
+        gpuResetErrorFlag(m_errflagD);
+        error_flagD = m_errflagD;
+    }
     MidpointStep_D<<<numBlocks, numThreads>>>(
         mR4CAST(sortedMarkers->posRadD), mR3CAST(sortedMarkers->velMasD), mR4CAST(sortedMarkers->rhoPresMuD), mR3CAST(sortedMarkers->tauXxYyZzD),
         mR3CAST(sortedMarkers->tauXyXzYzD), mR3CAST(sortedMarkers->pcEvSvD), mR3CAST(m_data_mgr.vel_XSPH_D), mR4CAST(m_data_mgr.derivVelRhoD), mR3CAST(m_data_mgr.derivTauXxYyZzD),
-        mR3CAST(m_data_mgr.derivTauXyXzYzD), U1CAST(m_data_mgr.freeSurfaceIdD), INT_32CAST(m_data_mgr.activityIdentifierSortedD), numActive, dT, error_occurred);
+        mR3CAST(m_data_mgr.derivTauXyXzYzD), U1CAST(m_data_mgr.freeSurfaceIdD), INT_32CAST(m_data_mgr.activityIdentifierSortedD), numActive, dT, error_flagD);
 
     if (m_check_errors) {
         gpuCheckError();
-        if (thrust::any_of(sortedMarkers->posRadD.begin(), sortedMarkers->posRadD.end(), check_infinite<Real4>()))
+        if (thrust::any_of(sortedMarkers->posRadD.begin(), sortedMarkers->posRadD.begin() + numActive, check_infinite<Real4>()))
             gpuThrowError("A particle position is NaN");
-        if (thrust::any_of(sortedMarkers->rhoPresMuD.begin(), sortedMarkers->rhoPresMuD.end(), check_infinite<Real4>()))
+        if (thrust::any_of(sortedMarkers->rhoPresMuD.begin(), sortedMarkers->rhoPresMuD.begin() + numActive, check_infinite<Real4>()))
             gpuThrowError("A particle density is NaN");
         // Even if one particle has this problem, we can't proceed
-        if (error_occurred)
-            gpuThrowError("Rheology model failed");
+        gpuCheckErrorFlag(error_flagD, "TauEulerStep (rheology model failure)");
     }
 }
 

--- a/src/chrono_fsi/sph/physics/SphFluidDynamics.cuh
+++ b/src/chrono_fsi/sph/physics/SphFluidDynamics.cuh
@@ -52,6 +52,11 @@ class SphFluidDynamics {
     /// Destructor of the fluid/granular dynamics class.
     ~SphFluidDynamics();
 
+    /// This class owns raw device resources (a stream and the rheology failure flag), so it is
+    /// neither copyable nor assignable.
+    SphFluidDynamics(const SphFluidDynamics&) = delete;
+    SphFluidDynamics& operator=(const SphFluidDynamics&) = delete;
+
     /// Perform proximity search.
     /// Sort particles (broad-phase) and create neighbor lists (narrow-phase)
     void ProximitySearch();
@@ -105,6 +110,7 @@ class SphFluidDynamics {
 
     bool m_verbose;
     bool m_check_errors;
+    bool* m_errflagD;  ///< device-resident rheology failure flag
 
     /// Advance the state of the fluid system using an explicit Euler step.
     void EulerStep(std::shared_ptr<SphMarkerDataD> sortedMarkers, Real dT);

--- a/src/tests/unit_tests/fsi/sph/CMakeLists.txt
+++ b/src/tests/unit_tests/fsi/sph/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TESTS
     utest_FSI-SPH_Poiseuille_flow
     utest_FSI-SPH_domain_update
     utest_FSI-SPH_setter_guard
+    utest_FSI-SPH_rheology_error_flag
 )
 
 list(APPEND LIBS Chrono_core)

--- a/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_rheology_error_flag.cpp
+++ b/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_rheology_error_flag.cpp
@@ -1,0 +1,172 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+//
+// Unit test for the CRM rheology-failure error flag.
+//
+// The flag aborts a run when the updated stress state of the active rheology
+// model is not finite. It must fire on a genuinely poisoned state and must not
+// fire on state the active model does not use.
+//
+// A CRM bed created with the default particle pressure starts with a non-finite
+// consolidation state: FsiDataManager::AddSphParticle derives the MCC specific
+// volume with log(pc / p1) and log(pc / confining), which is not finite for the
+// default pc = 0. Neither of the two runs below may be aborted by that state:
+//
+//   1. Under MU_OF_I the consolidation state is neither read nor updated, so it
+//      cannot indicate a failure of the active model.
+//   2. Under MCC it is part of the update, but the specific volume is clamped
+//      (fmax) on the first step, which also removes the non-finite value.
+//
+// Case 2 is NOT a claim that a default-pressure MCC bed is physically sound. The
+// non-finite specific volume is read before it is clamped: it feeds the MCC bulk
+// modulus candidate, and fmin(fmax(K_cand, 0.1 * K_bulk), K_bulk) returns the
+// floor when the candidate is NaN. Such a bed therefore runs with the bulk
+// modulus pinned at a tenth of nominal on the first step and with a specific
+// volume of exactly 1.0 (zero void ratio) thereafter, with no diagnostic. That
+// is an initialization defect, reported separately upstream. What this test
+// asserts is only that the error flag must not turn that silent repair into an
+// abort, since aborting would change behavior that this PR is not meant to
+// change.
+//
+// Case 1 is a regression guard: checking consolidation state under MU_OF_I made
+// the flag abort healthy runs. A genuine firing of the flag is not reproducible
+// from the public API at this revision (any input that makes the stress state
+// non-finite also makes positions non-finite in the same step, so the position
+// scan reports first); it is covered by a forced-fire build instead.
+//
+// =============================================================================
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "chrono/physics/ChSystemSMC.h"
+
+#include "chrono_fsi/sph/ChFsiProblemSPH.h"
+
+using namespace chrono;
+using namespace chrono::fsi;
+using namespace chrono::fsi::sph;
+
+double bxDim = 0.2;
+double byDim = 0.2;
+double bzDim = 0.1;
+double initial_spacing = 0.02;
+double dt = 1e-4;
+int num_steps = 10;
+
+int num_failures = 0;
+
+// Step a CRM bed built with the DEFAULT particle pressure under the given rheology.
+// Returns true if the run threw.
+bool RunBed(RheologyCRM rheology, std::string& what, bool depth_pressure = false) {
+    ChSystemSMC sysMBS;
+    ChFsiProblemCartesian fsi(initial_spacing, &sysMBS);
+    fsi.SetVerbose(false);
+
+    // The error checks this test exercises are enabled by default; ask for them
+    // explicitly so the test cannot be silently voided by a change of default.
+    fsi.GetFluidSystemSPH()->EnableGPUErrorCheck(true);
+    fsi.SetGravitationalAcceleration(ChVector3d(0, 0, -9.81));
+    sysMBS.SetGravitationalAcceleration(ChVector3d(0, 0, -9.81));
+
+    ChFsiFluidSystemSPH::ElasticMaterialProperties mat_props;
+    mat_props.density = 1700;
+    mat_props.Young_modulus = 1e6;
+    mat_props.Poisson_ratio = 0.3;
+    mat_props.mu_I0 = 0.04;
+    mat_props.mu_fric_s = 0.8;
+    mat_props.mu_fric_2 = 0.8;
+    mat_props.average_diam = 0.005;
+    mat_props.cohesion_coeff = 0;
+    mat_props.rheology_model = rheology;
+    mat_props.mcc_M = 1.2;
+    mat_props.mcc_kappa = 0.01;
+    mat_props.mcc_lambda = 0.1;
+    mat_props.mcc_v_lambda = 2.0;
+    fsi.SetElasticSPH(mat_props);
+
+    ChFsiFluidSystemSPH::SPHParameters sph_params;
+    sph_params.integration_scheme = IntegrationScheme::RK2;
+    sph_params.initial_spacing = initial_spacing;
+    sph_params.d0_multiplier = 1;
+    sph_params.artificial_viscosity = 0.5;
+    sph_params.viscosity_method = ViscosityMethod::ARTIFICIAL_BILATERAL;
+    sph_params.boundary_method = BoundaryMethod::ADAMI;
+    fsi.SetSPHParameters(sph_params);
+
+    fsi.SetStepSizeCFD(dt);
+    fsi.SetStepsizeMBD(dt);
+
+    // Bed with a floor and side walls; particle pressure is left at its default.
+    if (depth_pressure)
+        fsi.RegisterParticlePropertiesCallback(chrono_types::make_shared<DepthPressurePropertiesCallback>(bzDim));
+
+    fsi.Construct(ChVector3d(bxDim, byDim, bzDim), ChVector3d(0, 0, 0), BoxSide::ALL & ~BoxSide::Z_POS);
+    fsi.Initialize();
+
+    try {
+        for (int i = 0; i < num_steps; i++)
+            fsi.DoStepDynamics(dt);
+    } catch (const std::exception& e) {
+        what = e.what();
+        return true;
+    }
+    return false;
+}
+
+int main(int argc, char* argv[]) {
+    // ------------------------------------------------------------------------
+    // 1. mu(I): the non-finite consolidation state is not part of this model's
+    //    update, so the run must not be aborted by it.
+    std::string what;
+    std::cout << "MU_OF_I bed with default particle pressure:" << std::endl;
+    if (RunBed(RheologyCRM::MU_OF_I, what)) {
+        std::cout << "FAIL: the run aborted: " << what << std::endl;
+        num_failures++;
+    } else {
+        std::cout << "  ok: ran " << num_steps << " steps without aborting" << std::endl;
+    }
+
+    // ------------------------------------------------------------------------
+    // 2. MCC, same default-pressure initial condition: must also run. By the time
+    //    the predicate runs, the model has clamped the state it poisoned itself
+    //    with (see the note at the top of this file: the run is not healthy, it is
+    //    silently repaired). The flag must not convert that into an abort.
+    what.clear();
+    std::cout << "MCC bed with default particle pressure (non-finite initial consolidation state):" << std::endl;
+    if (RunBed(RheologyCRM::MCC, what)) {
+        std::cout << "FAIL: the run aborted: " << what << std::endl;
+        num_failures++;
+    } else {
+        std::cout << "  ok: ran " << num_steps << " steps without aborting" << std::endl;
+    }
+
+    // ------------------------------------------------------------------------
+    // 3. MCC with a physical depth-based initial pressure (the documented way to
+    //    initialize a Cam-Clay bed): must run.
+    what.clear();
+    std::cout << "MCC bed with depth-based initial pressure:" << std::endl;
+    if (RunBed(RheologyCRM::MCC, what, true)) {
+        std::cout << "FAIL: the run aborted: " << what << std::endl;
+        num_failures++;
+    } else {
+        std::cout << "  ok: ran " << num_steps << " steps without aborting" << std::endl;
+    }
+
+    if (num_failures > 0) {
+        std::cout << "\n" << num_failures << " failure(s)" << std::endl;
+        return 1;
+    }
+    std::cout << "\nAll rheology-error-flag checks passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Part of #781.

`SphFluidDynamics.cu` declares a host stack `bool error_occurred`, passes it **by
reference** into the `__global__` kernels `EulerStep_D` / `MidpointStep_D` and on into the
device function `TauEulerStep`, then reads it back on the host and calls
`gpuThrowError("Rheology model failed")`. Device code cannot write a host stack variable
and never assigns it, so the check is unreachable. Within the `m_check_errors` block,
positions and densities have working `thrust::any_of` NaN scans, but the updated CRM stress
state has none, and that is the state that went non-finite in the MCC overflow fixed by
#766.

## Change

- Replace the host reference with a device-resident flag, using the idiom this module
  already uses for `calcHashD` (`gpuMallocErrorFlag` / `gpuResetErrorFlag` /
  `gpuCheckErrorFlag` in `SphUtilsDevice.cuh`): the kernels take `volatile bool*`,
  `TauEulerStep` raises it when the updated stress state is not finite, and the host reads
  it back and throws with the kernel named.
- Allocation, reset and readback happen only when `m_check_errors` is enabled; otherwise
  the kernel receives `nullptr` and the entire predicate is skipped on device, so error
  checking costs nothing when it is turned off.
- The predicate covers `tau` and `rho/p` under both rheology models, and the consolidation
  state `pcEvSv` only under MCC. mu(I) neither reads nor updates `pcEvSv` (every access to
  it inside `TauEulerStep` is in the MCC branch), and that state is routinely non-finite
  straight out of default initialization, because `AddSphParticle` derives the specific
  volume with `log(pc / p1)` for the default `pc = 0` (item 1 of #781). Checking it under
  mu(I) aborts healthy runs.
- Same functions, related: `MidpointStep`'s NaN scans ran over the whole array while
  `EulerStep`'s stop at `numActive`, which is what the kernels actually touch. Unified on
  `numActive`.
- New unit test `utest_FSI-SPH_rheology_error_flag`: a CRM bed created with the default
  particle pressure starts with a non-finite consolidation state, and none of mu(I), MCC,
  or MCC with a depth-based initial pressure may be aborted by it. The mu(I) case is a
  regression guard for the false abort described above.

## Scope of the consolidation-state term, stated precisely

Under MCC, both consolidation components that the branch updates are clamped at the end of
it: `pcEvSv.x = fmax(Real(100.0), pcEvSv.x)` and `pcEvSv.z = fmax(Real(1.0), pcEvSv.z)`.
Since `fmax` returns the non-NaN operand, a NaN in either component is replaced by the
clamp floor before the predicate runs. In practice, therefore, the `pcEvSv` term can only
catch a non-finite volumetric strain rate (`pcEvSv.y`, which is not clamped). We mention it
because the clamping also means a nonsense initial specific volume is silently replaced by
1.0 rather than reported, which may be worth a separate look.

## Does the flag fire?

The plumbing is proven end to end by a forced-fire build (the flag raised unconditionally in
`TauEulerStep`), which aborts on the first step with
`Error flag intercepted in .../SphFluidDynamics.cu from TauEulerStep (rheology model
failure)`. The predicate is also demonstrably live on real data: with the earlier, broader
version of it, a CRMTerrain traverse built through `ChFsiProblemSPH` was aborted on step 1
by exactly this path, which is how the initialization issue in item 1 of #781 was found.

Being straightforward about the gap: there is no test that drives the shipped predicate to
fire from the public API. Any input that makes the stress state non-finite also makes
positions non-finite within the same step, and the host-side position scan reports first;
and the obvious deterministic candidate, a poisoned consolidation state under MCC, is
removed by the clamps described above before the predicate sees it.

## Validation

gcc 12.2 / ROCm 7.2, MI350X (gfx950), Release, both precisions. The new unit test passes in
both. A geostatic settling benchmark (106k particles) is unchanged to every printed digit;
wall clock 81-83 s against a 78 s baseline, inside the 78 to 83 s run-to-run spread measured
over eight runs.

Not tested: the CUDA backend (the `gpu*` macros are this module's own backend-portability
layer, used identically by `calcHashD` on both backends), and the ISPH path (these are the
explicit WCSPH integrators).

Deliberately left for follow-ups, since both are pre-existing and module-wide rather than
specific to this change: the per-step flag allocation could become a persistent member (it
also leaks on the throwing paths, which are aborting anyway), and the `SphUtilsDevice.cuh`
error-flag macros ignore their `[[nodiscard]] hipError_t` returns at every call site. Glad
to do either in a separate PR if you want them.
