### PR TITLE
Update the documented name of the FMU testing CMake option

### DIFF
--- a/src/demos/fmi/README.md
+++ b/src/demos/fmi/README.md
@@ -34,7 +34,7 @@ For additional examples of Chrono-based FMUs, see the Chrono::Vehicle [FMI demos
 ## FMU export compatibility information
 
 During export, any FMU generated with fmu-forge can be automatically tested with the `fmusim` validation tool (see [Reference-FMUs](https://github.com/modelica/Reference-FMUs)).<br>
-This option, available for both FMI 2.0 and FMI 3.0, can be enabled by setting the `FMU_TESTING` CMake variable to `ON`. See for example [CMakeLists.txt](https://github.com/projectchrono/fmu-forge/blob/01cda9654dc48adbd310267de1915a11f369e250/examples/fmi2/cosimulation/CMakeLists.txt#L10) for the FMI 2.0 co-simulation examples.<br>
+This option, available for both FMI 2.0 and FMI 3.0, can be enabled by setting the `CH_ENABLE_FMU_TESTING` CMake variable to `ON`. See for example [CMakeLists.txt](https://github.com/projectchrono/fmu-forge/blob/01cda9654dc48adbd310267de1915a11f369e250/examples/fmi2/cosimulation/CMakeLists.txt#L10) for the FMI 2.0 co-simulation examples.<br>
 All Chrono example FMUs provided here have been validated with `fmusim`. 
 
 The two FMI 2.0 CS FMUs for a [double-pendulum crane](https://github.com/projectchrono/chrono/tree/main/src/demos/fmi/cosim/fmu2_crane) and a [hydraulic actuator](https://github.com/projectchrono/chrono/tree/main/src/demos/fmi/cosim/fmu2_actuator) have been imported and co-simulated using [Simulink](https://mathworks.com/products/simulink.html).<br>


### PR DESCRIPTION
Commit 0977511768 ("Clean up Chrono::FMI-related CMake variables") renamed the user-facing FMU testing option from FMU_TESTING to CH_ENABLE_FMU_TESTING, but src/demos/fmi/README.md was not updated and still instructs the reader to set FMU_TESTING.

Following the README as written now has no effect. Each generated FMU's own CMakeLists.txt bridges to the fmu-forge internal variable with set(FMU_TESTING ${CH_ENABLE_FMU_TESTING}), so a FMU_TESTING value supplied on the command line is overwritten during configuration. That option also now defaults to OFF, so a reader who wants fmusim validation and follows the current text silently gets no validation at all.

Only the documented name of the cache option is corrected. The internal FMU_TESTING variable used by fmu-forge is left alone.