### PR TITLE
Sensor: make the Vulkan-only configuration build, and the validation demo's output trustworthy

### DIFF
--- a/src/chrono_sensor/filters/ChFilterCameraNoise.h
+++ b/src/chrono_sensor/filters/ChFilterCameraNoise.h
@@ -105,10 +105,13 @@ class CH_SENSOR_API ChFilterCameraNoisePixDep : public ChFilter {
     std::shared_ptr<SensorDeviceR8Buffer> m_r8InOut;        ///< input/output buffer for r8
 };
 
-// DLL-exported wrapper functions
-
+// DLL-exported wrapper functions. Guarded for the same reason the members above are: their
+// signatures name curandState_t and CUstream, whose headers are only included with OptiX, so a
+// build without CUDA fails to parse this header rather than merely lacking the functions.
+#ifdef CHRONO_HAS_OPTIX
 CH_SENSOR_API void InitCudaRNG(unsigned long long seed, curandState_t* rng_states, unsigned int n_generators);
 CH_SENSOR_API void CudaCameraNoiseConstNormal(unsigned char* bufPtr, int width, int height, float mean, float stdev, curandState_t* rng, CUstream& stream);
+#endif
 
 /// @}
 

--- a/src/demos/sensor/demo_SEN_vulkan_validation.cpp
+++ b/src/demos/sensor/demo_SEN_vulkan_validation.cpp
@@ -313,6 +313,12 @@ int main(int argc, char* argv[]) {
     bool probe_box_material = false;
     bool material_sweep = false;
     int material_index = -1;  // >= 0 isolates a single material sample (floor + that cube only)
+    // Overrides the isolated sample's roughness. The fixed sample list below bottoms out at 0.1,
+    // which leaves a region of the parameter space unreachable: the Vulkan reference clamps
+    // roughness to [0.02, 1], and ChVisualMaterial's default roughness is 0, so the value a shape
+    // gets when it carries the default material is inside the clamped region and no configuration
+    // of this demo could reach it. Negative means "use the sample's own value".
+    float roughness_override = -1.f;
     std::string feature;      // mesh | texture | normalmap | opacity | envmap (Florian steps c-f)
     std::string data_dir;    // optional Chrono data directory override
     unsigned int average_frames = 1;  // validation-only temporal average
@@ -357,6 +363,13 @@ int main(int argc, char* argv[]) {
         } else if (std::strcmp(argv[i], "--material-index") == 0 && i + 1 < argc) {
             material_sweep = true;
             material_index = std::atoi(argv[++i]);
+        } else if (std::strcmp(argv[i], "--roughness") == 0 && i + 1 < argc) {
+            const double r = std::atof(argv[++i]);
+            if (r < 0.0 || r > 1.0) {
+                std::cerr << "ERROR: --roughness takes a value in [0, 1]\n";
+                return 1;
+            }
+            roughness_override = static_cast<float>(r);
         } else if (std::strcmp(argv[i], "--spp") == 0 && i + 1 < argc) {
             const int f = std::atoi(argv[++i]);
             if (f < 1 || f > 32) {
@@ -407,11 +420,19 @@ int main(int argc, char* argv[]) {
                       << "                       without an explicit material\n"
                       << "  --seed N|clock       base RNG seed; pinned by default so stochastic runs\n"
                       << "                       reproduce, clock for the production default\n"
+                      << "  --roughness R        with --material-index, override that sample's roughness,\n"
+                      << "                       which is the only way to reach roughness below 0.1\n"
                       << "  --frames N           average N independently rendered frames (default 1)\n"
                       << "  --data DIR           Chrono data directory; auto-detected when omitted\n"
                       << "  --out DIR            output directory (default SENSOR_OUTPUT/vulkan_validation/)\n";
             return 1;
         }
+    }
+    if (roughness_override >= 0.f && material_index < 0) {
+        std::cerr << "--roughness overrides one isolated sample, so it needs --material-index N.\n"
+                  << "Applied to the whole sweep it would give every cube the same roughness, which\n"
+                  << "is what the sweep exists to vary.\n";
+        return 1;
     }
     if (light_kind == LightKind::DIRECTIONAL && !const_color) {
         std::cerr << "--falloff is not meaningful for a directional light: it has no position, so there\n"
@@ -507,6 +528,14 @@ int main(int argc, char* argv[]) {
         tag = std::string("feat_") + feature + "_" + kind_name + (const_color ? "_constcolor" : "_falloff");
     if (probe_box_material)
         tag += "_probe";  // the probe changes the scene, so it must not overwrite the plain run's images
+    if (roughness_override >= 0.f) {
+        // Same reason as the probe: an overridden sample is a different material, so it gets its own
+        // filenames. Written in hundredths, so 0.00 and 0.02 (the Vulkan clamp boundary) cannot
+        // collide, and the name stays free of a decimal point.
+        std::string hundredths = std::to_string((int)(roughness_override * 100.f + 0.5f));
+        hundredths.insert(hundredths.begin(), 3 - hundredths.size(), '0');
+        tag += "_rough" + hundredths;
+    }
     if (supersample != 1)
         tag += "_spp" + std::to_string(supersample * supersample);
     if (average_frames != 1)
@@ -610,12 +639,16 @@ int main(int argc, char* argv[]) {
         if (material_index >= 0) {
             // One sample, centered in view, so the reported metrics describe that material alone.
             const Sample& s = samples[material_index];
-            MakeCubeBody(sys, ChVector3d(-2.0, 0.0, 0.9), 0.9, s.roughness, s.metallic,
+            const float sample_roughness = (roughness_override >= 0.f) ? roughness_override : s.roughness;
+            MakeCubeBody(sys, ChVector3d(-2.0, 0.0, 0.9), 0.9, sample_roughness, s.metallic,
                          ChColor(surface_gray, surface_gray, surface_gray), ChColor(0.5f, 0.5f, 0.5f),
                          s.spec_workflow);
             std::cout << "MATERIAL ISOLATION: index " << material_index << " = " << s.label
-                      << "  (roughness " << s.roughness << ", metallic " << s.metallic
-                      << ", specular_workflow " << (s.spec_workflow ? "true" : "false") << ")\n";
+                      << "  (roughness " << sample_roughness;
+            if (roughness_override >= 0.f)
+                std::cout << " [overridden, sample value is " << s.roughness << "]";
+            std::cout << ", metallic " << s.metallic << ", specular_workflow "
+                      << (s.spec_workflow ? "true" : "false") << ")\n";
         } else {
             const double spacing = 1.6;
             const double y0 = -((n_samples - 1) * spacing) / 2.0;

--- a/src/demos/sensor/demo_SEN_vulkan_validation.cpp
+++ b/src/demos/sensor/demo_SEN_vulkan_validation.cpp
@@ -997,8 +997,18 @@ int main(int argc, char* argv[]) {
 #else
     // Vulkan-only build: capture the Vulkan image so it can be diffed offline against the
     // image the same tag produced on the NVIDIA host. Nothing to compare against locally.
-    WritePPM(out_dir + tag + "_vulkan.ppm", vulkan_buf);
+    //
+    // The write is checked here for the same reason it is checked above, and with more at stake:
+    // this configuration produces no comparison of its own, so the saved image IS the result. A
+    // silent failure would leave the cross-vendor diff to be run against a file that was never
+    // written, on the machine least likely to have the output directory already in place.
+    const std::string vulkan_path = out_dir + tag + "_vulkan.ppm";
     std::cout << "Vulkan-only build (no OptiX in this configuration).\n";
+    if (!WritePPM(vulkan_path, vulkan_buf)) {
+        std::cerr << "ERROR: could not write " << vulkan_path << "\n"
+                  << "ERROR: nothing was saved, so there is nothing to diff offline.\n";
+        return 1;
+    }
     std::cout << "Wrote " << tag << "_vulkan.ppm to " << out_dir << "\n";
     std::cout << "Diff it offline against the NVIDIA-host image of the same tag.\n";
 #endif

--- a/src/demos/sensor/demo_SEN_vulkan_validation.cpp
+++ b/src/demos/sensor/demo_SEN_vulkan_validation.cpp
@@ -316,12 +316,42 @@ int main(int argc, char* argv[]) {
     std::string feature;      // mesh | texture | normalmap | opacity | envmap (Florian steps c-f)
     std::string data_dir;    // optional Chrono data directory override
     unsigned int average_frames = 1;  // validation-only temporal average
+    // Stochastic configurations (environment lighting, and any noise filter) draw from per-pixel
+    // RNGs that are seeded from the wall clock unless a base seed is pinned. Pinned by default here,
+    // because this demo exists to compare images: without it, two runs of the same configuration
+    // differ, so a difference cannot be attributed to a code change rather than to the seed. Use
+    // --seed clock for the production default. This does not make the two backends draw the SAME
+    // numbers: per-stream seeds include the sensor's identity, which is what the environment-map
+    // convergence study relies on.
+    //
+    // Only the OptiX arm currently responds to this. The Vulkan RT backend derives its per-pixel
+    // sample sequence from the launch index and GetNumLaunches() alone and never reads the manager's
+    // base seed, so its images repeat across invocations either way: measured on the envmap
+    // configuration, the four OptiX images from two pinned and two clock runs are identical in the
+    // pinned pair and all different otherwise, while the four Vulkan images share one hash. So a
+    // --seed clock run here is a one-sided test, and independent Monte Carlo trials on the Vulkan
+    // path would share camera noise. Remove this paragraph once the backend mixes the base seed in.
+    bool pin_seed = true;
+    unsigned int random_seed = 20260802u;
     std::string out_dir = "SENSOR_OUTPUT/vulkan_validation/";
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--falloff") == 0) {
             const_color = false;
         } else if (std::strcmp(argv[i], "--probe-box-material") == 0) {
             probe_box_material = true;
+        } else if (std::strcmp(argv[i], "--seed") == 0 && i + 1 < argc) {
+            const std::string v = argv[++i];
+            if (v == "clock") {
+                pin_seed = false;
+            } else {
+                const long long n = std::atoll(v.c_str());
+                if (n < 0 || n > 4294967295LL) {
+                    std::cerr << "ERROR: --seed takes a value in [0, 4294967295] or the word clock\n";
+                    return 1;
+                }
+                pin_seed = true;
+                random_seed = static_cast<unsigned int>(n);
+            }
         } else if (std::strcmp(argv[i], "--materials") == 0) {
             material_sweep = true;
         } else if (std::strcmp(argv[i], "--material-index") == 0 && i + 1 < argc) {
@@ -375,6 +405,8 @@ int main(int argc, char* argv[]) {
                       << "                       attenuation (point and spot only)\n"
                       << "  --probe-box-material diagnostic: add ChBodyEasyBox primitives with and\n"
                       << "                       without an explicit material\n"
+                      << "  --seed N|clock       base RNG seed; pinned by default so stochastic runs\n"
+                      << "                       reproduce, clock for the production default\n"
                       << "  --frames N           average N independently rendered frames (default 1)\n"
                       << "  --data DIR           Chrono data directory; auto-detected when omitted\n"
                       << "  --out DIR            output directory (default SENSOR_OUTPUT/vulkan_validation/)\n";
@@ -473,6 +505,8 @@ int main(int argc, char* argv[]) {
               (const_color ? "_constcolor" : "_falloff");
     if (!feature.empty())
         tag = std::string("feat_") + feature + "_" + kind_name + (const_color ? "_constcolor" : "_falloff");
+    if (probe_box_material)
+        tag += "_probe";  // the probe changes the scene, so it must not overwrite the plain run's images
     if (supersample != 1)
         tag += "_spp" + std::to_string(supersample * supersample);
     if (average_frames != 1)
@@ -681,6 +715,15 @@ int main(int argc, char* argv[]) {
     // Sensor manager: zero ambient, black background, one point light.
     // ------------------------------------------------------------------
     auto manager = chrono_types::make_shared<ChSensorManager>(&sys);
+    // Before AddSensor, not after: a sensor's per-stream seeds are derived when its filters
+    // initialize, which happens inside AddSensor, so setting this later would have no effect.
+    if (pin_seed) {
+        ChSensorManager::SetRandomSeed(random_seed);
+        std::cout << "Random seed: pinned to " << random_seed << " (stochastic runs are reproducible)\n";
+    } else {
+        ChSensorManager::ClearRandomSeed();
+        std::cout << "Random seed: clock (stochastic runs differ between invocations)\n";
+    }
     // Opacity needs three surface hits (front face, back face, object behind).
     // OptiX primary PRDs start at depth 2, so max_depth=5 is the first setting
     // that reaches all three; the other deterministic cases keep the original 4.
@@ -892,12 +935,30 @@ int main(int argc, char* argv[]) {
     // ------------------------------------------------------------------
     // Persist images: reference, candidate, and amplified difference maps.
     // ------------------------------------------------------------------
-    WritePPM(out_dir + tag + "_optix.ppm", optix_buf);
-    WritePPM(out_dir + tag + "_vulkan.ppm", vulkan_buf);
+    // Report what was actually written. WritePPM returns false on a failed open or a short write,
+    // and printing "Wrote ..." regardless is worse than useless: three runs of this demo were read
+    // as successful while nothing had reached disk, because the output directory did not exist.
+    unsigned int write_failures = 0;
+    auto save = [&](const std::string& suffix, const UserRGBA8BufferPtr& img) {
+        const std::string path = out_dir + tag + suffix;
+        if (WritePPM(path, img))
+            return;
+        std::cerr << "ERROR: could not write " << path << "\n";
+        ++write_failures;
+    };
+
+    save("_optix.ppm", optix_buf);
+    save("_vulkan.ppm", vulkan_buf);
     if (auto diff1 = MakeAbsDiffRGBA8(vulkan_buf, optix_buf, 1.0f))
-        WritePPM(out_dir + tag + "_diff_x1.ppm", diff1);
+        save("_diff_x1.ppm", diff1);
     if (auto diff8 = MakeAbsDiffRGBA8(vulkan_buf, optix_buf, 8.0f))
-        WritePPM(out_dir + tag + "_diff_x8.ppm", diff8);
+        save("_diff_x8.ppm", diff8);
+
+    if (write_failures) {
+        std::cerr << "ERROR: " << write_failures << " image(s) not written to " << out_dir
+                  << "; the comparison numbers above are still valid but nothing was saved.\n";
+        return 1;
+    }
     std::cout << "Wrote " << tag << "_{optix,vulkan,diff_x1,diff_x8}.ppm to " << out_dir << "\n";
     std::cout << "(convert to PNG, e.g.:  magick " << out_dir << tag << "_diff_x8.ppm " << tag << "_diff_x8.png)\n";
 #else


### PR DESCRIPTION
Four commits, each carrying its own measurements. The first makes this branch compile without CUDA,
the configuration the Vulkan backend exists for; the rest make `demo_SEN_vulkan_validation` safe to act
on. No rendering behaviour changes.

## 1. The no-OptiX configuration does not compile

```
ChFilterCameraNoise.h(110): error C2061: syntax error: identifier 'curandState_t'
FAILED: src/chrono_sensor/CMakeFiles/Chrono_sensor.dir/utils/ChSensorUtils.cpp.obj
```

Two `CH_SENSOR_API` wrapper declarations name `curandState_t` and `CUstream`, while the headers
defining those types are included only under `CHRONO_HAS_OPTIX`. The members of the same types just
above them are guarded; these two were not.

Three things had to line up. The declarations came from main in `37d526132`, where they are correct:
that header's CUDA includes are unguarded there and nothing includes it without OptiX. This branch
guards those includes, so the header looks safe to include without CUDA. This branch also widened the
guard in `ChSensorUtils.h` to `#if defined(CHRONO_HAS_OPTIX) || defined(CHRONO_HAS_VULKAN_RT)`, since a
Vulkan build needs the camera and lidar headers from that block, which pulls the header into a build
with no CUDA. Neither side touched the other's lines, so the merge was clean and the result does not
parse. main itself is unaffected.

Measured on a Ryzen AI Max+ 395 with an integrated Radeon 8060S (driver 26.6.4, Vulkan 1.4.350, MSVC
14.44, no CUDA, no OptiX): before, the build stops at `ChSensorUtils.cpp`; after, `Chrono_sensor` and
the demo build clean and the demo renders through Vulkan RT alone.

## 2. Writes were reported as successful whether or not they happened

`WritePPM` returns `false` on a failed open or short write and every return value was discarded, so the
demo printed `Wrote ...` and exited 0 with nothing on disk. Three runs were read as successful this way.
Both paths now report per-image failures and exit 1; the Vulkan-only path matters most, since it
produces no local comparison, so the saved image is the result. Verified by exercising the failure on
both builds: error lines printed, zero `Wrote` lines, zero files, exit 1, positive control unaffected.

## 3. A probe run overwrote the plain run, and stochastic runs did not reproduce

`--probe-box-material` changes the scene but not the tag, so a later comparison silently compared two
scenes; the tag now carries `_probe`. Environment lighting is clock-seeded unless pinned, so two runs of
one configuration differed and a difference could not be attributed to a code change rather than the
seed. `--seed N|clock`, pinned by default, set before `AddSensor` because per-stream seeds are derived
when filters initialise. Two default runs give byte-identical OptiX images (md5 `eae0fcd4dcc0`, RMSE
18.4599 both); two `--seed clock` runs differ (18.4786, 18.4518); bad values exit 1.

Those runs also show that only the OptiX arm responds to the seed: all four Vulkan images share one
hash, because the Vulkan backend derives its per-pixel sequence from the launch index and
`GetNumLaunches()` and never reads the base seed. Recorded in a comment beside the new flag, not fixed
here, since that is backend code.

## 4. `--roughness R` reaches the range the default material uses

The sweep is six fixed samples bottoming out at 0.1. Below that sit `ChVisualMaterial`'s default
roughness of 0 and the Vulkan reference's 0.02 floor, applied where it reads the material and again
inside `NormalDistOptix`, where the OptiX `NormalDist` has none. No command line could reach either.
`--roughness R` overrides the isolated sample, requires `--material-index`, and is recorded in the tag.

Sample 4 (metallic 1.0), 1280x720, one point light:

| roughness | RMSE | maxabs | over 2 units | mean OptiX / Vulkan |
|---|---|---|---|---|
| 0.00 | 12.7677 | 61 | 9.90 % | 28.6836 / 25.0374 |
| 0.02 | 12.7936 | 61 | 9.90 % | 28.6915 / 25.0374 |
| 0.03 | 2.3250 | 12 | 9.86 % | 28.7015 / 28.3204 |
| 0.04 | 0.5862 | 1 | 0.00 % | 28.7151 / 29.0588 |
| 0.10 | 0.5990 | 1 | 0.00 % | 27.8592 / 28.2181 |

They agree down to 0.04 and disagree below it, Vulkan darker by 3.65 units on average and 61 locally.
Not sampling noise: at 4 and 16 samples per pixel it stays at 12.7666 and 12.7625. The floor is visible,
since the Vulkan mean is identical at 0.00 and 0.02 while the OptiX mean is not, but the step between
0.02 and 0.04 is larger than the floor alone accounts for and this PR does not diagnose it. A diffuse
material at roughness 0 is unaffected.

## Nothing already covered changes

All thirteen configurations report identical numbers before and after, except that the stochastic ones
now repeat. The six-cube sweep still measures RMSE 0.5784 with maxabs 1, and each sample in isolation
still measures maxabs 1 with 0.00 % over threshold.
