### PR TITLE
Sensor: shade material-less shapes with Chrono's default material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log
 ==========
 
 - [Unreleased (development branch)](#unreleased-development-branch)
+  - [\[Changed\] Chrono::Sensor appearance of shapes with no visual material](#changed-chronosensor-appearance-of-shapes-with-no-visual-material)
 - [Release 10.0.0 (2026-03-27)](#release-1000-2026-03-27)
   - [\[Changed\] Python support in conda packages](#changed-python-support-in-conda-packages)
   - [\[Added\] PyChrono-NumPy integration](#added-pychrono-numpy-integration)
@@ -128,6 +129,37 @@ Change Log
 - [Release 4.0.0 (2019-02-22)](#release-400-2019-02-22)
 
 # Unreleased (development branch) 
+
+## [Changed] Chrono::Sensor appearance of shapes with no visual material
+
+A visual shape that carries no `ChVisualMaterial` is now rendered by Chrono::Sensor with
+`ChVisualMaterial::Default()`, the same material `ChVisualShape::GetColor()` reports for an empty
+material list and the same one the Irrlicht and VSG run-time visualization systems use. The OptiX
+backend previously built its own default from literals, a 0.5 grey with roughness 1, which had
+drifted from the shared default and made a material-less shape render about twice as dark under
+Chrono::Sensor as under the other visualization systems.
+
+**This changes rendered output.** Any scene containing a shape with no explicit material, including
+a scene deserialized from a file saved with an empty material list, now renders brighter (diffuse
+1.0 white instead of 0.5 grey) and glossier (roughness 0 instead of 1). Two standard helpers were
+also inconsistent with each other and are now consistent: `chrono::utils::AddBoxGeometry` attaches
+`ChVisualMaterial::Default()` through a default argument, while `ChBodyEasyBox` attaches nothing, so
+the same box rendered white through one path and grey through the other.
+
+To keep the previous appearance, attach an explicit material rather than relying on the default:
+
+```cpp
+auto mat = chrono_types::make_shared<ChVisualMaterial>();
+mat->SetDiffuseColor({0.5f, 0.5f, 0.5f});
+mat->SetRoughness(1.0f);
+shape->AddMaterial(mat);
+```
+
+Note that the material the OptiX backend uploads is a snapshot taken when the device-side material
+pool is built, not a live reference to the singleton. That happens when the sensor scene is
+constructed, on the first sensor update, and not again, so mutating `ChVisualMaterial::Default()`
+after that point has no effect on what a sensor renders. Mutating it at all is unsupported and
+always was: it is shared by every material-less shape in the scene.
 
 # Release 10.0.0 (2026-03-27)
 

--- a/doxygen/documentation/manuals/sensor/sensor_overview.md
+++ b/doxygen/documentation/manuals/sensor/sensor_overview.md
@@ -30,6 +30,7 @@ The Chrono::Sensor module provides support for simulating RGB cameras, lidar, ra
 		 - Fresnel effect
 		 - Mesh support based on Wavefront OBJ+MTL format
 		 - Programmatic material creation
+		 - A shape carrying no ChVisualMaterial is rendered with ChVisualMaterial::Default(), the same material the Irrlicht and VSG visualization systems use for such a shape. The values are copied into the device-side material pool when the scene is built, on the first sensor update, so mutating the shared default after that has no effect on what a sensor renders.
 		 - Legacy integrator supports partial transparency without refractance
 	 - Objects
 		 - Box primitives

--- a/src/chrono/assets/ChVisualMaterial.cpp
+++ b/src/chrono/assets/ChVisualMaterial.cpp
@@ -36,7 +36,20 @@ ChVisualMaterial::ChVisualMaterial()
       class_id(0),
       instance_id(0),
       emissive_power(0.f),
-      bsdf_type(BSDFType::PRINCIPLED) {} 
+      bsdf_type(BSDFType::PRINCIPLED),
+      // The Hapke members are only meaningful once SetHapkeParameters and SetBSDF(HAPKE) have
+      // both been called, but they must still be initialized here. Consumers read them
+      // unconditionally: ChOptixPipeline::GetMaterial copies all seven into its device-side
+      // material struct for every material it converts, without testing bsdf_type first. Leaving
+      // them out of this list made that a read of indeterminate values.
+      use_hapke(false),
+      hapke_w(0.f),
+      hapke_b(0.f),
+      hapke_c(0.f),
+      hapke_B_s0(0.f),
+      hapke_h_s(0.f),
+      hapke_phi(0.f),
+      hapke_theta_p(0.f) {}
 
 void ChVisualMaterial::SetKdTexture(const std::string& filename) {
     kd_texture.SetFilename(filename);
@@ -226,13 +239,12 @@ void ChVisualMaterial::ArchiveIn(ChArchiveIn& archive_in) {
 
 // -----------------------------------------------------------------------------
 
-static std::shared_ptr<ChVisualMaterial> default_material;
-
 std::shared_ptr<ChVisualMaterial> ChVisualMaterial::Default() {
-    if (!default_material) {
-        default_material = chrono_types::make_shared<ChVisualMaterial>();
-    }
-
+    // Function-local static, not a namespace-scope one guarded by an if. C++11 guarantees that
+    // initialization of a function-local static is thread-safe; the previous
+    // "if (!default_material) default_material = ..." on a namespace-scope pointer was not, and
+    // Chrono::Sensor calls this from its own scene thread.
+    static std::shared_ptr<ChVisualMaterial> default_material = chrono_types::make_shared<ChVisualMaterial>();
     return default_material;
 }
 

--- a/src/chrono/assets/ChVisualMaterial.h
+++ b/src/chrono/assets/ChVisualMaterial.h
@@ -143,6 +143,18 @@ class ChApi ChVisualMaterial {
     virtual void ArchiveIn(ChArchiveIn& archive_in);
 
     /// Create a default material.
+    /// This is the shared material that describes a visual shape carrying no material of its own. It
+    /// is what ChVisualShape::GetColor() reports for an empty material list, and what the Irrlicht,
+    /// VSG and Sensor rendering backends all use for such a shape. Every call returns the same
+    /// object.
+    ///
+    /// Do not mutate what this returns. The pointer is non-const only because attaching a material to
+    /// a shape takes a non-const shared_ptr; a setter called on this object would change the
+    /// appearance of every material-less shape in every scene. ChVisualShape's own setters copy it
+    /// before writing for exactly that reason (see ChVisualShape::SetColor). Chrono::Sensor copies
+    /// the values into a device-side material pool when it builds its scene, which happens on the
+    /// first sensor update and not again, so a mutation after that point would additionally make the
+    /// CPU-side and GPU-side pictures disagree.
     static std::shared_ptr<ChVisualMaterial> Default();
 
   private:

--- a/src/chrono_sensor/optix/ChOptixPipeline.cpp
+++ b/src/chrono_sensor/optix/ChOptixPipeline.cpp
@@ -785,128 +785,113 @@ CUdeviceptr ChOptixPipeline::GetMaterialPool() {
     return md_material_pool;
 }
 
+MaterialParameters ChOptixPipeline::MakeMaterialParameters(const ChVisualMaterial& mat) {
+    // Value-initialized. MaterialParameters has no default member initializers, so a bare
+    // local leaves any field this function does not assign holding whatever was on the stack,
+    // and the struct is memcpy'd straight into the device material pool. With `{}` an omission
+    // costs a zero instead of a random number. The old hardcoded default branch omitted
+    // anisotropy and theta_p exactly this way.
+    MaterialParameters material{};
+    material.Kd = {mat.GetDiffuseColor().R, mat.GetDiffuseColor().G, mat.GetDiffuseColor().B};
+    material.Ks = {mat.GetSpecularColor().R, mat.GetSpecularColor().G, mat.GetSpecularColor().B};
+    material.Ke = {mat.GetEmissiveColor().R, mat.GetEmissiveColor().G, mat.GetEmissiveColor().B};
+    material.fresnel_exp = mat.GetFresnelExp();
+    material.fresnel_min = mat.GetFresnelMin();
+    material.fresnel_max = mat.GetFresnelMax();
+    material.transparency = mat.GetOpacity();
+    material.roughness = mat.GetRoughness();
+    material.metallic = mat.GetMetallic();
+    material.anisotropy = mat.GetAnisotropy();
+    material.use_specular_workflow = mat.GetUseSpecularWorkflow();
+    material.lidar_intensity = 1.f;    // TODO: allow setting of this in the visual material chrono-side
+    material.radar_backscatter = 1.f;  // TODO: allow setting of this in the visual material chrono-side
+    material.kn_tex = 0;               // explicitely null as default
+    material.kd_tex = 0;               // explicitely null as default
+    material.ks_tex = 0;               // explicitely null as default
+    material.ke_tex = 0;               // explicitely null as default
+    material.metallic_tex = 0;         // explicitely null as default
+    material.roughness_tex = 0;        // explicitely null as default
+    material.opacity_tex = 0;          // explicitely null as default
+    material.weight_tex = 0;
+    material.class_id = mat.GetClassID();
+    material.instance_id = mat.GetInstanceID();
+
+    material.w = mat.GetHapkeW();
+    material.b = mat.GetHapkeB();
+    material.c = mat.GetHapkeC();
+    material.B_s0 = mat.GetHapkeBs0();
+    material.h_s = mat.GetHapkeHs();
+    material.phi = mat.GetHapkePhi();
+    material.theta_p = mat.GetHapkeRoughness();
+
+    material.tex_scale = {mat.GetTextureScale().x(), mat.GetTextureScale().y()};
+    material.emissive_power = mat.GetEmissivePower();
+    material.bsdf_type = mat.GetBSDF();
+
+    // normal texture
+    if (mat.GetNormalMapTexture() != "") {
+        cudaArray_t d_img_array;
+        CreateDeviceTexture(material.kn_tex, d_img_array, mat.GetNormalMapTexture());
+    }
+    // diffuse texture
+    if (mat.GetKdTexture() != "") {
+        cudaArray_t d_img_array;
+        CreateDeviceTexture(material.kd_tex, d_img_array, mat.GetKdTexture());
+    }
+    // specular texture
+    if (mat.GetKsTexture() != "") {
+        cudaArray_t d_img_array;
+        CreateDeviceTexture(material.ks_tex, d_img_array, mat.GetKsTexture());
+    }
+
+    // metallic texture
+    if (mat.GetMetallicTexture() != "") {
+        cudaArray_t d_img_array;
+        CreateDeviceTexture(material.metallic_tex, d_img_array, mat.GetMetallicTexture());
+    }
+    // roughness texture
+    if (mat.GetRoughnessTexture() != "") {
+        cudaArray_t d_img_array;
+        CreateDeviceTexture(material.roughness_tex, d_img_array, mat.GetRoughnessTexture());
+    }
+    // opacity texture
+    if (mat.GetOpacityTexture() != "") {
+        cudaArray_t d_img_array;
+        CreateDeviceTexture(material.opacity_tex, d_img_array, mat.GetOpacityTexture());
+    }
+    // weight texture
+    if (mat.GetWeightTexture() != "") {
+        cudaArray_t d_img_array;
+        CreateDeviceTexture(material.weight_tex, d_img_array, mat.GetWeightTexture());
+    }
+    return material;
+}
+
 unsigned int ChOptixPipeline::GetMaterial(std::shared_ptr<ChVisualMaterial> mat) {
-    if (mat) {
-        MaterialParameters material;
-        material.Kd = {mat->GetDiffuseColor().R, mat->GetDiffuseColor().G, mat->GetDiffuseColor().B};
-        material.Ks = {mat->GetSpecularColor().R, mat->GetSpecularColor().G, mat->GetSpecularColor().B};
-        material.Ke = {mat->GetEmissiveColor().R, mat->GetEmissiveColor().G, mat->GetEmissiveColor().B};
-        material.fresnel_exp = mat->GetFresnelExp();
-        material.fresnel_min = mat->GetFresnelMin();
-        material.fresnel_max = mat->GetFresnelMax();
-        material.transparency = mat->GetOpacity();
-        material.roughness = mat->GetRoughness();
-        material.metallic = mat->GetMetallic();
-        material.anisotropy = mat->GetAnisotropy();
-        material.use_specular_workflow = mat->GetUseSpecularWorkflow();
-        material.lidar_intensity = 1.f;    // TODO: allow setting of this in the visual material chrono-side
-        material.radar_backscatter = 1.f;  // TODO: allow setting of this in the visual material chrono-side
-        material.kn_tex = 0;               // explicitely null as default
-        material.kd_tex = 0;               // explicitely null as default
-        material.ks_tex = 0;               // explicitely null as default
-        material.ke_tex = 0;               // explicitely null as default
-        material.metallic_tex = 0;         // explicitely null as default
-        material.roughness_tex = 0;        // explicitely null as default
-        material.opacity_tex = 0;          // explicitely null as default
-        material.weight_tex = 0;
-        material.class_id = mat->GetClassID();
-        material.instance_id = mat->GetInstanceID();
-
-        material.w = mat->GetHapkeW();
-        material.b = mat->GetHapkeB();
-        material.c = mat->GetHapkeC();
-        material.B_s0 = mat->GetHapkeBs0();
-        material.h_s = mat->GetHapkeHs();
-        material.phi = mat->GetHapkePhi();
-        material.theta_p = mat->GetHapkeRoughness();
-
-        material.tex_scale = {mat->GetTextureScale().x(), mat->GetTextureScale().y()};
-        material.emissive_power = mat->GetEmissivePower();
-        material.bsdf_type = mat->GetBSDF();
-
-        // normal texture
-        if (mat->GetNormalMapTexture() != "") {
-            cudaArray_t d_img_array;
-            CreateDeviceTexture(material.kn_tex, d_img_array, mat->GetNormalMapTexture());
-        }
-        // diffuse texture
-        if (mat->GetKdTexture() != "") {
-            cudaArray_t d_img_array;
-            CreateDeviceTexture(material.kd_tex, d_img_array, mat->GetKdTexture());
-        }
-        // specular texture
-        if (mat->GetKsTexture() != "") {
-            cudaArray_t d_img_array;
-            CreateDeviceTexture(material.ks_tex, d_img_array, mat->GetKsTexture());
-        }
-        
-        // metallic texture
-        if (mat->GetMetallicTexture() != "") {
-            cudaArray_t d_img_array;
-            CreateDeviceTexture(material.metallic_tex, d_img_array, mat->GetMetallicTexture());
-        }
-        // roughness texture
-        if (mat->GetRoughnessTexture() != "") {
-            cudaArray_t d_img_array;
-            CreateDeviceTexture(material.roughness_tex, d_img_array, mat->GetRoughnessTexture());
-        }
-        // opacity texture
-        if (mat->GetOpacityTexture() != "") {
-            cudaArray_t d_img_array;
-            CreateDeviceTexture(material.opacity_tex, d_img_array, mat->GetOpacityTexture());
-        }
-        // weight texture
-        if (mat->GetWeightTexture() != "") {
-            cudaArray_t d_img_array;
-            CreateDeviceTexture(material.weight_tex, d_img_array, mat->GetWeightTexture());
-        }
-
-        m_material_pool.push_back(material);
-        return static_cast<unsigned int>(m_material_pool.size() - 1);
-
-    } else {
+    if (!mat) {
+        // A shape with no material of its own is shaded with Chrono's default material: the
+        // one ChVisualShape::GetColor() reports for an empty material list, and the one the
+        // Irrlicht and VSG backends already use. This branch used to build a separate default
+        // from literals (Kd 0.5 grey, roughness 1). That was a deliberate choice in 2021, when
+        // the core default was an unusable Kd = (1.0, 2.0, 2.0); core was corrected to white in
+        // 2022 and this copy was never revisited, so the two silently drifted apart. Going
+        // through the same conversion as an explicit material is what keeps them from drifting
+        // again.
+        //
+        // This is a snapshot, not a live reference: the pool holds values, and the default
+        // material is treated as immutable (ChVisualShape's setters copy it rather than mutate
+        // it). The guard matters because the conversion appends a pool entry every call, so
+        // without it a scene of N material-less shapes would push N identical copies.
         if (!m_default_material_inst) {
-            MaterialParameters material;
-            material.Kd = {.5f, .5f, .5f};
-            material.Ks = {.2f, .2f, .2f};
-            material.Ke = {.0f, .0f, .0f};
-            material.fresnel_exp = 5.f;
-            material.fresnel_min = 0.f;
-            material.fresnel_max = 1.f;
-            material.transparency = 1.f;
-            material.roughness = 1.f;
-            material.metallic = 0.0f;
-            material.lidar_intensity = 1.f;
-            material.radar_backscatter = 1.f;
-            material.kd_tex = 0;
-            material.ks_tex = 0;
-            material.kn_tex = 0;
-            material.ke_tex = 0;
-            material.roughness_tex = 0;
-            material.metallic_tex = 0;
-            material.opacity_tex = 0;
-            material.weight_tex = 0;
-            material.use_specular_workflow = 0;
-            material.w = 0.0f;
-            material.b = 0.0f;
-            material.c = 0.0f;
-            material.B_s0 = 0.0f;
-            material.h_s = 0.0f;
-            material.phi = 0.0f;
-            material.class_id = 0;
-            material.instance_id = 0;
-            material.tex_scale = {1.f, 1.f};
-            material.emissive_power = 0.f;
-            material.pad = {0.f, 0.f, 0.f};
-            material.bsdf_type = BSDFType::PRINCIPLED;
-
-            m_material_pool.push_back(material);
+            m_material_pool.push_back(MakeMaterialParameters(*ChVisualMaterial::Default()));
             m_default_material_id = static_cast<unsigned int>(m_material_pool.size() - 1);
             m_default_material_inst = true;
         }
-
         return m_default_material_id;
     }
+
+    m_material_pool.push_back(MakeMaterialParameters(*mat));
+    return static_cast<unsigned int>(m_material_pool.size() - 1);
 }
 
 unsigned int ChOptixPipeline::GetBoxMaterial(std::vector<std::shared_ptr<ChVisualMaterial>> mat_list) {

--- a/src/chrono_sensor/optix/ChOptixPipeline.h
+++ b/src/chrono_sensor/optix/ChOptixPipeline.h
@@ -192,6 +192,12 @@ class CH_SENSOR_API ChOptixPipeline {
 
     unsigned int GetMaterial(std::shared_ptr<ChVisualMaterial> mat = nullptr);
 
+    /// Translate a Chrono visual material into the device-side material struct.
+    /// Both arms of GetMaterial go through this one function, so that a shape with no material of
+    /// its own is shaded exactly like a shape carrying ChVisualMaterial::Default(). Not static:
+    /// it uploads textures through CreateDeviceTexture.
+    MaterialParameters MakeMaterialParameters(const ChVisualMaterial& mat);
+
     void CreateDeviceTexture(cudaTextureObject_t& d_tex_sampler,
                              cudaArray_t& d_img_array,
                              std::string file_name,
@@ -286,7 +292,10 @@ class CH_SENSOR_API ChOptixPipeline {
 
     // default material in the material pool
     bool m_default_material_inst = false;
-    unsigned int m_default_material_id;
+    // Initialized, though it is only read while the guard above is true, for the same reason the
+    // Hapke members are: a member whose reads happen to be guarded today is still a member someone
+    // will read tomorrow, and a zero is a better wrong answer than whatever was on the heap.
+    unsigned int m_default_material_id = 0;
 
     // bodies in simulation
     std::vector<std::shared_ptr<ChBody>> m_bodies;

--- a/src/tests/unit_tests/sensor/CMakeLists.txt
+++ b/src/tests/unit_tests/sensor/CMakeLists.txt
@@ -3,6 +3,14 @@ set(TESTS
     # Deliberately outside the OptiX block: it tests the seed algebra and identity assignment, not
     # cuRAND, so it must also run in configurations built without OptiX.
     utest_SEN_rng_streams
+    # Also outside the OptiX block: it pins what a shape with no material of its own looks like,
+    # which is the contract every backend must honour, not the GPU code that honours it.
+    utest_SEN_default_material
+    # One test, deliberately in its own executable. ChVisualMaterial::Default() initializes a static
+    # on first call, so a concurrent-first-access test only has something to race over if nothing in
+    # the process has called Default() yet. Sharing a binary with the tests above would leave the
+    # static already built and the test unable to fail; measured, 0 of 200 runs versus 200 of 200.
+    utest_SEN_default_material_firstaccess
 )
 
 if(CH_USE_SENSOR_OPTIX)

--- a/src/tests/unit_tests/sensor/utest_SEN_default_material.cpp
+++ b/src/tests/unit_tests/sensor/utest_SEN_default_material.cpp
@@ -1,0 +1,364 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Dan Negrut
+// =============================================================================
+//
+// What a visual shape with no material of its own looks like.
+//
+// Chrono has one answer to that question, ChVisualMaterial::Default(), and every rendering
+// backend is supposed to use it. The OptiX backend used to keep a second, hardcoded answer
+// (Kd = 0.5 grey, roughness = 1), which drifted from the shared one when the shared one was
+// corrected in 2022. The result was measurable: a material-less box rendered exactly 2x darker
+// under OptiX than under the Vulkan RT backend, and, with no second backend involved at all,
+// two standard Chrono box helpers rendered the same box differently, because
+// chrono::utils::AddBoxGeometry attaches Default() while ChBodyEasyBox attaches nothing.
+//
+// These tests pin the shared answer. They are deliberately CPU-only and live outside the OptiX
+// block in CMakeLists: they test the contract the backends must honour, not the GPU code that
+// honours it, so they must also run in builds without OptiX. The OptiX side is covered by
+// demo_SEN_vulkan_validation --probe-box-material, which needs a GPU.
+//
+// =============================================================================
+
+#include <atomic>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "chrono/assets/ChVisualMaterial.h"
+#include "chrono/assets/ChVisualShapeBox.h"
+#include "chrono/physics/ChBodyEasy.h"
+#include "chrono/physics/ChSystemNSC.h"
+#include "chrono/serialization/ChArchiveJSON.h"
+
+using namespace chrono;
+
+// -----------------------------------------------------------------------------
+// The default material's own values.
+// -----------------------------------------------------------------------------
+
+// The values a backend gets when it asks Chrono what "no material" looks like. Pinned as exact
+// numbers rather than as "whatever the constructor says", because the whole defect was a second
+// copy of these numbers drifting away from the first. A backend that hardcodes its own copy
+// should have to change this test to stay green.
+TEST(DefaultVisualMaterial, has_the_documented_appearance) {
+    auto def = ChVisualMaterial::Default();
+    ASSERT_NE(def, nullptr);
+
+    EXPECT_FLOAT_EQ(def->GetDiffuseColor().R, 1.0f);
+    EXPECT_FLOAT_EQ(def->GetDiffuseColor().G, 1.0f);
+    EXPECT_FLOAT_EQ(def->GetDiffuseColor().B, 1.0f);
+    EXPECT_FLOAT_EQ(def->GetRoughness(), 0.0f);
+    EXPECT_FLOAT_EQ(def->GetMetallic(), 0.0f);
+    EXPECT_FLOAT_EQ(def->GetOpacity(), 1.0f);
+    EXPECT_TRUE(def->GetUseSpecularWorkflow());
+}
+
+// ChVisualShape::GetColor() is the accessor a backend is expected to consult for a shape with an
+// empty material list. It must agree with Default(); if it did not, "use GetColor()" and "use
+// Default()" would be two different policies and backends would split between them.
+TEST(DefaultVisualMaterial, empty_material_list_reports_the_default_color) {
+    ChVisualShapeBox shape(1.0, 1.0, 1.0);
+    ASSERT_EQ(shape.GetNumMaterials(), 0u);
+
+    const ChColor from_shape = shape.GetColor();
+    const ChColor from_default = ChVisualMaterial::Default()->GetDiffuseColor();
+    EXPECT_FLOAT_EQ(from_shape.R, from_default.R);
+    EXPECT_FLOAT_EQ(from_shape.G, from_default.G);
+    EXPECT_FLOAT_EQ(from_shape.B, from_default.B);
+}
+
+// -----------------------------------------------------------------------------
+// Every member is initialized.
+// -----------------------------------------------------------------------------
+
+// The Hapke members had no initializer, in the constructor or in the class. Nothing gated reading
+// them: ChOptixPipeline::GetMaterial copies all seven into its device struct for every material it
+// converts, without testing bsdf_type first, so every render was copying indeterminate host memory
+// to the GPU. It could not change a pixel, because the shader only reads those values when the
+// user selected the Hapke BSDF and such a user has called SetHapkeParameters. Latent, but still
+// undefined behaviour, and the fix routes one more caller through that read.
+//
+// Note what this test can and cannot do: reading an uninitialized float is undefined, so a build
+// where it is broken may legitimately produce anything, including these values by luck. The test
+// is a tripwire against the initializers being dropped again, not proof of definedness.
+TEST(DefaultVisualMaterial, hapke_members_are_initialized) {
+    ChVisualMaterial mat;
+
+    EXPECT_FALSE(mat.GetUseHapke());
+    EXPECT_FLOAT_EQ(mat.GetHapkeW(), 0.0f);
+    EXPECT_FLOAT_EQ(mat.GetHapkeB(), 0.0f);
+    EXPECT_FLOAT_EQ(mat.GetHapkeC(), 0.0f);
+    EXPECT_FLOAT_EQ(mat.GetHapkeBs0(), 0.0f);
+    EXPECT_FLOAT_EQ(mat.GetHapkeHs(), 0.0f);
+    EXPECT_FLOAT_EQ(mat.GetHapkePhi(), 0.0f);
+    EXPECT_FLOAT_EQ(mat.GetHapkeRoughness(), 0.0f);
+}
+
+// Two independently constructed materials must agree on every field a backend reads. If any member
+// were left uninitialized, two stack allocations would eventually disagree, and this catches that
+// without depending on which particular garbage a given run produces.
+TEST(DefaultVisualMaterial, two_fresh_materials_agree_on_every_read_field) {
+    ChVisualMaterial a;
+    ChVisualMaterial b;
+
+    EXPECT_FLOAT_EQ(a.GetDiffuseColor().R, b.GetDiffuseColor().R);
+    EXPECT_FLOAT_EQ(a.GetSpecularColor().R, b.GetSpecularColor().R);
+    EXPECT_FLOAT_EQ(a.GetEmissiveColor().R, b.GetEmissiveColor().R);
+    EXPECT_FLOAT_EQ(a.GetFresnelExp(), b.GetFresnelExp());
+    EXPECT_FLOAT_EQ(a.GetFresnelMin(), b.GetFresnelMin());
+    EXPECT_FLOAT_EQ(a.GetFresnelMax(), b.GetFresnelMax());
+    EXPECT_FLOAT_EQ(a.GetOpacity(), b.GetOpacity());
+    EXPECT_FLOAT_EQ(a.GetRoughness(), b.GetRoughness());
+    EXPECT_FLOAT_EQ(a.GetMetallic(), b.GetMetallic());
+    EXPECT_FLOAT_EQ(a.GetAnisotropy(), b.GetAnisotropy());
+    EXPECT_EQ(a.GetUseSpecularWorkflow(), b.GetUseSpecularWorkflow());
+    EXPECT_EQ(a.GetBSDF(), b.GetBSDF());
+    EXPECT_FLOAT_EQ(a.GetEmissivePower(), b.GetEmissivePower());
+    EXPECT_EQ(a.GetUseHapke(), b.GetUseHapke());
+    EXPECT_FLOAT_EQ(a.GetHapkeW(), b.GetHapkeW());
+    EXPECT_FLOAT_EQ(a.GetHapkeB(), b.GetHapkeB());
+    EXPECT_FLOAT_EQ(a.GetHapkeC(), b.GetHapkeC());
+    EXPECT_FLOAT_EQ(a.GetHapkeBs0(), b.GetHapkeBs0());
+    EXPECT_FLOAT_EQ(a.GetHapkeHs(), b.GetHapkeHs());
+    EXPECT_FLOAT_EQ(a.GetHapkePhi(), b.GetHapkePhi());
+    EXPECT_FLOAT_EQ(a.GetHapkeRoughness(), b.GetHapkeRoughness());
+}
+
+// SetHapkeParameters sets the seven floats and nothing else. Recorded so that defaulting
+// use_hapke to false cannot be mistaken for a behaviour change: a Hapke user must already call
+// SetBSDF separately, since neither this setter nor the constructor touches bsdf_type.
+TEST(DefaultVisualMaterial, set_hapke_parameters_does_not_switch_the_bsdf) {
+    ChVisualMaterial mat;
+    mat.SetHapkeParameters(0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f);
+
+    EXPECT_FLOAT_EQ(mat.GetHapkeW(), 0.1f);
+    EXPECT_FLOAT_EQ(mat.GetHapkeRoughness(), 0.7f);
+    EXPECT_EQ(mat.GetBSDF(), BSDFType::PRINCIPLED);
+}
+
+// -----------------------------------------------------------------------------
+// The singleton.
+// -----------------------------------------------------------------------------
+
+// Default() is one shared object, and the pipeline caches a snapshot of it rather than holding a
+// reference, so it matters that it is stable.
+TEST(DefaultVisualMaterial, default_is_a_stable_singleton) {
+    EXPECT_EQ(ChVisualMaterial::Default(), ChVisualMaterial::Default());
+}
+
+// SetColor on a shape must never write through to the shared default. ChVisualShape guards this
+// with copy-on-write; if that guard were lost, colouring one shape would recolour every
+// material-less shape in every scene, including through the OptiX default path this change adds.
+TEST(DefaultVisualMaterial, coloring_a_shape_does_not_mutate_the_singleton) {
+    const ChColor before = ChVisualMaterial::Default()->GetDiffuseColor();
+
+    ChVisualShapeBox shape(1.0, 1.0, 1.0);
+    shape.SetColor(ChColor(0.123f, 0.456f, 0.789f));
+
+    const ChColor after = ChVisualMaterial::Default()->GetDiffuseColor();
+    EXPECT_FLOAT_EQ(after.R, before.R);
+    EXPECT_FLOAT_EQ(after.G, before.G);
+    EXPECT_FLOAT_EQ(after.B, before.B);
+    EXPECT_FLOAT_EQ(shape.GetColor().R, 0.123f);
+}
+
+// Concurrent FIRST access to Default() is tested by utest_SEN_default_material_firstaccess, in its
+// own executable. It cannot live here: several tests in this file call Default(), gtest runs them in
+// declaration order, and once any of them has run, the static is built and a concurrency test races
+// over nothing. Measured with the pre-fix implementation swapped back in, the same test passed in
+// this binary and failed 200 of 200 runs in its own. Keeping a copy here would only add a test that
+// cannot fail.
+
+// The default material names no texture files. This is what makes installing it into the OptiX
+// material pool a non-throwing operation: the only throwing paths in that conversion are the
+// texture uploads, each guarded by a non-empty filename test. If someone gives the default a
+// texture later, the install could throw partway and this test is where they find out.
+TEST(DefaultVisualMaterial, default_names_no_textures) {
+    auto def = ChVisualMaterial::Default();
+
+    EXPECT_TRUE(def->GetKdTexture().empty());
+    EXPECT_TRUE(def->GetKsTexture().empty());
+    EXPECT_TRUE(def->GetNormalMapTexture().empty());
+    EXPECT_TRUE(def->GetMetallicTexture().empty());
+    EXPECT_TRUE(def->GetRoughnessTexture().empty());
+    EXPECT_TRUE(def->GetOpacityTexture().empty());
+    EXPECT_TRUE(def->GetWeightTexture().empty());
+}
+
+// -----------------------------------------------------------------------------
+// Serialization.
+// -----------------------------------------------------------------------------
+
+// The fields ArchiveOut actually writes must come back unchanged. This is the baseline the next
+// test is measured against: it establishes that the round trip works at all, so a failure there
+// means something about the unwritten fields, not a broken archive.
+TEST(DefaultVisualMaterial, archived_fields_survive_a_round_trip) {
+    // Both sides must use the same variable name: CHNVP takes the archive key from the identifier,
+    // so reading into a differently named variable throws "Cannot find ...". Hence the scopes.
+    std::stringstream buffer;
+    {
+        auto material = chrono_types::make_shared<ChVisualMaterial>();
+        material->SetDiffuseColor(ChColor(0.11f, 0.22f, 0.33f));
+        material->SetSpecularColor(ChColor(0.44f, 0.55f, 0.66f));
+        material->SetRoughness(0.75f);
+        material->SetMetallic(0.25f);
+        material->SetOpacity(0.5f);
+        material->SetUseSpecularWorkflow(false);
+        material->SetKdTexture("some/diffuse.png");
+
+        ChArchiveOutJSON archive_out(buffer);
+        archive_out << CHNVP(material);
+    }
+
+    std::shared_ptr<ChVisualMaterial> restored;
+    {
+        std::shared_ptr<ChVisualMaterial> material;
+        ChArchiveInJSON archive_in(buffer);
+        archive_in >> CHNVP(material);
+        restored = material;
+    }
+    ASSERT_NE(restored, nullptr);
+
+    EXPECT_FLOAT_EQ(restored->GetDiffuseColor().R, 0.11f);
+    EXPECT_FLOAT_EQ(restored->GetDiffuseColor().G, 0.22f);
+    EXPECT_FLOAT_EQ(restored->GetDiffuseColor().B, 0.33f);
+    EXPECT_FLOAT_EQ(restored->GetSpecularColor().R, 0.44f);
+    EXPECT_FLOAT_EQ(restored->GetRoughness(), 0.75f);
+    EXPECT_FLOAT_EQ(restored->GetMetallic(), 0.25f);
+    EXPECT_FLOAT_EQ(restored->GetOpacity(), 0.5f);
+    EXPECT_FALSE(restored->GetUseSpecularWorkflow());
+    EXPECT_EQ(restored->GetKdTexture(), "some/diffuse.png");
+}
+
+// The other half of the round trip, and the half this change is responsible for.
+//
+// ArchiveOut writes 23 of ChVisualMaterial's 40 members. It does not write emissive_power,
+// anisotropy, use_hapke, bsdf_type, class_id, instance_id, or the seven Hapke floats, so a
+// deserialized material takes those from the default constructor, not from the file. That is a
+// pre-existing gap in ChVisualMaterial's archive and it is deliberately NOT fixed here: adding
+// fields to ArchiveOut changes the on-disk format and needs a version bump, which is a separate
+// change from this one.
+//
+// What matters here is that the constructor is now the whole story for those members. Before the
+// Hapke members were initialized, deserializing a material produced eight values read from
+// uninitialized stack, and ChOptixPipeline copies all of them to the GPU. So this test asserts
+// determinism, not a particular value: two independent round trips of the same archive must agree
+// on every unwritten member. It stays correct if someone later adds these fields to the archive.
+TEST(DefaultVisualMaterial, round_trip_leaves_the_unarchived_members_deterministic) {
+    std::stringstream buffer;
+    {
+        auto material = chrono_types::make_shared<ChVisualMaterial>();
+        material->SetHapkeParameters(0.31f, 0.32f, 0.33f, 0.34f, 0.35f, 0.36f, 0.37f);
+        material->SetBSDF(BSDFType::HAPKE);
+        material->SetAnisotropy(0.44f);
+        material->SetEmissivePower(7.5f);
+        material->SetClassID(11);
+        material->SetInstanceID(22);
+
+        ChArchiveOutJSON archive_out(buffer);
+        archive_out << CHNVP(material);
+    }
+    const std::string archived = buffer.str();
+
+    std::shared_ptr<ChVisualMaterial> first;
+    std::shared_ptr<ChVisualMaterial> second;
+    {
+        std::shared_ptr<ChVisualMaterial> material;
+        std::stringstream in(archived);
+        ChArchiveInJSON archive_in(in);
+        archive_in >> CHNVP(material);
+        first = material;
+    }
+    {
+        std::shared_ptr<ChVisualMaterial> material;
+        std::stringstream in(archived);
+        ChArchiveInJSON archive_in(in);
+        archive_in >> CHNVP(material);
+        second = material;
+    }
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+
+    EXPECT_EQ(first->GetUseHapke(), second->GetUseHapke());
+    EXPECT_FLOAT_EQ(first->GetHapkeW(), second->GetHapkeW());
+    EXPECT_FLOAT_EQ(first->GetHapkeB(), second->GetHapkeB());
+    EXPECT_FLOAT_EQ(first->GetHapkeC(), second->GetHapkeC());
+    EXPECT_FLOAT_EQ(first->GetHapkeBs0(), second->GetHapkeBs0());
+    EXPECT_FLOAT_EQ(first->GetHapkeHs(), second->GetHapkeHs());
+    EXPECT_FLOAT_EQ(first->GetHapkePhi(), second->GetHapkePhi());
+    EXPECT_FLOAT_EQ(first->GetHapkeRoughness(), second->GetHapkeRoughness());
+    EXPECT_EQ(first->GetBSDF(), second->GetBSDF());
+    EXPECT_FLOAT_EQ(first->GetAnisotropy(), second->GetAnisotropy());
+    EXPECT_FLOAT_EQ(first->GetEmissivePower(), second->GetEmissivePower());
+    EXPECT_EQ(first->GetClassID(), second->GetClassID());
+    EXPECT_EQ(first->GetInstanceID(), second->GetInstanceID());
+}
+
+// A shape saved with an empty material list must come back with an empty material list, and so must
+// resolve to the default at render time rather than to whatever a backend keeps of its own. This is
+// the shape-level half of the serialization question: it is what makes the appearance change apply
+// to already-saved scenes, which is the part of this change users are most likely to notice.
+//
+// What it does not cover: rendering a deserialized scene through the GPU backends and comparing. That
+// needs a GPU and full ChSystem serialization, and it is not done.
+TEST(DefaultVisualMaterial, an_empty_material_list_survives_a_round_trip) {
+    std::stringstream buffer;
+    {
+        auto shape = chrono_types::make_shared<ChVisualShapeBox>(1.0, 2.0, 3.0);
+        ASSERT_EQ(shape->GetNumMaterials(), 0u);
+        ChArchiveOutJSON archive_out(buffer);
+        archive_out << CHNVP(shape);
+    }
+
+    std::shared_ptr<ChVisualShapeBox> restored;
+    {
+        std::shared_ptr<ChVisualShapeBox> shape;
+        ChArchiveInJSON archive_in(buffer);
+        archive_in >> CHNVP(shape);
+        restored = shape;
+    }
+    ASSERT_NE(restored, nullptr);
+
+    EXPECT_EQ(restored->GetNumMaterials(), 0u);
+    const ChColor from_default = ChVisualMaterial::Default()->GetDiffuseColor();
+    EXPECT_FLOAT_EQ(restored->GetColor().R, from_default.R);
+    EXPECT_FLOAT_EQ(restored->GetColor().G, from_default.G);
+    EXPECT_FLOAT_EQ(restored->GetColor().B, from_default.B);
+}
+
+// -----------------------------------------------------------------------------
+// The two creation paths.
+// -----------------------------------------------------------------------------
+
+// The inconsistency that showed this was not a deliberate convention. ChBodyEasyBox leaves the
+// material list empty; chrono::utils::AddBoxGeometry defaults its vis_material argument to
+// Default() and attaches it. Under the old OptiX code those rendered 0.5 grey and white
+// respectively. They must now report the same colour, since both resolve to the same default.
+TEST(DefaultVisualMaterial, easy_box_and_explicit_default_agree_on_color) {
+    ChSystemNSC sys;
+
+    auto easy = chrono_types::make_shared<ChBodyEasyBox>(1.0, 1.0, 1.0, 1000, true, false);
+    sys.Add(easy);
+    auto easy_shape = easy->GetVisualModel()->GetShapeInstances()[0].shape;
+    ASSERT_EQ(easy_shape->GetNumMaterials(), 0u);
+
+    ChVisualShapeBox explicit_shape(1.0, 1.0, 1.0);
+    explicit_shape.AddMaterial(ChVisualMaterial::Default());
+    ASSERT_EQ(explicit_shape.GetNumMaterials(), 1u);
+
+    EXPECT_FLOAT_EQ(easy_shape->GetColor().R, explicit_shape.GetColor().R);
+    EXPECT_FLOAT_EQ(easy_shape->GetColor().G, explicit_shape.GetColor().G);
+    EXPECT_FLOAT_EQ(easy_shape->GetColor().B, explicit_shape.GetColor().B);
+}

--- a/src/tests/unit_tests/sensor/utest_SEN_default_material_firstaccess.cpp
+++ b/src/tests/unit_tests/sensor/utest_SEN_default_material_firstaccess.cpp
@@ -1,0 +1,80 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// Authors: Dan Negrut
+// =============================================================================
+//
+// Concurrent FIRST access to ChVisualMaterial::Default().
+//
+// This is one test in its own executable, and the reason is the whole point of the file. Default()
+// initializes a static on first call, so the hazard exists only on the first call in a process.
+// Chrono::Sensor reaches it from ChOptixEngine::ConstructScene(), and every engine has its own
+// scene thread, so two engines coming up together can both be that first caller.
+//
+// Sharing a binary with the other default-material tests destroys the test. Those tests call
+// Default() too, gtest runs them in declaration order, and by the time a concurrency test ran the
+// singleton would already be built, so the threads would race over nothing. That is not a
+// hypothesis: with the pre-fix implementation of Default() swapped back in, this test passed inside
+// the shared binary and failed 200 out of 200 runs as its own binary. One test alone in a process
+// is what makes it the first caller.
+//
+// What it catches: the pattern this change replaced, a namespace-scope pointer initialized under
+// "if (!ptr) ptr = ...", which has no synchronization at all. C++11 guarantees thread-safe
+// initialization of a function-local static instead, so the shipped code needs no lock and gets
+// none. Measured on the old code: every run returned more than one distinct material, worst case 7
+// of 8 threads holding a different object, and some runs aborted outright in the allocator, since
+// racing shared_ptr assignments corrupt the reference count.
+//
+// =============================================================================
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "chrono/assets/ChVisualMaterial.h"
+
+using namespace chrono;
+
+TEST(DefaultVisualMaterialFirstAccess, concurrent_first_access_returns_one_object) {
+    constexpr int kThreads = 16;
+    std::vector<std::shared_ptr<ChVisualMaterial>> seen(kThreads);
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    // The gate is load-bearing. Spawning threads in a loop and letting each run as it is created
+    // gives the first one time to finish initializing before the second starts, and then there is
+    // no concurrent first access left to test. Every thread parks here until all of them exist.
+    std::atomic<int> ready{0};
+    std::atomic<bool> gate{false};
+
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&seen, &ready, &gate, i]() {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!gate.load(std::memory_order_acquire))
+                std::this_thread::yield();
+            seen[i] = ChVisualMaterial::Default();
+        });
+    }
+    while (ready.load(std::memory_order_acquire) < kThreads)
+        std::this_thread::yield();
+    gate.store(true, std::memory_order_release);
+
+    for (auto& t : threads)
+        t.join();
+
+    for (int i = 0; i < kThreads; ++i) {
+        ASSERT_NE(seen[i], nullptr) << "thread " << i << " got null";
+        EXPECT_EQ(seen[i], seen[0]) << "thread " << i << " got a different object";
+    }
+}


### PR DESCRIPTION
A visual shape with no `ChVisualMaterial` was shaded by the OptiX backend from literals inside
`ChOptixPipeline::GetMaterial`, `Kd = 0.5` grey with `roughness = 1`, instead of
`ChVisualMaterial::Default()`, which is white and smooth and is what `ChVisualShape::GetColor()`
reports for an empty material list. Irrlicht and VSG use the shared default; OptiX was the only
backend that did not. The grey was deliberate when written (2f6e628f6, 2021), because the core default
was then an unusable `Kd = (1.0, 2.0, 2.0)`. Core was fixed a year later (45264a525) and this copy was
never revisited, so the two drifted apart.

## Measured (RTX 5090, CUDA 12.8, OptiX 9.0.0)

- A material-less box rendered **2.0011x darker** under OptiX than under a second ray-tracing backend
  given the same scene in the same process: RMSE 11.68, max 68 code units, 14.41 % of pixels off by
  more than 2. After: RMSE 0.52, max 1, **0.00 %** over threshold. Same factor of two then measured on
  material-less spheres, cylinders and an explicit triangle mesh, each reaching the default through a
  different function.
- Two standard helpers disagreed with each other, no second backend involved:
  `chrono::utils::AddBoxGeometry` attaches `Default()` by default argument and rendered white;
  `ChBodyEasyBox` attaches nothing and rendered grey.
- Strongest check, and it needs no second backend: box, sphere, cylinder and mesh with no material
  produce a **byte-identical** OptiX frame to those same shapes carrying `Default()` explicitly
  (md5 `0040464e8f25f8bfec8d91b4db4fc833`). Any disagreeing struct field would show up here.

## The change

The explicit-material conversion is extracted into `MakeMaterialParameters` and both arms of
`GetMaterial` call it, so the two cannot drift again. The struct is value-initialized: it has no
default member initializers, and the old default branch omitted `anisotropy` and `theta_p`, which
reached the device as stack garbage. Field coverage is mechanical: 34 declared members, 33 assigned,
the exception being the padding.

The first commit lands separately because it changes nothing a correct program can observe.
`ChVisualMaterial`'s constructor left `use_hapke` and seven `hapke_*` members uninitialized, and
`GetMaterial` copies the seven floats to the device for every material without testing `bsdf_type`, so
every render copied indeterminate host memory to the GPU. Latent, since the shader reads them only
under the Hapke BSDF, but undefined, and this change adds a caller. The same commit makes `Default()`'s
lazy init thread-safe by moving the static inside the function: ThreadSanitizer reports **1038 data
races over 30 runs** of an 8-thread first-access probe against the old namespace-scope `if (!ptr)`
pattern and **none over 30 runs** against the new one, and the old pattern returned more than one
distinct "singleton" in all 30 runs, worst case 7 of 8 threads holding different objects.

## Behaviour change, deliberate

Scenes containing shapes with no explicit material now render brighter and glossier, including scenes
deserialized from files saved with an empty material list. `CHANGELOG.md` records this under
Unreleased with the three lines that restore the old look, and the Sensor manual gains a line. Shapes
carrying an explicit material are bit-identical before and after, on six scene configurations.

## Tests

Two CPU-only binaries, outside the OptiX block so they run without a GPU.
`utest_SEN_default_material` (12 tests) pins the default's values, initialization of every member,
serialization round trips including the 17 members `ArchiveOut` does not write, and that colouring a
shape cannot mutate the shared singleton. `utest_SEN_default_material_firstaccess` holds one test
alone in its process, because `Default()` initializes on first call and a concurrent-first-access test
only has a race to observe if nothing else has called it yet: against the old code it fails **200 of
200** runs alone and **0 of 200** sharing a binary. Sensor suite 13 of 13; whole-tree build clean.

