### PR TITLE
Core: link the CUDA runtime, which Chrono_core already calls

### DIFF
--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -1538,6 +1538,14 @@ if(CHRONO_THRUST_FOUND)
   endif()
 endif()
 
+if(CHRONO_CUDA_FOUND)
+  # The multicore collision sources reach the CUDA runtime API through gpu/ChGpuRuntime.h, so
+  # Chrono_core itself references cudaGetErrorString. Declare that here rather than leaving the
+  # symbol for a consumer to satisfy by accident: it resolves only in builds where something else
+  # already links the runtime, and fails in those where nothing does.
+  target_link_libraries(Chrono_core PRIVATE CUDA::cudart)
+endif()
+
 if(CH_ENABLE_OPENMP)
   target_link_libraries(Chrono_core PUBLIC OpenMP::OpenMP_CXX)
 endif()


### PR DESCRIPTION
The multicore collision sources reach the CUDA runtime API through gpu/ChGpuRuntime.h, so libChrono_core carries an undefined reference to cudaGetErrorString and never links cudart. It resolves by accident in builds where some other target pulls the runtime in, and fails where none does:

  /usr/bin/ld: libChrono_core.so: undefined reference to `cudaGetErrorString`

Reproduced with -DCH_ENABLE_MODULE_SENSOR=ON -DCH_USE_SENSOR_OPTIX=OFF on a machine that has CUDA installed, which is what one would configure to exercise a non-OptiX rendering path on an NVIDIA box. That configuration links after this change.