### PR TITLE
FSI-SPH: fix the swapped MCC kappa/lambda docs, enforce preconditions

### DIFF
--- a/doxygen/documentation/manuals/fsi/fsi_mcc_rheology.md
+++ b/doxygen/documentation/manuals/fsi/fsi_mcc_rheology.md
@@ -140,7 +140,18 @@ Critical consistency checks:
 - `mcc_kappa > 0`
 - `mcc_lambda > mcc_kappa` (hardening denominator uses `lambda-kappa`)
 - `mcc_M > 0`
+- `mcc_v_lambda > 0`
 - `pc > 0` and initial `p0 > 0` where NCL-based initialization is used
+
+The first four are enforced. `ChFsiFluidSystemSPH::CheckSPHParameters()`, which runs during
+`Initialize()`, rejects a violating configuration with a `std::runtime_error` rather than letting
+it run; all four parameters are also required to be finite. The `pc` and `p0` condition is checked
+separately, per particle, in `ChFsiFluidSystemSPH::AddSPHParticle()`.
+
+The same function additionally reports, without rejecting, a `lambda-kappa` difference smaller than
+`max(1e-6, 1e-3 * lambda)`. Such a configuration is legal, but since the hardening rate scales as
+`1 / (lambda-kappa)`, it produces a very large plastic modulus and an ill-conditioned return
+mapping, which is rarely what is intended.
 
 Naming note:
 

--- a/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
+++ b/src/chrono_fsi/sph/ChFsiFluidSystemSPH.cpp
@@ -23,6 +23,8 @@
 
 #include <cmath>
 #include <algorithm>
+#include <sstream>
+#include <string>
 
 #include "chrono/core/ChTypes.h"
 
