### PR TITLE
FSI-SPH: initialize SPHParameters::shifting_method, fix doc defaults

### DIFF
--- a/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
@@ -436,7 +436,7 @@ void ChFsiFluidSystemSPH::CheckSPHParameters() {
 
     // Check shifting method and whether defaults have changed
     if (m_paramsH->shifting_method == ShiftingMethod::NONE) {
-        if (m_paramsH->shifting_xsph_eps != 0.5 || m_paramsH->shifting_ppst_push != 1.0 || m_paramsH->shifting_ppst_pull != 1.0) {
+        if (m_paramsH->shifting_xsph_eps != 0.5 || m_paramsH->shifting_ppst_push != 3.0 || m_paramsH->shifting_ppst_pull != 1.0) {
             cerr << "WARNING: Shifting method is NONE, but shifting parameters have been modified. These "
                     "changes will not take effect."
                  << endl;
@@ -522,6 +522,7 @@ ChFsiFluidSystemSPH::SPHParameters::SPHParameters()
       initial_spacing(0.01),
       d0_multiplier(1.2),
       max_velocity(1.0),
+      shifting_method(ShiftingMethod::XSPH),
       shifting_xsph_eps(0.5),
       shifting_ppst_push(3.0),
       shifting_ppst_pull(1.0),

--- a/src/chrono_fsi/sph/ChFsiFluidSystemSPH.h
+++ b/src/chrono_fsi/sph/ChFsiFluidSystemSPH.h
@@ -83,7 +83,7 @@ class CH_FSI_API ChFsiFluidSystemSPH : public ChFsiFluidSystem {
         EosType eos_type;                              ///< equation of state (default: ISOTHERMAL)
         ViscosityMethod viscosity_method;              ///< viscosity treatment (default: ARTIFICIAL_UNILATERAL)
         BoundaryMethod boundary_method;                ///< boundary treatment (default: ADAMI)
-        KernelType kernel_type;                        ///< kernel type (default: CUBIC_CPLINE)
+        KernelType kernel_type;                        ///< kernel type (default: CUBIC_SPLINE)
         ShiftingMethod shifting_method;                ///< shifting method (default: XSPH)
         int num_bce_layers;                            ///< number of BCE layers (boundary and solids, default: 3)
         double initial_spacing;                        ///< initial particle spacing (default: 0.01)
@@ -93,7 +93,7 @@ class CH_FSI_API ChFsiFluidSystemSPH : public ChFsiFluidSystem {
         double shifting_ppst_push;                     ///< PPST pushing coefficient (default: 3.0)
         double shifting_ppst_pull;                     ///< shifting beta coefficient (default: 1.0)
         double shifting_beta_implicit;                 ///< shifting coefficient used in implicit solver (default: 1.0)
-        double shifting_diffusion_A;                   ///< shifting coefficient used in diffusion (default: 2.0, range 1 to 6)
+        double shifting_diffusion_A;                   ///< shifting coefficient used in diffusion (default: 1.0, range 1 to 6)
         double shifting_diffusion_AFSM;                ///< shifting coefficient used in diffusion (default: 3.0)
         double shifting_diffusion_AFST;                ///< shifting coefficient used in diffusion (default: 2.0)
         double min_distance_coefficient;               ///< min inter-particle distance as fraction of kernel radius (default: 0.01)
@@ -108,7 +108,7 @@ class CH_FSI_API ChFsiFluidSystemSPH : public ChFsiFluidSystem {
                                                        ///< field is computed and compared to this threshold. Particles with divergence
                                                        ///< less than this threshold are considered free surface particles (CRM only,
                                                        ///< default: 2.0)
-        int num_proximity_search_steps;                ///< number of steps between updates to neighbor lists (default: 4)
+        int num_proximity_search_steps;                ///< number of steps between updates to neighbor lists (default: 1)
         bool use_variable_time_step;                   ///< use variable time step (default: false)
 
         SPHParameters();

--- a/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_setter_guard.cpp
+++ b/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_setter_guard.cpp
@@ -23,6 +23,8 @@
 //    domain mid-simulation; the output level is a host-only setting).
 // 4. The system still advances after the rejected calls (no partial state
 //    mutation).
+// 5. A default-constructed SPHParameters holds the defaults its documentation
+//    states (shifting_method was not initialized at all).
 //
 // =============================================================================
 
@@ -68,7 +70,33 @@ void ExpectNoThrow(const std::string& name, std::function<void()> f) {
     }
 }
 
+// A default-constructed SPHParameters must actually hold the defaults its documentation states.
+// shifting_method was missing from the constructor's initializer list, so reading it was undefined
+// behavior and the documented default of XSPH was never applied to anything. The other three below
+// are the values whose doc comments disagreed with the constructor.
+void CheckDefaults() {
+    ChFsiFluidSystemSPH::SPHParameters defaults;
+
+    auto check = [](const std::string& name, bool ok) {
+        if (ok) {
+            std::cout << "  ok (default):  " << name << std::endl;
+        } else {
+            std::cout << "FAIL (default): " << name << std::endl;
+            num_failures++;
+        }
+    };
+
+    check("shifting_method == XSPH", defaults.shifting_method == ShiftingMethod::XSPH);
+    check("kernel_type == CUBIC_SPLINE", defaults.kernel_type == KernelType::CUBIC_SPLINE);
+    check("shifting_diffusion_A == 1.0", defaults.shifting_diffusion_A == 1.0);
+    check("num_proximity_search_steps == 1", defaults.num_proximity_search_steps == 1);
+}
+
 int main(int argc, char* argv[]) {
+    std::cout << "Documented SPHParameters defaults:" << std::endl;
+    CheckDefaults();
+    std::cout << std::endl;
+
     // Create the FSI problem (same minimal setup as utest_FSI-SPH_Poiseuille_flow)
     ChSystemSMC sysMBS;
     ChFsiProblemCartesian fsi(initial_spacing, &sysMBS);


### PR DESCRIPTION
`SPHParameters::SPHParameters()` set 27 of its 28 members and skipped `shifting_method`, which has
no default member initializer either. So a default-constructed `SPHParameters` carried an
indeterminate shifting selection into `SetSPHParameters()`, and the documented default of XSPH was
never applied by anything. One line fixes it.

These construct `SPHParameters` without assigning it, so they were all reading it uninitialized:

```
src/demos/fsi/sph/demo_FSI-SPH_CouetteFlow.cpp
src/demos/robot/viper/demo_ROBOT_Viper_CRM.cpp
src/demos/sensor/demo_SEN_CRM_Rendering.cpp
src/demos/vehicle/terrain/demo_VEH_CRMTerrain_MovingPatch.cpp
src/demos/vehicle/terrain/demo_VEH_CRMTerrain_WheeledVehicle.cpp
src/tests/unit_tests/fsi/sph/utest_FSI-SPH_rheology_error_flag.cpp
```

It turned up because two builds of the same source, differing only in `CH_USE_SPH_DOUBLE`, took
different branches on that member. More detail in the issue.

Also here, since it is the same drift between the doc comments and the constructor:

- The `ShiftingMethod::NONE` branch of `CheckSPHParameters` compared `shifting_ppst_push` against
  `1.0` when the default is `3.0`, so it told everyone who selected `NONE` that they had modified
  shifting parameters. The XSPH branch just below already compared against `3.0`. The unit
  test suite printed that false warning 17 times per run; it is now 0.
- Three comments corrected to match the constructor: `num_proximity_search_steps` said 4 and is 1,
  `shifting_diffusion_A` said 2.0 and is 1.0, `kernel_type` said `CUBIC_CPLINE`.

The comments were changed to match the code rather than the reverse, because the code is what runs
and changing those two numbers would alter behavior for existing users. If either was meant to be
the documented value, that is a separate and deliberate change. Worth knowing for
`num_proximity_search_steps`: at 1, neighbor lists are rebuilt every step.

One thing to check on my side: every CRM demo that sets `shifting_method` explicitly picks
`PPST_XSPH`, not `XSPH`. I used the documented value. If XSPH is not the default you want, say so.

`utest_FSI-SPH_setter_guard` now checks that a default-constructed `SPHParameters` holds these four
documented defaults.

Validated on an MI350X in both single and double precision: all five FSI-SPH unit tests pass in
each, and the false-warning count across the whole suite goes from 17 per run to 0 in both.

On the demos, precisely, since this changes their behavior from "whatever was in memory" to XSPH:
two of the five were exercised, `demo_FSI-SPH_CouetteFlow` and
`demo_VEH_CRMTerrain_WheeledVehicle`, both of which run to completion with no false warning. The
other three were not built in a headless configuration: `demo_ROBOT_Viper_CRM` and
`demo_VEH_CRMTerrain_MovingPatch` are gated on `CH_ENABLE_MODULE_VSG`, and `demo_SEN_CRM_Rendering`
on the sensor module. If your CI covers those, that is the gap worth checking.

Closes #797.