### PR TITLE
FSI-SPH: fix the double-precision launch configuration (blocks of 256, not 1024)

### DIFF
--- a/src/chrono_fsi/sph/physics/SphForceWCSPH.cu
+++ b/src/chrono_fsi/sph/physics/SphForceWCSPH.cu
@@ -545,9 +545,23 @@ void SphForceWCSPH::Initialize() {
 
 void SphForceWCSPH::ForceSPH(std::shared_ptr<SphMarkerDataD> sortedSphMarkersD, Real time, Real step) {
     // Calculate GPU execution configuration
-    // All kernels in SphForceWCSPH work on a total of numExtendedParticles threads, in blocks of size 1024 (or 256)
+    // All kernels in SphForceWCSPH work on a total of numExtendedParticles threads, in blocks of size 256.
+    //
+    // The block size is not free to choose. On CUDA devices a thread block shares a fixed pool of 65536
+    // registers, so the most a thread may use is roughly 65536 / blockSize, before allocation granularity.
+    // That figure was queried from the device rather than assumed, on compute capability 12.0, and the
+    // compiler reports the same 64-register ceiling for sm_80, sm_90 and sm_120 when told the block size
+    // is 1024. At 1024 threads it leaves 64 registers per thread, and the boundary-condition kernels here
+    // (CrmHolmesBC, CrmAdamiBC, CfdHolmesBC, CfdAdamiBC, calcKernelSupport) need 68 to 96 once Real is
+    // double, so in double precision they cannot be launched at all: every step fails with "too many
+    // resources requested for launch". At 256 they have 256 registers available and fit easily.
+    //
+    // HIP organises its register file differently and does launch these at 1024, so this is not a fix for
+    // the AMD backend. It was measured there anyway, since the change applies to both: on MI350X at 1024,
+    // 512 and 256, in both precisions, the difference is below run-to-run scatter. 256 is also already what
+    // CrmRHS and CfdRHS use below, so this makes the file consistent rather than introducing a third value.
     numActive = (uint)m_data_mgr.countersH->numExtendedParticles;
-    computeGridSize(numActive, 1024, numBlocks, numThreads);
+    computeGridSize(numActive, 256, numBlocks, numThreads);
 
     //
     m_bce_mgr.updateBCEAcc();
@@ -1980,7 +1994,8 @@ __global__ void Calc_Shifting_D(Real3* vel_XSPH_Sorted_D,
 void SphForceWCSPH::CalculateShifting(std::shared_ptr<SphMarkerDataD> sortedSphMarkersD) {
     gpuResetErrorFlag(m_errflagD);
 
-    computeGridSize(numActive, 1024, numBlocks, numThreads);
+    // 256 rather than 1024, for the register-budget reason given in ForceSPH above.
+    computeGridSize(numActive, 256, numBlocks, numThreads);
 
     thrust::fill(m_data_mgr.vel_XSPH_D.begin(), m_data_mgr.vel_XSPH_D.begin() + numActive, mR3(0));
 


### PR DESCRIPTION
Chrono::SPH cannot run in double precision on CUDA. Every step dies in SphForceWCSPH.cu with "too many resources requested for launch".

The cause is a register budget rather than a defect in any kernel. A thread block shares a fixed pool of 65536 registers, so the most a thread may use is 65536 divided by the block size. ForceSPH and CalculateShifting each request 1024 threads per block, which leaves 64 registers per thread, and that setting applies to every launch until the next computeGridSize call: calcRho_kernel and the boundary-condition kernels in the first case, the Calc_Shifting_D variants in the second.

Compiled with Real = double those kernels need more than 64: calcKernelSupport 68, CfdAdamiBC 80, CfdHolmesBC 88, CrmAdamiBC 92, CrmHolmesBC 96, measured on sm_120. Every one exceeds the budget, so none can be launched. On sm_90 the same kernels need 77 to 114, so restricting the architecture list does not help either. In single precision they need 41 to 56, which fits under 64, and that is why this has gone unnoticed. Two of the five are CRM kernels, so the CRM solver is affected as well as CFD.

The fix requests 256 threads per block, which gives 256 registers per thread. That is not a new number in this file: CrmRHS and CfdRHS already use 256, and these two sites were the outliers.

Cost, measured because it applies to every user and not only to the broken configuration: none that is detectable, and stated with the scope of what was actually measured. On MI350X, the periodic Poiseuille regression with 7 interleaved repeats per side at 1024, 512 and 256 differs by less than the run-to-run scatter in both precisions. On an RTX 5090 the same regression at 1024 against 256 in single precision differs by 0.18%, with the sign varying from round to round. Two separate MI350X jobs disagreed on the sign, which is how one knows this is noise rather than signal: the scatter is around 0.5% and swamps anything smaller. Not measured: any production-size case, and on CUDA any double-precision comparison, since 1024 does not run there at all.

Scope of the change, checked rather than assumed. numThreads and numBlocks are members, so each computeGridSize call sets the block size for every launch until the next one: from ForceSPH that is calcRho_kernel and the boundary-condition kernels, from CalculateShifting it is the Calc_Shifting_D variants. What makes that safe is a property of the whole file, counted rather than eyeballed: SphForceWCSPH.cu contains zero __shared__ declarations, zero __syncthreads, zero atomics, zero warp primitives (shfl, ballot, any, all, cooperative groups), zero thrust reductions, zero uses of gridDim and no grid-stride loops. All fourteen uses of threadIdx are the same blockIdx.x * blockDim.x + threadIdx.x global index, and each kernel writes its own element of that index. So none of the constructs by which a kernel's output can depend on how its threads are grouped is present here. That is an absence of every known mechanism rather than a proof of impossibility, and it is the basis for the claim.

Validated on MI350X (gfx950, ROCm 7.2) and on an RTX 5090 (nvcc 12.9, host g++ 13.3), both precisions, against the full FSI-SPH unit test set. In double precision on CUDA every test passes where before no kernel could launch, and the results agree with the HIP double-precision reference to every printed digit.

One note for anyone reproducing a double-precision CUDA build: it also fails to compile under the default architecture list, because SphBceManager.cu calls atomicAdd on double, which CUDA declares only for compute capability 60 and above, while all-major includes sm_50. Naming an architecture explicitly, for example -DCHRONO_CUDA_ARCHITECTURES=native, gets past it, and a CUDA 13 toolkit has no sm_50 in that list at all. That is a separate issue and this change leaves it alone.