@@ -392,6 +394,90 @@ void ChFsiFluidSystemSPH::CheckSPHParameters() {
         if (m_paramsH->mu0 > Real(0.001)) {
             cerr << "WARNING: The Laminar viscosity parameter has been set to " << m_paramsH->mu0
                  << " but the viscosity model is not laminar. This parameter will have no influence on simulation." << endl;
+        }
+
+        // Modified Cam-Clay parameter preconditions.
+        //
+        // Three of these, mcc_kappa > 0, mcc_lambda > mcc_kappa and mcc_M > 0, are the
+        // "critical consistency checks" the MCC manual page already published; nothing enforced
+        // them. The fourth, mcc_v_lambda > 0, is added here and to the manual at the same time.
+        // They are preconditions of the equations, not style:
+        // the elastic bulk modulus is K = v p / mcc_kappa, and the hardening update divides by
+        // (mcc_lambda - mcc_kappa). A user who transposes the two slopes gets a negative
+        // denominator, which inverts the hardening law, and the run then completes with no
+        // diagnostic of any kind while producing essentially zero bearing capacity.
+        //
+        // Gated on the PAIR of flags, not on the rheology alone: SetCfdSPH clears elastic_SPH
+        // without resetting rheology_model_crm, so a CFD problem can legitimately be left with
+        // rheology_model_crm == MCC and must not be rejected here.
+        if (m_paramsH->rheology_model_crm == RheologyCRM::MCC) {
+            auto mcc_fatal = [](const std::string& msg) {
+                cerr << "ERROR: " << msg << endl;
+                throw std::runtime_error(msg);
+            };
+            auto mcc_finite = [&](Real value, const char* name) {
+                if (!std::isfinite(double(value)))
+                    mcc_fatal(std::string("MCC parameter ") + name + " is not a finite number.");
+            };
+            // Stream formatting, not to_string: to_string formats a float with %f, so a small
+            // but legal value such as 1e-8 would be reported back to the user as "0.000000" by
+            // the very message that exists to tell them what they set.
+            auto mcc_num = [](Real value) {
+                std::ostringstream os;
+                os << value;
+                return os.str();
+            };
+
+            mcc_finite(m_paramsH->mcc_M, "mcc_M");
+            mcc_finite(m_paramsH->mcc_kappa, "mcc_kappa");
+            mcc_finite(m_paramsH->mcc_lambda, "mcc_lambda");
+            mcc_finite(m_paramsH->mcc_v_lambda, "mcc_v_lambda");
+
+            if (m_paramsH->mcc_kappa <= 0) {
+                mcc_fatal("MCC parameter mcc_kappa (swelling index) must be positive, but is " +
+                          mcc_num(m_paramsH->mcc_kappa) +
+                          ". The elastic bulk modulus is computed as K = v p / mcc_kappa.");
+            }
+            if (m_paramsH->mcc_lambda <= m_paramsH->mcc_kappa) {
+                mcc_fatal("MCC requires mcc_lambda (compression index) > mcc_kappa (swelling index), but "
+                          "mcc_lambda = " + mcc_num(m_paramsH->mcc_lambda) + " and mcc_kappa = " +
+                          mcc_num(m_paramsH->mcc_kappa) +
+                          ". The hardening law divides by (mcc_lambda - mcc_kappa). If these two look "
+                          "swapped, they probably are: lambda is the normal-consolidation-line slope and "
+                          "is the larger of the two.");
+            }
+            if (m_paramsH->mcc_M <= 0) {
+                mcc_fatal("MCC parameter mcc_M (critical state line slope) must be positive, but is " +
+                          mcc_num(m_paramsH->mcc_M) + ".");
+            }
+            if (m_paramsH->mcc_v_lambda <= 0) {
+                mcc_fatal("MCC parameter mcc_v_lambda (specific volume at the reference pressure) must be "
+                          "positive, but is " + mcc_num(m_paramsH->mcc_v_lambda) + ".");
+            }
+
+            // Last, and a warning rather than an error: the ordering above can hold by a
+            // vanishingly small margin. The hardening update divides by (mcc_lambda - mcc_kappa),
+            // so as that gap goes to zero the plastic modulus v / (mcc_lambda - mcc_kappa) grows
+            // without bound and the return mapping becomes ill-conditioned. A narrow gap is a
+            // legal, if extreme, model, so this reports and continues; only the ordering itself is
+            // fatal.
+            //
+            // Two arms, because these are dimensionless slopes and neither test alone is enough.
+            // The absolute floor catches a gap that has lost its significance entirely, which is
+            // what single precision does to a difference of nearly equal values. The relative
+            // floor catches the same pathology at a larger scale, where the gap is well
+            // represented but is still a thousandth of the slopes it came from.
+            Real mcc_gap = m_paramsH->mcc_lambda - m_paramsH->mcc_kappa;
+            Real mcc_gap_floor = std::max(Real(1e-6), Real(1e-3) * m_paramsH->mcc_lambda);
+            if (mcc_gap < mcc_gap_floor) {
+                cerr << "WARNING: MCC parameters mcc_lambda = " << mcc_num(m_paramsH->mcc_lambda)
+                     << " and mcc_kappa = " << mcc_num(m_paramsH->mcc_kappa) << " differ by only "
+                     << mcc_num(mcc_gap)
+                     << ". The hardening law divides by that difference, so the plastic modulus will be "
+                        "very large and the return mapping poorly conditioned. This is accepted as given, "
+                        "but confirm it is what was intended."
+                     << endl;
+            }
         }
     } else {
         if (m_paramsH->viscosity_method == ViscosityMethod::ARTIFICIAL_BILATERAL) {

--- a/src/chrono_fsi/sph/ChFsiFluidSystemSPH.h
+++ b/src/chrono_fsi/sph/ChFsiFluidSystemSPH.h
@@ -69,10 +69,18 @@ class CH_FSI_API ChFsiFluidSystemSPH : public ChFsiFluidSystem {
         double average_diam;         ///< average particle diameter (default: 0.005)
         double cohesion_coeff;       ///< cohesion coefficient (default: 0)
         RheologyCRM rheology_model;  ///< rheology model (default: MU_OF_I)
-        double mcc_M;                ///< CSL line slope
-        double mcc_kappa;            ///< Compression index
-        double mcc_lambda;           ///< Swelling index
+        double mcc_M;                ///< Cam-Clay critical state line slope, q = M p (default: 0)
+        double mcc_kappa;            ///< Cam-Clay swelling index: slope of the elastic
+                                     ///< unload/reload line in v-ln(p). Sets the elastic bulk
+                                     ///< modulus, K = v p / kappa. Must satisfy
+                                     ///< 0 < mcc_kappa < mcc_lambda (default: 0)
+        double mcc_lambda;           ///< Cam-Clay compression index: slope of the normal
+                                     ///< consolidation line in v-ln(p). Governs virgin
+                                     ///< compressibility and the hardening rate, which divides
+                                     ///< by (mcc_lambda - mcc_kappa). Must exceed mcc_kappa
+                                     ///< (default: 0)
         double mcc_v_lambda;         ///< Specific volume at reference pressure of 1000 Pa
+                                     ///< (default: 2.0)
 
         ElasticMaterialProperties();
     };

--- a/src/chrono_fsi/sph/ChFsiParamsSPH.h
+++ b/src/chrono_fsi/sph/ChFsiParamsSPH.h
@@ -170,9 +170,13 @@ struct ChFsiParamsSPH {
     ///< field is computed and compared to this threshold. Particles with divergence
     ///< less than this threshold are considered free surface particles (CRM only,
     ///< default: 2.0)
-    Real mcc_M;         ///< CSL line slope
-    Real mcc_kappa;     ///< Compression index
-    Real mcc_lambda;    ///< Swelling index
+    Real mcc_M;         ///< Cam-Clay critical state line slope, q = M p
+    Real mcc_kappa;     ///< Cam-Clay swelling index: slope of the elastic unload/reload line in
+                        ///< v-ln(p). Sets the elastic bulk modulus, K = v p / kappa.
+                        ///< Must satisfy 0 < mcc_kappa < mcc_lambda
+    Real mcc_lambda;    ///< Cam-Clay compression index: slope of the normal consolidation line in
+                        ///< v-ln(p). Governs virgin compressibility and the hardening rate, which
+                        ///< divides by (mcc_lambda - mcc_kappa). Must exceed mcc_kappa
     Real mcc_v_lambda;  ///< Specific volume at reference pressure of 1000 Pa
 
     Real boxDimX;  ///< Dimension of the space domain - X

--- a/src/tests/unit_tests/fsi/sph/CMakeLists.txt
+++ b/src/tests/unit_tests/fsi/sph/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TESTS
     utest_FSI-SPH_domain_update
     utest_FSI-SPH_setter_guard
     utest_FSI-SPH_rheology_error_flag
+    utest_FSI-SPH_mcc_parameters
 )
 
 list(APPEND LIBS Chrono_core)

--- a/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_mcc_parameters.cpp
+++ b/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_mcc_parameters.cpp
@@ -1,0 +1,328 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+//
+// Unit test for the Modified Cam-Clay parameter preconditions.
+//
+// The MCC equations require 0 < kappa < lambda: the elastic bulk modulus is
+// K = v p / kappa, and the hardening update divides by (lambda - kappa). Before
+// these checks existed, a configuration violating that ran to completion with no
+// diagnostic at all and produced essentially zero bearing capacity, which is how
+// the transposed kappa/lambda documentation went unnoticed.
+//
+// Checks:
+// 1. A valid MCC parameter set is accepted.
+// 2. Every violating set is rejected: non-finite, kappa <= 0, lambda <= kappa
+//    (including exact equality), M <= 0, v_lambda <= 0.
+// 3. An ordering that holds by a vanishingly small margin is warned about and
+//    accepted, not rejected: it is a legal if extreme model. Both arms of the
+//    floor are exercised, and a gap just above the floor must stay silent.
+// 4. A default-constructed material, which has all four MCC values at zero, is
+//    accepted for mu(I) and rejected only when MCC is actually selected.
+// 5. A CFD problem is never rejected by these checks, even when a stale MCC
+//    rheology selection is left behind. SetCfdSPH clears elastic_SPH without
+//    resetting rheology_model_crm, so the pair can come apart and the checks are
+//    gated on both flags.
+// 6. The rejection happens on the real path: a full Initialize() with the
+//    transposed values throws before any time stepping.
+//
+// =============================================================================
+
+#include <cmath>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include "chrono/physics/ChSystemSMC.h"
+
+#include "chrono_fsi/sph/ChFsiProblemSPH.h"
+
+using namespace chrono;
+using namespace chrono::fsi;
+using namespace chrono::fsi::sph;
+
+double initial_spacing = 0.02;
+double dt = 1e-4;
+
+int num_failures = 0;
+
+void ExpectThrow(const std::string& name, std::function<void()> f) {
+    try {
+        f();
+        std::cout << "FAIL (no throw): " << name << std::endl;
+        num_failures++;
+    } catch (const std::runtime_error& e) {
+        std::cout << "  ok (rejected): " << name << std::endl;
+        std::cout << "                 " << e.what() << std::endl;
+    }
+}
+
+void ExpectNoThrow(const std::string& name, std::function<void()> f) {
+    try {
+        f();
+        std::cout << "  ok (accepted): " << name << std::endl;
+    } catch (const std::exception& e) {
+        std::cout << "FAIL (threw):   " << name << " - " << e.what() << std::endl;
+        num_failures++;
+    }
+}
+
+// The near-equality condition is reported on cerr and accepted, not thrown, so these two helpers
+// capture cerr and key on a substring unique to that one message. CheckSPHParameters emits other,
+// unrelated warnings, so keying on the word WARNING alone would give a test that can pass for the
+// wrong reason.
+const char* gap_warning_marker = "differ by only";
+
+std::string CaptureCerr(std::function<void()> f) {
+    std::ostringstream capture;
+    std::streambuf* saved = std::cerr.rdbuf(capture.rdbuf());
+    try {
+        f();
+    } catch (...) {
+        std::cerr.rdbuf(saved);
+        throw;
+    }
+    std::cerr.rdbuf(saved);
+    return capture.str();
+}
+
+void ExpectGapWarning(const std::string& name, std::function<void()> f) {
+    try {
+        std::string out = CaptureCerr(f);
+        if (out.find(gap_warning_marker) == std::string::npos) {
+            std::cout << "FAIL (accepted, but did not warn): " << name << std::endl;
+            num_failures++;
+            return;
+        }
+        std::cout << "  ok (warned, accepted): " << name << std::endl;
+        std::cout << "                 " << out.substr(0, out.find('\n')) << std::endl;
+    } catch (const std::exception& e) {
+        std::cout << "FAIL (threw):   " << name << " - " << e.what() << std::endl;
+        num_failures++;
+    }
+}
+
+void ExpectNoGapWarning(const std::string& name, std::function<void()> f) {
+    try {
+        std::string out = CaptureCerr(f);
+        if (out.find(gap_warning_marker) != std::string::npos) {
+            std::cout << "FAIL (warned):  " << name << std::endl;
+            num_failures++;
+            return;
+        }
+        std::cout << "  ok (no warning): " << name << std::endl;
+    } catch (const std::exception& e) {
+        std::cout << "FAIL (threw):   " << name << " - " << e.what() << std::endl;
+        num_failures++;
+    }
+}
+
+// A parameter set that satisfies every precondition. Individual tests spoil one value at a time,
+// so that each failure is attributable to the value it changed.
+ChFsiFluidSystemSPH::ElasticMaterialProperties ValidMCC() {
+    ChFsiFluidSystemSPH::ElasticMaterialProperties mat_props;
+    mat_props.density = 1700;
+    mat_props.Young_modulus = 1e6;
+    mat_props.Poisson_ratio = 0.3;
+    mat_props.rheology_model = RheologyCRM::MCC;
+    mat_props.mcc_M = 1.2;
+    mat_props.mcc_kappa = 0.00625;
+    mat_props.mcc_lambda = 0.025;
+    mat_props.mcc_v_lambda = 2.0;
+    return mat_props;
+}
+
+ChFsiFluidSystemSPH::SPHParameters CrmSPHParameters() {
+    ChFsiFluidSystemSPH::SPHParameters sph_params;
+    sph_params.integration_scheme = IntegrationScheme::RK2;
+    // Set explicitly, even though shifting is irrelevant to parameter validation and even though
+    // this is the documented default: SPHParameters::SPHParameters() does not initialize
+    // shifting_method, so reading it without assigning it first is undefined behavior. Leaving it
+    // alone made this test take different branches in the single- and double-precision builds of
+    // identical source.
+    sph_params.shifting_method = ShiftingMethod::XSPH;
+    sph_params.initial_spacing = initial_spacing;
+    sph_params.d0_multiplier = 1;
+    sph_params.num_bce_layers = 3;
+    sph_params.artificial_viscosity = 0.5;
+    sph_params.viscosity_method = ViscosityMethod::ARTIFICIAL_BILATERAL;
+    sph_params.boundary_method = BoundaryMethod::ADAMI;
+    return sph_params;
+}
+
+// Validate a material without building a bed or touching the GPU. CheckSPHParameters() is public
+// and is exactly what Initialize() calls, so this exercises the shipped code path; case 5 below
+// then proves the same call really is reached from Initialize().
+void ValidateMaterial(const ChFsiFluidSystemSPH::ElasticMaterialProperties& mat_props) {
+    ChFsiFluidSystemSPH sysSPH;
+    sysSPH.SetVerbose(false);
+    sysSPH.SetElasticSPH(mat_props);
+    sysSPH.SetSPHParameters(CrmSPHParameters());
+    sysSPH.CheckSPHParameters();
+}
+
+int main(int argc, char* argv[]) {
+    std::cout << "1. A valid MCC parameter set:" << std::endl;
+    ExpectNoThrow("kappa 0.00625 < lambda 0.025, M 1.2, v_lambda 2.0", [&] { ValidateMaterial(ValidMCC()); });
+
+    std::cout << "\n2. Violating parameter sets, one spoiled value each:" << std::endl;
+
+    ExpectThrow("lambda < kappa (the transposition this test exists for)", [&] {
+        auto m = ValidMCC();
+        m.mcc_kappa = 0.025;
+        m.mcc_lambda = 0.00625;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("lambda == kappa (zero hardening denominator)", [&] {
+        auto m = ValidMCC();
+        m.mcc_lambda = m.mcc_kappa;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("kappa == 0 (division by zero in K = v p / kappa)", [&] {
+        auto m = ValidMCC();
+        m.mcc_kappa = 0;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("kappa < 0", [&] {
+        auto m = ValidMCC();
+        m.mcc_kappa = -0.01;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("M == 0", [&] {
+        auto m = ValidMCC();
+        m.mcc_M = 0;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("M < 0", [&] {
+        auto m = ValidMCC();
+        m.mcc_M = -1.2;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("v_lambda == 0", [&] {
+        auto m = ValidMCC();
+        m.mcc_v_lambda = 0;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("v_lambda < 0", [&] {
+        auto m = ValidMCC();
+        m.mcc_v_lambda = -1.0;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("kappa is NaN", [&] {
+        auto m = ValidMCC();
+        m.mcc_kappa = std::numeric_limits<double>::quiet_NaN();
+        ValidateMaterial(m);
+    });
+    ExpectThrow("lambda is infinite", [&] {
+        auto m = ValidMCC();
+        m.mcc_lambda = std::numeric_limits<double>::infinity();
+        ValidateMaterial(m);
+    });
+
+    // ------------------------------------------------------------------------
+    // 3. lambda > kappa can hold by a margin so small that the hardening law, which divides by
+    //    (lambda - kappa), is effectively dividing by nothing. The floor is
+    //    max(1e-6, 1e-3 * lambda), so with lambda near 0.025 the relative arm governs at
+    //    2.5e-5 and the absolute arm only matters for far smaller slopes. The two warning
+    //    cases below are chosen to fire through different arms, and the last case sits just
+    //    above the floor to show the warning is bounded and does not fire on ordinary values.
+    std::cout << "\n3. An ordering that holds only barely (warn, do not reject):" << std::endl;
+
+    ExpectNoGapWarning("the valid set, gap 0.01875 against a floor of 2.5e-5: silent", [&] {  //
+        ValidateMaterial(ValidMCC());
+    });
+    ExpectGapWarning("gap 1e-7, below both arms of the floor", [&] {
+        auto m = ValidMCC();
+        m.mcc_kappa = 0.025;
+        m.mcc_lambda = 0.0250001;
+        ValidateMaterial(m);
+    });
+    ExpectGapWarning("gap 1e-5, above the absolute arm at 1e-6 but below the relative arm at 2.5e-5", [&] {
+        auto m = ValidMCC();
+        m.mcc_kappa = 0.025;
+        m.mcc_lambda = 0.02501;
+        ValidateMaterial(m);
+    });
+    ExpectNoGapWarning("gap 1e-4, just above the floor: silent", [&] {
+        auto m = ValidMCC();
+        m.mcc_kappa = 0.025;
+        m.mcc_lambda = 0.0251;
+        ValidateMaterial(m);
+    });
+
+    std::cout << "\n4. The all-zero MCC defaults:" << std::endl;
+    ExpectNoThrow("default material, mu(I) selected: the zero MCC defaults are irrelevant", [&] {
+        ChFsiFluidSystemSPH::ElasticMaterialProperties m;  // mcc_* all default to 0
+        m.rheology_model = RheologyCRM::MU_OF_I;
+        ValidateMaterial(m);
+    });
+    ExpectThrow("default material, MCC selected: unset parameters must not run silently", [&] {
+        ChFsiFluidSystemSPH::ElasticMaterialProperties m;
+        m.rheology_model = RheologyCRM::MCC;
+        ValidateMaterial(m);
+    });
+
+    std::cout << "\n5. A CFD problem is out of scope for these checks:" << std::endl;
+    ExpectNoThrow("SetElasticSPH(MCC) then SetCfdSPH: stale MCC selection must not reject CFD", [&] {
+        ChFsiFluidSystemSPH sysSPH;
+        sysSPH.SetVerbose(false);
+        sysSPH.SetElasticSPH(ValidMCC());  // leaves rheology_model_crm == MCC ...
+        ChFsiFluidSystemSPH::FluidProperties fluid_props;
+        fluid_props.density = 1000;
+        fluid_props.viscosity = 1;
+        sysSPH.SetCfdSPH(fluid_props);  // ... and clears elastic_SPH without resetting it
+        auto sph_params = CrmSPHParameters();
+        sph_params.viscosity_method = ViscosityMethod::LAMINAR;  // CFD rejects ARTIFICIAL_BILATERAL
+        sysSPH.SetSPHParameters(sph_params);
+        sysSPH.CheckSPHParameters();
+    });
+
+    // ------------------------------------------------------------------------
+    // 6. The check must fire on the path a user actually takes, not only when
+    //    CheckSPHParameters() is called directly. These are the values measured
+    //    to produce a silent zero-bearing-capacity run before the fix.
+    std::cout << "\n6. Full Initialize() on a CRM bed:" << std::endl;
+
+    auto build_and_initialize = [](double kappa, double lambda) {
+        ChSystemSMC sysMBS;
+        ChFsiProblemCartesian fsi(initial_spacing, &sysMBS);
+        fsi.SetVerbose(false);
+        fsi.SetGravitationalAcceleration(ChVector3d(0, 0, -9.81));
+        sysMBS.SetGravitationalAcceleration(ChVector3d(0, 0, -9.81));
+
+        auto mat_props = ValidMCC();
+        mat_props.mcc_kappa = kappa;
+        mat_props.mcc_lambda = lambda;
+        fsi.SetElasticSPH(mat_props);
+        fsi.SetSPHParameters(CrmSPHParameters());
+        fsi.SetStepSizeCFD(dt);
+        fsi.SetStepsizeMBD(dt);
+
+        fsi.Construct(ChVector3d(0.2, 0.2, 0.1), ChVector3d(0, 0, 0), BoxSide::ALL & ~BoxSide::Z_POS);
+        fsi.Initialize();
+        fsi.DoStepDynamics(dt);
+    };
+
+    ExpectThrow("Initialize() with kappa 0.025, lambda 0.00625 (the measured silent-failure case)",
+                [&] { build_and_initialize(0.025, 0.00625); });
+    ExpectNoThrow("Initialize() and one step with kappa 0.00625, lambda 0.025",
+                  [&] { build_and_initialize(0.00625, 0.025); });
+
+    if (num_failures > 0) {
+        std::cout << "\n" << num_failures << " failure(s)" << std::endl;
+        return 1;
+    }
+    std::cout << "\nAll MCC parameter checks passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
`mcc_kappa` and `mcc_lambda` were documented with each other's meanings in two public headers. The
code, the manual page and every shipped demo use them the standard way round, so only the comments
were wrong, but they are what Doxygen publishes and what an IDE shows at the moment a user types the
assignment.

Measured on an MI350X, 240,944 particles, a rigid plate pushed 4 cm into a settled bed, four runs
identical except for these two numbers:

| `mcc_kappa` | `mcc_lambda` | peak plate force |
|---|---|---|
| 0.00625 | 0.025 | 39,640 N (the demo values) |
| 0.00625 | 0.05 | 18,315 N |
| 0.0125 | 0.025 | 41,566 N |
| 0.025 | 0.00625 | about 0 N (what the headers told a user to enter) |

The last case exits 0 with no warning, no error and no NaN: with `(lambda - kappa)` negative the
hardening update changes sign, 6.8% of the particles under the plate finish pinned on the
`fmax(100, ...)` floor while others reach 9.1 MPa, and the soil carries no load.

So this also enforces the preconditions in `CheckSPHParameters()`. Three of them
(`mcc_kappa > 0`, `mcc_lambda > mcc_kappa`, `mcc_M > 0`) the MCC manual page has published as
"critical consistency checks" all along with nothing enforcing them; `mcc_v_lambda > 0` is added
here and to the manual together. All four must also be finite. Both slopes default to zero, so
selecting MCC and forgetting to set them was silently accepted too.

Gated on `elastic_SPH && rheology_model_crm == MCC` rather than on the rheology alone, because
`SetCfdSPH` clears `elastic_SPH` without resetting the rheology selection, so a CFD problem can
carry a stale MCC selection and must not be rejected. There is a test for exactly that.

One condition reports instead of rejecting: a `lambda - kappa` gap below
`max(1e-6, 1e-3 * lambda)` is legal but makes the plastic modulus enormous and the return mapping
ill-conditioned, so it warns and continues. Every shipped demo sits at least 750 times above that
floor.

Nothing in the tree violates any of it, so no demo or existing test changes.

**Validation**, on an MI350X in both single and double precision: the new
`utest_FSI-SPH_mcc_parameters` (18 checks) and all five pre-existing FSI-SPH unit tests pass in
each. A control on unpatched `origin/main` passes its five. The built library was verified by
content to contain the new messages before any demo was allowed to run.

**All four in-tree demos that set MCC parameters were run with MCC selected** and all four get past
`Initialize()` without tripping either the new error or the new warning. Three are clean.
`demo_VEH_CRMTerrain_TrackedVehicle --rheology_model_crm=MCC` initializes, runs about 2,250 steps to
t = 1.128 s, and then aborts inside `TauEulerStep`. **That is pre-existing and unrelated to this
change**: this commit alters no device code, and an unpatched `origin/main` control built in the same
worktree aborts at t = 1.1225 s, within one printed step. It is specific to MCC, since the same demo
on mu(I) reached t = 12.26 s and was still running. Reported separately.

**Not fixed here, and worth knowing:** `ChFsiFluidSystem::DoStepDynamics` has no
`m_is_initialized` guard, unlike `ChFsiSystem::DoStepDynamics`, so a bare `ChFsiFluidSystemSPH`
can be stepped without `Initialize()` and therefore without these checks. Practical impact is
bounded, since `m_fluid_dynamics` only exists after `Initialize()` and the first such step
dereferences null. Left out because it is a different class, a different directory, and it affects
CFD as well as CRM.

Closes #789.
