### PR TITLE
CI: clear CI_COMMIT_MESSAGE in Windows to prevent MSBuild MSB4166 crashes

### DIFF
--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -393,6 +393,13 @@ linux:ubuntu22.04:arm64:deploy-python3.13:
   tags:
   - windows11
   before_script:
+  # Windows caps a single environment variable at 32767 chars. A branch head whose
+  # (squash) commit message exceeds that limit crashes every parallel MSBuild child
+  # node with MSB4166 "Environment variable name or value is too long", because
+  # MSBuild replicates the whole environment into its worker processes. Clear the
+  # only unbounded variables before any build tool runs. (Job 'rules:' that match
+  # on CI_COMMIT_MESSAGE are evaluated server-side and are NOT affected.)
+  - $env:CI_COMMIT_MESSAGE = ""; $env:CI_COMMIT_DESCRIPTION = ""
   - '& "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Launch-VsDevShell.ps1"'
   - $env:CONDA_INSTALL_LOCN="C:\Users\builder\miniconda3"
   - echo $CI_PROJECT_DIR
@@ -443,6 +450,8 @@ windows:vs2022:test:
   tags:
     - windows11
   before_script:
+    # See .windows: oversized CI_COMMIT_MESSAGE (>32767 chars) crashes MSBuild workers.
+    - $env:CI_COMMIT_MESSAGE = ""; $env:CI_COMMIT_DESCRIPTION = ""
     - $env:CONDA_INSTALL_LOCN="C:\Users\builder\miniconda3"
     - echo $CI_PROJECT_DIR
     - git submodule init


### PR DESCRIPTION

Windows caps a single environment variable at 32767 characters. GitLab injects the full commit message of the pipeline's head commit into the job environment as CI_COMMIT_MESSAGE. When a branch head carries a very large message (e.g. the 74k-character squash commit currently at the tip of feature/sensor_vulkan), every parallel MSBuild child node dies at startup with

  MSBUILD : error MSB4166: Child node exited prematurely.
  System.ArgumentException: Environment variable name or value is too long.
  at Microsoft.Build.Execution.OutOfProcNode.HandleNodeConfiguration

because MSBuild replicates the parent environment into its worker processes through .NET SetEnvironmentVariable, which enforces the 32k limit. The windows:vs2022:build job then fails in under a second while main (with normal-sized commit messages) builds fine on the same runners. Linux jobs are unaffected since ninja does not replicate the environment this way.

Fix: blank CI_COMMIT_MESSAGE and CI_COMMIT_DESCRIPTION at the top of the Windows before_script blocks (.windows and .windows-deploy-base), before any build tool runs. Job rules that match on CI_COMMIT_MESSAGE (the [install] trigger for the installer jobs) are evaluated server-side before the job starts, so they are not affected by clearing the runtime environment.