### PR TITLE
FSI-SPH: apply parameter updates to every translation unit, not only under HIP

### DIFF
--- a/src/chrono_fsi/sph/physics/SphBceManager.cu
+++ b/src/chrono_fsi/sph/physics/SphBceManager.cu
@@ -35,15 +35,12 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
-#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
 void CopyParametersToDevice_SphBceManager(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
     gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
     gpuCheckError();
     gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
     gpuCheckError();
 }
-
-#endif
 
 SphBceManager::SphBceManager(FsiDataManager& data_mgr, NodeDirections node_directions_mode, bool verbose, bool check_errors)
     : m_data_mgr(data_mgr), m_node_directions_mode(node_directions_mode), m_verbose(verbose), m_check_errors(check_errors) {

--- a/src/chrono_fsi/sph/physics/SphCollisionSystem.cu
+++ b/src/chrono_fsi/sph/physics/SphCollisionSystem.cu
@@ -25,15 +25,12 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
-#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
 void CopyParametersToDevice_SphCollisionSystem(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
     gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
     gpuCheckError();
     gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
     gpuCheckError();
 }
-
-#endif
 
 // =============================================================================
 

--- a/src/chrono_fsi/sph/physics/SphFluidDynamics.cu
+++ b/src/chrono_fsi/sph/physics/SphFluidDynamics.cu
@@ -33,15 +33,12 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
-#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
 void CopyParametersToDevice_SphFluidDynamics(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
     gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
     gpuCheckError();
     gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
     gpuCheckError();
 }
-
-#endif
 
 SphFluidDynamics::SphFluidDynamics(FsiDataManager& data_mgr, SphBceManager& bce_mgr, bool verbose, bool check_errors)
     : m_data_mgr(data_mgr), m_verbose(verbose), m_check_errors(check_errors) {

--- a/src/chrono_fsi/sph/physics/SphForceISPH.cu
+++ b/src/chrono_fsi/sph/physics/SphForceISPH.cu
@@ -37,15 +37,12 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
-#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
 void CopyParametersToDevice_SphForceISPH(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
     gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
     gpuCheckError();
     gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
     gpuCheckError();
 }
-
-#endif
 
 __device__ void BCE_Vel_Acc(int i_idx,
                             Real3& myAcc,         // output: BCE marker acceleration

--- a/src/chrono_fsi/sph/physics/SphForceWCSPH.cu
+++ b/src/chrono_fsi/sph/physics/SphForceWCSPH.cu
@@ -26,15 +26,12 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
-#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
 void CopyParametersToDevice_SphForceWCSPH(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
     gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
     gpuCheckError();
     gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
     gpuCheckError();
 }
-
-#endif
 
 // =============================================================================
 

--- a/src/chrono_fsi/sph/physics/SphGeneral.cu
+++ b/src/chrono_fsi/sph/physics/SphGeneral.cu
@@ -24,29 +24,26 @@ namespace chrono {
 namespace fsi {
 namespace sph {
 
-#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
 static void CopyParametersToDevice_SphGeneral(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
     gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
     gpuCheckError();
     gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
     gpuCheckError();
 }
-#endif
 
+// Upload the parameter and counter blocks to EVERY translation unit's copy of the
+// device constants. The symbols are translation-unit local (see SphGeneral.cuh), on
+// CUDA as well as HIP, so writing only one of them would leave the kernels compiled
+// in the other translation units reading stale parameters. That is invisible during
+// Initialize, where each subsystem uploads its own copy, but not for a parameter
+// update issued while the simulation is running.
 void CopyParametersToDevice(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH) {
-#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
     CopyParametersToDevice_SphGeneral(paramsH, countersH);
     CopyParametersToDevice_SphBceManager(paramsH, countersH);
     CopyParametersToDevice_SphCollisionSystem(paramsH, countersH);
     CopyParametersToDevice_SphFluidDynamics(paramsH, countersH);
     CopyParametersToDevice_SphForceWCSPH(paramsH, countersH);
     CopyParametersToDevice_SphForceISPH(paramsH, countersH);
-#else
-    gpuMemcpyToSymbolAsync(paramsD, paramsH.get(), sizeof(ChFsiParamsSPH));
-    gpuCheckError();
-    gpuMemcpyToSymbolAsync(countersD, countersH.get(), sizeof(Counters));
-    gpuCheckError();
-#endif
 }
 
 //--------------------------------------------------------------------------------------------------------------------------------

--- a/src/chrono_fsi/sph/physics/SphGeneral.cuh
+++ b/src/chrono_fsi/sph/physics/SphGeneral.cuh
@@ -54,13 +54,15 @@ __constant__ static ChFsiParamsSPH paramsD;
 __constant__ static Counters countersD;
 #endif
 
-#if defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
+// Per-translation-unit parameter uploads: each of these writes the paramsD and
+// countersD copies belonging to the translation unit it is defined in, and
+// CopyParametersToDevice calls all of them. Required on every backend, since the
+// symbols above are translation-unit local.
 void CopyParametersToDevice_SphBceManager(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
 void CopyParametersToDevice_SphCollisionSystem(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
 void CopyParametersToDevice_SphFluidDynamics(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
 void CopyParametersToDevice_SphForceWCSPH(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
 void CopyParametersToDevice_SphForceISPH(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
-#endif
 
 void CopyParametersToDevice(std::shared_ptr<ChFsiParamsSPH> paramsH, std::shared_ptr<Counters> countersH);
 


### PR DESCRIPTION
Follow-up to #783, which is merged but only effective on HIP. Fixes the CUDA failure of
`utest_FSI-SPH_domain_update` that @rserban reported on Windows.


## What is wrong

`paramsD` and `countersD` are declared `__constant__ static` in `SphGeneral.cuh:52`, so every
device translation unit holds its own copy. That is true on CUDA as well as HIP, and the comment
above the declaration says so.

During `Initialize` this is invisible, because each subsystem uploads to its own copy
(`SphBceManager.cu:61`, `SphCollisionSystem.cu:315`, `SphFluidDynamics.cu:67`,
`SphForceISPH.cu:920`, `SphForceWCSPH.cu:545`, and `SphGeneral`'s through
`SphForce::Initialize`). It stops being invisible as soon as a parameter is updated while the
simulation is running: `CopyParametersToDevice` fanned out to all six translation-unit copies
only under HIP, while the CUDA branch wrote a single symbol, the copy belonging to
`SphGeneral.cu`.

Nothing depended on that until #783. Before it, every configuration setter was
pre-initialization only, so no runtime parameter update existed and the asymmetry was latent.
#783 added the first one: `SetComputationalDomain` after `Initialize`, for the CRMTerrain moving
patch. It goes through `CopyParametersToDevice`, so on CUDA the updated domain never reaches the
copies read by `calcHashD` in `SphCollisionSystem.cu` or by the periodic-boundary kernel in
`SphFluidDynamics.cu`. The patch keeps binning against the domain fixed at `Initialize` and
particles outside the new domain are never wrapped, which is the pre-#783 behavior. So #783 works
on HIP and does nothing on CUDA, and its unit test fails on a CUDA build, which is exactly what
the test was written to detect.

## Change

Remove the backend guards so the per-translation-unit fan-out is unconditional, and delete the
single-copy CUDA branch. Seven files, 10 insertions, 26 deletions: five guard pairs around the
`CopyParametersToDevice_*` helpers, the guard around the `SphGeneral` helper, the `#if/#else` in
the aggregator, and the guard around the declarations in the header.

Cost: five extra symbol copies per call. All four call sites are constructors or `Initialize`
(`SphForce.cu:38`, `SphForceWCSPH.cu:534`, `SphForceISPH.cu:886`) plus the domain update from
#783 (`ChFsiFluidSystemSPH.cpp:1439`), so nothing per step. In the moving-patch traverse the
domain update fires about eleven times per second of simulated time.

Any future runtime parameter change now reaches every translation unit on both backends, rather
than silently applying on one and not the other.

## Localizing the defect before fixing it

The diagnosis does not rest on reading the preprocessor. On the HIP build the fan-out was reduced
to the same single copy the CUDA branch used, then rebuilt and run against the unchanged unit
test on an MI350X. It failed three checks:

```
before update: fluid x in [-0.05, 0.05]
after  update: fluid x in [-0.05, 0.05], wrapped particles: 0
FAIL:           particles wrapped to the far end of the new domain (device saw the update)
FAIL:           no fluid particle below the new lower x-boundary
  ok:            no fluid particle beyond the new upper x-boundary
  ok:            wrap distance equals the domain period
  ok (rejected): post-init domain update that changes the domain size in x
  ok (rejected): post-init domain update that changes the domain size in y
  ok (rejected): post-init domain update that changes the domain size in z
  ok (rejected): post-init domain update that changes the BC types
  ok:            stepping continues after rejected updates
  ok:            25 successive translations accepted, stepping continues
FAIL:           fluid inside the final domain after the traverse

3 failure(s)
```

The three failures are the device-observable checks; the host-side safety rails pass. That
isolates the failure to the parameter-upload path rather than to the backend or to the test. If
the Windows failure shows these same three checks failing and the rest passing, it is the same
mechanism.

## Validation

MI350X (gfx950), ROCm 7.2, gcc 12.2, Release, single and double precision:

1. `utest_FSI-SPH_domain_update`: all checks pass in both precisions.
2. `utest_FSI-SPH_setter_guard` (from #782): 37 checks, 0 failures, both precisions.
3. CRMTerrain moving-patch vehicle traverse: completes 4.17 m with 34 patch relocations.
4. Geostatic settling benchmark, 106k particles: slope/gamma 0.991, rms 3.6%, unchanged.

Also verified on CUDA, on an NVIDIA RTX PRO 6000 Blackwell (compute capability 12.0, driver
595.71.05) with CUDA 12.9 and gcc 14.3, Release, `CH_USE_SPH_DOUBLE=OFF`. One build tree, one
test binary, with only the three Chrono shared libraries swapped between runs and `ldd` checked
each time to confirm which were loaded:

5. Before, upstream `main` at `5ccb1ce1b`: 3 of 11 checks fail, `wrapped particles: 0`, the
   fluid stays in its original x range while the domain moves away from it.
6. After, the same tree plus this change: all checks pass, `wrapped particles: 198`, the bed
   ends inside the final domain.

The three failures are exactly the device-observable checks, and they are the same three that
the HIP-side experiment above predicted, so the mechanism is confirmed by two independent
routes. Full output is posted as a comment on the PR. Build detail: `CHRONO_CUDA_ARCHITECTURES`
resolved to `all-major`, so the kernels ran on sm_120 via PTX JIT rather than from an sm_120
binary, which affects neither the mechanism nor the result.
