### PR TITLE
Feat/gpu backend hardware first

### DIFF
--- a/cmake/ChronoConfig.cmake.in
+++ b/cmake/ChronoConfig.cmake.in
@@ -315,9 +315,50 @@ endif()
 # configured Chrono) decide a gate.
 #-------------------------------------------------------------------------------
 
-set(CHRONO_GPU_BACKEND_RESOLVED "@CHRONO_GPU_BACKEND_RESOLVED@")
+# The backend each GPU component was actually built with. There is no longer a
+# single build-wide answer: components resolve independently, so a consumer
+# must be told per component which language, if any, it needs enabled.
+#
+# Empty means the component was not built at all.
+set(CHRONO_DEM_GPU_BACKEND     "@CHRONO_DEM_BACKEND@")
+set(CHRONO_FSI_SPH_GPU_BACKEND "@CHRONO_FSISPH_BACKEND@")
+
+# Chrono::Sensor needs CUDA only for its optional OptiX renderer; its default
+# Vulkan RT renderer is vendor-neutral. Keying on the module would force a
+# pointless CUDA search on consumers of an AMD or CPU-only Sensor build.
+set(CHRONO_SENSOR_USES_OPTIX   "@CH_USE_SENSOR_OPTIX@")
+
+set(CHRONO_GPU_VENDOR          "@CHRONO_GPU_VENDOR_RESOLVED@")
+set(CHRONO_HIP_PLATFORM        "@CHRONO_HIP_PLATFORM@")
+
 set(CHRONO_CUDA_FOUND FALSE)
 set(CHRONO_HIP_FOUND FALSE)
+
+# Derive what the REQUESTED components actually need. A consumer asking only
+# for components that resolved to HIP must not have CUDA enabled behind its
+# back, and vice versa.
+set(_chrono_need_cuda FALSE)
+set(_chrono_need_hip FALSE)
+
+if(Chrono_DEM_REQUESTED)
+  if(CHRONO_DEM_GPU_BACKEND STREQUAL "CUDA")
+    set(_chrono_need_cuda TRUE)
+  elseif(CHRONO_DEM_GPU_BACKEND STREQUAL "HIP")
+    set(_chrono_need_hip TRUE)
+  endif()
+endif()
+
+if(Chrono_FSI_SPH_REQUESTED)
+  if(CHRONO_FSI_SPH_GPU_BACKEND STREQUAL "CUDA")
+    set(_chrono_need_cuda TRUE)
+  elseif(CHRONO_FSI_SPH_GPU_BACKEND STREQUAL "HIP")
+    set(_chrono_need_hip TRUE)
+  endif()
+endif()
+
+if(Chrono_SENSOR_REQUESTED AND CHRONO_SENSOR_USES_OPTIX)
+  set(_chrono_need_cuda TRUE)
+endif()
 
 #-------------------------------------------------------------------------------
 # Enable CUDA if necessary
@@ -327,8 +368,7 @@ set(CHRONO_HIP_FOUND FALSE)
 # CHRONO_CUDA_FOUND false, which is the correct value but for the wrong reason.
 #-------------------------------------------------------------------------------
 
-if((Chrono_DEM_REQUESTED OR Chrono_FSI_SPH_REQUESTED OR Chrono_SENSOR_REQUESTED)
-   AND NOT CHRONO_GPU_BACKEND_RESOLVED STREQUAL "HIP")
+if(_chrono_need_cuda)
   set(CMAKE_CUDA_COMPILER "@CMAKE_CUDA_COMPILER@" CACHE PATH "CUDA compiler")
   set(CUDAToolkit_DIR "@CUDAToolkit_LIBRARY_ROOT@" CACHE PATH "CUDAToolkit library location (should contain 'version.json')")
 
@@ -379,8 +419,7 @@ endif()
 # exported Chrono targets reference.
 #-------------------------------------------------------------------------------
 
-if((Chrono_DEM_REQUESTED OR Chrono_FSI_SPH_REQUESTED)
-   AND CHRONO_GPU_BACKEND_RESOLVED STREQUAL "HIP")
+if(_chrono_need_hip)
   set(CHRONO_ROCM_ROOT "@CHRONO_ROCM_ROOT@" CACHE PATH "ROCm root used to build Chrono")
 
   # Do NOT mutate CMAKE_PREFIX_PATH here. This code runs in the CONSUMER's scope,

--- a/cmake/ChronoGPUDetect.cmake
+++ b/cmake/ChronoGPUDetect.cmake
@@ -163,6 +163,21 @@ if(_chrono_hip_platform_request)
       set(CMAKE_HIP_PLATFORM "${_chrono_hip_platform_request}" CACHE STRING "HIP platform")
     endif()
 
+    # On the NVIDIA platform the HIP compiler IS nvcc: HIP compiles to CUDA
+    # there, and ROCm ships no compiler that targets NVIDIA. check_language(HIP)
+    # searches for hipcc/clang, finds neither usable, and reports "no HIP
+    # compiler" -- which reads like a broken ROCm install rather than a missing
+    # setting. We already located nvcc when CUDA was enabled above, so use it
+    # instead of making every user pass -DCMAKE_HIP_COMPILER by hand.
+    #
+    # Only a default: an explicit CMAKE_HIP_COMPILER always wins.
+    if(_chrono_hip_platform_request STREQUAL "nvidia"
+       AND NOT DEFINED CMAKE_HIP_COMPILER
+       AND CMAKE_CUDA_COMPILER)
+      set(CMAKE_HIP_COMPILER "${CMAKE_CUDA_COMPILER}" CACHE FILEPATH "HIP compiler")
+      message(STATUS "  HIP compiler defaulted to the CUDA compiler: ${CMAKE_HIP_COMPILER}")
+    endif()
+
     check_language(HIP)
 
     if(NOT CMAKE_HIP_COMPILER)

--- a/cmake/ChronoGPUDetect.cmake
+++ b/cmake/ChronoGPUDetect.cmake
@@ -217,6 +217,48 @@ unset(_chrono_hip_platform_request)
 
 chrono_report_missing_gpu_toolchain()
 
+# Report a global preference that cannot be honoured.
+#
+# CHRONO_GPU_BACKEND is documented as a preference, so quietly using the other
+# backend is the correct OUTCOME -- but doing it silently is not. Someone who
+# passed -DCHRONO_GPU_BACKEND=HIP and got a CUDA build with no mention of HIP
+# anywhere in the log has no way to tell whether their request was honoured,
+# ignored, or misspelled.
+#
+# Reported once here, where the toolchain facts are known, rather than once per
+# feature in Layer 2: the cause is global, so repeating it per module would be
+# noise around a single piece of information.
+if(NOT CHRONO_GPU_BACKEND STREQUAL "AUTO")
+  set(_requested_available FALSE)
+  if(CHRONO_GPU_BACKEND STREQUAL "CUDA" AND CHRONO_CUDA_FOUND)
+    set(_requested_available TRUE)
+  elseif(CHRONO_GPU_BACKEND STREQUAL "HIP" AND CHRONO_HIP_FOUND)
+    set(_requested_available TRUE)
+  endif()
+
+  if(_requested_available)
+    message(STATUS "  Preferred GPU backend:   ${CHRONO_GPU_BACKEND} (available)")
+  else()
+    set(_hint "")
+    if(CHRONO_GPU_BACKEND STREQUAL "HIP" AND CHRONO_GPU_VENDOR_RESOLVED STREQUAL "NVIDIA")
+      set(_hint
+          "  This build targets NVIDIA. To use HIP on NVIDIA hardware, configure with "
+          "-DCHRONO_ENABLE_HIP_ON_NVIDIA=ON (requires CMake >= 3.28); to build for AMD "
+          "hardware instead, use -DCHRONO_GPU_VENDOR=AMD.")
+    elseif(CHRONO_GPU_BACKEND STREQUAL "CUDA" AND CHRONO_GPU_VENDOR_RESOLVED STREQUAL "AMD")
+      set(_hint "  This build targets AMD, where CUDA is not searched for. Use "
+                "-DCHRONO_GPU_VENDOR=NVIDIA to build for NVIDIA hardware.")
+    endif()
+    string(REPLACE ";" "" _hint "${_hint}")
+
+    message(WARNING
+      "CHRONO_GPU_BACKEND=${CHRONO_GPU_BACKEND} was requested, but ${CHRONO_GPU_BACKEND} is "
+      "not available in this configuration (CUDA=${CHRONO_CUDA_FOUND}, HIP=${CHRONO_HIP_FOUND}). "
+      "Modules will use whichever backend they can.\n"
+      "${_hint}")
+  endif()
+endif()
+
 # Retained for backward compatibility with anything reading a single "is there
 # a GPU" flag. Under independent facts this is simply the disjunction; it must
 # NOT be used to decide which backend anything compiles as.

--- a/cmake/ChronoGPUDetect.cmake
+++ b/cmake/ChronoGPUDetect.cmake
@@ -1,0 +1,238 @@
+#=============================================================================
+# Chrono GPU backend detection -- orchestrator
+#
+# This file is include()d from src/CMakeLists.txt and DELIBERATELY EXECUTES AT
+# FILE SCOPE rather than wrapping its body in a function.
+#
+# That is not a style choice. enable_language() is only valid at file scope:
+# called from inside a function it configures without complaint and then fails
+# at generate time with "required internal CMake variable not set ...
+# CMAKE_CUDA_COMPILE_WHOLE_COMPILATION", and CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR
+# never gets defined. include() runs in the includer's scope, so the language
+# enabling below lands in src/ directory scope exactly as it did when this code
+# was inline.
+#
+# Everything that does NOT touch language state lives in pure functions in
+# ChronoGPUVendor.cmake (Layer 0) and ChronoGPUToolchains.cmake (Layer 1).
+#
+# Publishes into src/ directory scope, and therefore into every module:
+#   CHRONO_GPU_VENDOR_RESOLVED   NVIDIA | AMD | NONE
+#   CHRONO_GPU_HOST_VENDOR       NVIDIA | AMD | BOTH | NONE | UNKNOWN
+#   CHRONO_GPU_CROSS_TARGET      TRUE | FALSE
+#   CHRONO_CUDA_FOUND            independent fact
+#   CHRONO_HIP_FOUND             independent fact
+#   CHRONO_HIP_PLATFORM          amd | nvidia | ""
+#=============================================================================
+
+include(CheckLanguage)
+include(ChronoGPUToolchains)
+include(ChronoGPUVendor)
+
+mark_as_advanced(FORCE CMAKE_CUDA_ARCHITECTURES)
+mark_as_advanced(FORCE CMAKE_HIP_ARCHITECTURES)
+
+message(STATUS "Searching for GPU backends")
+
+#-----------------------------------------------------------------------------
+# Layer 0 -- vendor
+#-----------------------------------------------------------------------------
+
+chrono_resolve_gpu_vendor()
+
+#-----------------------------------------------------------------------------
+# Layer 1 -- toolchains
+#
+# Note the shape here: these are two independent searches, not an if/else. On
+# NVIDIA, CUDA is searched and HIP MAY ALSO be searched; the outcome of one
+# does not suppress the other. The old code gated the CUDA search behind
+# "if(NOT CHRONO_HIP_FOUND)", which is what allowed a stray ROCm install to
+# hide a perfectly good CUDA toolkit.
+#-----------------------------------------------------------------------------
+
+set(CHRONO_CUDA_FOUND FALSE)
+set(CHRONO_HIP_FOUND FALSE)
+set(CHRONO_HIP_PLATFORM "")
+set(CHRONO_ROCM_VERSION "")
+set(_chrono_hip_platform_request "")
+
+#--- CUDA -------------------------------------------------------------------
+# Searched only for NVIDIA. On an AMD build a CUDA toolkit that happens to be
+# installed tells us nothing useful, and probing for it would only emit a
+# confusing "CUDA not found" diagnostic about something we never wanted.
+
+if(CHRONO_GPU_VENDOR_RESOLVED STREQUAL "NVIDIA")
+
+  message(STATUS "Searching for CUDA")
+  check_language(CUDA)
+
+  if(CMAKE_CUDA_COMPILER)
+
+    enable_language(CUDA)
+    find_package(CUDAToolkit)
+    message(STATUS "  CUDA compiler:           ${CMAKE_CUDA_COMPILER}")
+    message(STATUS "  CUDA toolkit version:    ${CUDAToolkit_VERSION}")
+    message(STATUS "  CUDA toolkit root dir:   ${CUDAToolkit_LIBRARY_ROOT}")
+
+    if(CHRONO_CUDA_ARCHITECTURES STREQUAL "")
+      # all-major is a fat-binary default and so is already correct for
+      # distribution builds; CUDA needs no cross-target special case here,
+      # unlike HIP below.
+      if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.23")
+        set(CHRONO_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR}"
+            CACHE STRING "Chrono CUDA architectures" FORCE)
+        message(STATUS "  CUDA archs (set to):     ${CHRONO_CUDA_ARCHITECTURES}")
+      endif()
+    else()
+      message(STATUS "  CUDA archs (from cache): ${CHRONO_CUDA_ARCHITECTURES}")
+    endif()
+
+    chrono_guard_cross_target_arch("CUDA" CHRONO_CUDA_ARCHITECTURES)
+
+    # Architecture 50 has no double-precision atomicAdd.
+    list(REMOVE_ITEM CHRONO_CUDA_ARCHITECTURES "50" "50-real")
+    message(STATUS "  CUDA archs (filtered):   ${CHRONO_CUDA_ARCHITECTURES}")
+
+    if(CHRONO_CUDA_ARCHITECTURES STREQUAL "")
+      message(WARNING "  CUDA architectures not found. Set CHRONO_CUDA_ARCHITECTURES")
+    else()
+      set(CHRONO_CUDA_FOUND TRUE)
+      set(CMAKE_CUDA_ARCHITECTURES ${CHRONO_CUDA_ARCHITECTURES} CACHE STRING "CUDA architectures" FORCE)
+      if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+        set(CUDA_SEPARABLE_COMPILATION OFF)
+      endif()
+      message(STATUS "  CUDA found and enabled.")
+    endif()
+
+  else()
+
+    mark_as_advanced(FORCE CHRONO_CUDA_ARCHITECTURES)
+    message(STATUS "  CUDA not found. CUDA features will be disabled.")
+
+  endif()
+
+  #--- HIP on NVIDIA (secondary, opt-in) ------------------------------------
+  if(CHRONO_ENABLE_HIP_ON_NVIDIA)
+    # CMake gained HIP language support in 3.21, but for the AMD platform only.
+    # Driving the HIP language with CMAKE_HIP_PLATFORM=nvidia needs 3.28.
+    # Refusing here is better than letting check_language(HIP) fail in a way
+    # that reads like a broken ROCm install.
+    if(CMAKE_VERSION VERSION_LESS "3.28")
+      message(WARNING
+        "CHRONO_ENABLE_HIP_ON_NVIDIA requires CMake >= 3.28 (have ${CMAKE_VERSION}); "
+        "HIP on NVIDIA will not be enabled.")
+    else()
+      set(_chrono_hip_platform_request "nvidia")
+    endif()
+  endif()
+
+elseif(CHRONO_GPU_VENDOR_RESOLVED STREQUAL "AMD")
+
+  set(_chrono_hip_platform_request "amd")
+
+else()
+
+  message(STATUS "  No GPU vendor resolved; skipping GPU toolchain search.")
+
+endif()
+
+#--- HIP --------------------------------------------------------------------
+
+if(_chrono_hip_platform_request)
+
+  message(STATUS "Searching for HIP (platform: ${_chrono_hip_platform_request})")
+
+  chrono_find_rocm(_chrono_rocm_root _chrono_rocm_ver)
+
+  if(NOT _chrono_rocm_root)
+
+    message(STATUS "  ROCm not found. HIP features will be disabled.")
+
+  elseif(_chrono_rocm_ver VERSION_LESS CHRONO_HIP_MIN_VERSION)
+
+    message(WARNING
+      "  Found ROCm ${_chrono_rocm_ver} at ${_chrono_rocm_root}, but Chrono requires "
+      ">= ${CHRONO_HIP_MIN_VERSION}. HIP features will be disabled.")
+
+  else()
+
+    list(PREPEND CMAKE_PREFIX_PATH "${_chrono_rocm_root}")
+    if(NOT DEFINED CMAKE_HIP_COMPILER_ROCM_ROOT)
+      set(CMAKE_HIP_COMPILER_ROCM_ROOT "${_chrono_rocm_root}" CACHE PATH "ROCm root path")
+    endif()
+    if(NOT DEFINED CMAKE_HIP_PLATFORM)
+      set(CMAKE_HIP_PLATFORM "${_chrono_hip_platform_request}" CACHE STRING "HIP platform")
+    endif()
+
+    check_language(HIP)
+
+    if(NOT CMAKE_HIP_COMPILER)
+
+      message(STATUS "  No HIP compiler was found. HIP features will be disabled.")
+
+    else()
+
+      enable_language(HIP)
+
+      if(CHRONO_HIP_ARCHITECTURES STREQUAL "")
+        # Prefer a concrete gfx target discovered by rocminfo over "native": it
+        # is equally accurate here and, unlike "native", it survives being
+        # copied into a preset or a CI script that runs somewhere else.
+        if(CHRONO_GPU_HOST_GFX)
+          set(CHRONO_HIP_ARCHITECTURES "${CHRONO_GPU_HOST_GFX}"
+              CACHE STRING "Chrono HIP architectures" FORCE)
+        elseif(NOT CHRONO_GPU_CROSS_TARGET AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.21")
+          set(CHRONO_HIP_ARCHITECTURES "native" CACHE STRING "Chrono HIP architectures" FORCE)
+        endif()
+      endif()
+
+      chrono_guard_cross_target_arch("HIP" CHRONO_HIP_ARCHITECTURES)
+
+      if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
+        set(CMAKE_HIP_ARCHITECTURES ${CHRONO_HIP_ARCHITECTURES} CACHE STRING "HIP architectures" FORCE)
+      endif()
+
+      set(CHRONO_HIP_FOUND TRUE)
+      set(CHRONO_HIP_PLATFORM "${_chrono_hip_platform_request}")
+      set(CHRONO_ROCM_VERSION "${_chrono_rocm_ver}")
+      set(CHRONO_ROCM_ROOT "${_chrono_rocm_root}" CACHE PATH "Explicit ROCm root for HIP builds" FORCE)
+
+      message(STATUS "  HIP compiler:            ${CMAKE_HIP_COMPILER}")
+      message(STATUS "  ROCm version:            ${CHRONO_ROCM_VERSION}")
+      message(STATUS "  ROCm root dir:           ${CHRONO_ROCM_ROOT}")
+      if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
+        message(STATUS "  HIP archs:               ${CHRONO_HIP_ARCHITECTURES}")
+      endif()
+
+    endif()
+
+  endif()
+
+endif()
+
+unset(_chrono_hip_platform_request)
+
+#-----------------------------------------------------------------------------
+# Summary and diagnostics
+#-----------------------------------------------------------------------------
+
+chrono_report_missing_gpu_toolchain()
+
+# Retained for backward compatibility with anything reading a single "is there
+# a GPU" flag. Under independent facts this is simply the disjunction; it must
+# NOT be used to decide which backend anything compiles as.
+if(CHRONO_CUDA_FOUND OR CHRONO_HIP_FOUND)
+  set(CHRONO_GPU_FOUND TRUE)
+else()
+  set(CHRONO_GPU_FOUND FALSE)
+endif()
+
+# Hide the knobs that are irrelevant for the resolved vendor.
+if(CHRONO_GPU_VENDOR_RESOLVED STREQUAL "NVIDIA")
+  mark_as_advanced(FORCE CHRONO_HIP_ARCHITECTURES)
+  mark_as_advanced(FORCE CHRONO_HIP_MIN_VERSION)
+  mark_as_advanced(FORCE CHRONO_ROCM_ROOT)
+elseif(CHRONO_GPU_VENDOR_RESOLVED STREQUAL "AMD")
+  mark_as_advanced(FORCE CHRONO_CUDA_ARCHITECTURES)
+endif()
+
+message(STATUS "  GPU toolchains available: CUDA=${CHRONO_CUDA_FOUND} HIP=${CHRONO_HIP_FOUND}")

--- a/cmake/ChronoGPUModule.cmake
+++ b/cmake/ChronoGPUModule.cmake
@@ -392,9 +392,24 @@ function(chrono_apply_gpu_backend target backend)
           # forwards it to the host compiler, producing
           # "gcc: error: unrecognized command-line option '--offload-arch=...'".
           # Translate to a CUDA gencode spec instead.
-          string(REGEX REPLACE "^sm_" "" _cc "${_arch}")
-          target_compile_options(${target} PRIVATE
-            $<$<COMPILE_LANGUAGE:HIP>:--generate-code=arch=compute_${_cc},code=sm_${_cc}>)
+          if(_arch STREQUAL "native")
+            # "native" is a keyword, not an architecture, so it must not be
+            # pasted into a gencode spec -- that yields compute_native and
+            # "nvcc fatal: Unsupported gpu architecture 'compute_native'".
+            # nvcc spells the same request -arch=native (CUDA >= 11.5), which
+            # is also what CHRONO_HIP_ARCHITECTURES defaults to, so this is the
+            # path taken whenever the user does not set an architecture.
+            #
+            # Cross-target builds never reach here: chrono_guard_cross_target_arch()
+            # rejects "native" at configure time, since there is no local GPU to
+            # detect.
+            target_compile_options(${target} PRIVATE
+              $<$<COMPILE_LANGUAGE:HIP>:-arch=native>)
+          else()
+            string(REGEX REPLACE "^sm_" "" _cc "${_arch}")
+            target_compile_options(${target} PRIVATE
+              $<$<COMPILE_LANGUAGE:HIP>:--generate-code=arch=compute_${_cc},code=sm_${_cc}>)
+          endif()
         else()
           target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:HIP>:--offload-arch=${_arch}>)
           target_link_options(${target} PRIVATE $<$<LINK_LANGUAGE:HIP>:--offload-arch=${_arch}>)

--- a/cmake/ChronoGPUModule.cmake
+++ b/cmake/ChronoGPUModule.cmake
@@ -1,0 +1,363 @@
+#=============================================================================
+# Chrono GPU backend resolution -- Layer 2: per-feature selection
+#
+# Answers: WHICH BACKEND DOES THIS PARTICULAR FEATURE COMPILE AS?
+#
+# Granularity is per FEATURE, not per module. That distinction is load-bearing
+# rather than pedantic: Chrono::Sensor requires no GPU backend at all (its
+# default renderer is Vulkan RT, which is vendor-neutral), while its optional
+# OptiX renderer requires CUDA specifically. A module-level "Sensor requires
+# CUDA" rule would wrongly disable the whole module on AMD hardware, where it
+# builds and runs perfectly well.
+#
+# Layer 2 cannot observe HOW the vendor was decided in Layer 0, and must not
+# try to. Preference engages whenever two or more toolchain facts satisfy a
+# feature's REQUIRES -- a function of Layer 1's output alone. That keeps this
+# layer testable by injecting fact combinations, with no hardware involved.
+#=============================================================================
+
+include_guard(GLOBAL)
+
+# Whether an explicitly requested feature that cannot get a backend is a fatal
+# error or a loud warning.
+#
+# Defaults OFF so this is not a breaking change for matrix builds that sweep
+# -DCH_ENABLE_MODULE_*=ON across heterogeneous machines and rely on modules
+# quietly dropping out. Chrono's own CI should turn it ON.
+option(CHRONO_STRICT_MODULE_REQUIREMENTS
+       "Treat an unsatisfiable GPU requirement for an explicitly enabled module as a fatal error" OFF)
+
+# Global backend preference, applied when a feature could use either backend.
+#
+# This variable previously named the single exclusive backend for the entire
+# build. It now expresses a PREFERENCE. The spelling and accepted values are
+# unchanged, so anyone who was setting it explicitly keeps getting what they
+# asked for; what changed is that it no longer suppresses the search for the
+# backend it did not name.
+set(CHRONO_GPU_BACKEND "AUTO" CACHE STRING
+    "Preferred GPU backend when a module could use either: AUTO, CUDA, HIP")
+set_property(CACHE CHRONO_GPU_BACKEND PROPERTY STRINGS AUTO CUDA HIP)
+
+# Validate here rather than at the point of use. Preference is only consulted
+# when two or more backends are available, so a typo would otherwise pass
+# unnoticed on every single-backend machine and only surface for the one user
+# who happens to have both SDKs installed.
+if(NOT CHRONO_GPU_BACKEND MATCHES "^(AUTO|CUDA|HIP)$")
+  message(FATAL_ERROR
+    "Invalid CHRONO_GPU_BACKEND='${CHRONO_GPU_BACKEND}'. Expected AUTO, CUDA, or HIP.")
+endif()
+
+#-----------------------------------------------------------------------------
+# chrono_select_gpu_backend(<out_var>
+#                           FEATURE  <human readable name>
+#                           REQUIRES <CUDA|HIP|CUDA_OR_HIP>
+#                           [NAME    <SHORTNAME>]
+#                           [PREFER  <CUDA|HIP>])
+#
+# Sets <out_var> to CUDA, HIP, or NONE.
+#
+# Precedence:
+#   1. CHRONO_<SHORTNAME>_GPU_BACKEND   per-feature override  -> FATAL if unmet
+#   2. CHRONO_GPU_BACKEND               global preference
+#   3. PREFER                           the feature's own declared preference
+#   4. the single satisfying fact
+#   5. NONE
+#
+# A per-feature override is deliberately NOT registered as a documented cache
+# entry. The mechanism exists (passing -DCHRONO_DEM_GPU_BACKEND=HIP works and
+# is honoured), but every advertised cache variable is a permanent
+# compatibility obligation, and nothing in-tree needs one yet. Promote it to a
+# real option() when a module actually diverges.
+#-----------------------------------------------------------------------------
+
+function(chrono_select_gpu_backend out_var)
+  cmake_parse_arguments(ARG "" "FEATURE;REQUIRES;NAME;PREFER" "" ${ARGN})
+
+  if(NOT ARG_FEATURE OR NOT ARG_REQUIRES)
+    message(FATAL_ERROR "chrono_select_gpu_backend() requires FEATURE and REQUIRES")
+  endif()
+
+  # Which facts would satisfy this feature?
+  set(_candidates "")
+  if(ARG_REQUIRES STREQUAL "CUDA")
+    if(CHRONO_CUDA_FOUND)
+      list(APPEND _candidates "CUDA")
+    endif()
+  elseif(ARG_REQUIRES STREQUAL "HIP")
+    if(CHRONO_HIP_FOUND)
+      list(APPEND _candidates "HIP")
+    endif()
+  elseif(ARG_REQUIRES STREQUAL "CUDA_OR_HIP")
+    if(CHRONO_CUDA_FOUND)
+      list(APPEND _candidates "CUDA")
+    endif()
+    if(CHRONO_HIP_FOUND)
+      list(APPEND _candidates "HIP")
+    endif()
+  else()
+    message(FATAL_ERROR
+      "chrono_select_gpu_backend(): invalid REQUIRES='${ARG_REQUIRES}'. "
+      "Expected CUDA, HIP, or CUDA_OR_HIP.")
+  endif()
+
+  # --- Tier 1: per-feature override -----------------------------------------
+  # An explicit request that cannot be satisfied is a user error, not an
+  # invitation to silently substitute something else.
+  if(ARG_NAME)
+    set(_override_var "CHRONO_${ARG_NAME}_GPU_BACKEND")
+    if(DEFINED ${_override_var} AND NOT "${${_override_var}}" STREQUAL "AUTO")
+      set(_want "${${_override_var}}")
+      if(NOT _want MATCHES "^(CUDA|HIP)$")
+        message(FATAL_ERROR "Invalid ${_override_var}='${_want}'. Expected AUTO, CUDA, or HIP.")
+      endif()
+      if(NOT "${_want}" IN_LIST _candidates)
+        message(FATAL_ERROR
+          "${_override_var}=${_want} was requested for ${ARG_FEATURE}, but ${_want} is not "
+          "available in this configuration (CUDA=${CHRONO_CUDA_FOUND}, HIP=${CHRONO_HIP_FOUND}, "
+          "vendor=${CHRONO_GPU_VENDOR_RESOLVED}).")
+      endif()
+      set(${out_var} "${_want}" PARENT_SCOPE)
+      return()
+    endif()
+  endif()
+
+  list(LENGTH _candidates _n)
+
+  if(_n EQUAL 0)
+    set(${out_var} "NONE" PARENT_SCOPE)
+    return()
+  endif()
+
+  if(_n EQUAL 1)
+    set(${out_var} "${_candidates}" PARENT_SCOPE)
+    return()
+  endif()
+
+  # --- Tier 2: global preference --------------------------------------------
+  if(NOT CHRONO_GPU_BACKEND STREQUAL "AUTO")
+    if(NOT CHRONO_GPU_BACKEND MATCHES "^(CUDA|HIP)$")
+      message(FATAL_ERROR
+        "Invalid CHRONO_GPU_BACKEND='${CHRONO_GPU_BACKEND}'. Expected AUTO, CUDA, or HIP.")
+    endif()
+    if("${CHRONO_GPU_BACKEND}" IN_LIST _candidates)
+      set(${out_var} "${CHRONO_GPU_BACKEND}" PARENT_SCOPE)
+      return()
+    endif()
+  endif()
+
+  # --- Tier 3: the feature's declared preference ----------------------------
+  if(ARG_PREFER AND "${ARG_PREFER}" IN_LIST _candidates)
+    set(${out_var} "${ARG_PREFER}" PARENT_SCOPE)
+    return()
+  endif()
+
+  list(GET _candidates 0 _first)
+  set(${out_var} "${_first}" PARENT_SCOPE)
+endfunction()
+
+#-----------------------------------------------------------------------------
+# chrono_gpu_feature_unavailable(FEATURE <name>
+#                                [OPTION <cache var to force OFF>]
+#                                [CLASS  EXPLICIT|IMPLIED])
+#
+# Reports a feature that cannot get the backend it needs, at a severity that
+# depends on how the feature came to be enabled:
+#
+#   EXPLICIT  the user set option(... OFF)-defaulted switch to ON by hand.
+#             Silently handing them a build missing exactly what they asked
+#             for is the wrong behaviour -> WARNING, or FATAL under
+#             CHRONO_STRICT_MODULE_REQUIREMENTS.
+#
+#   IMPLIED   enabled automatically via cmake_dependent_option(... ON).
+#             The user never asked; quietly dropping it is correct -> STATUS.
+#
+# The module declares its own class, so no "was this explicit?" guesswork is
+# needed -- the defaults already in the tree encode it.
+#-----------------------------------------------------------------------------
+
+function(chrono_gpu_feature_unavailable)
+  cmake_parse_arguments(ARG "" "FEATURE;OPTION;CLASS;REQUIRES" "" ${ARGN})
+
+  if(NOT ARG_CLASS)
+    set(ARG_CLASS "EXPLICIT")
+  endif()
+
+  set(_detail
+      "${ARG_FEATURE} requires a GPU backend")
+  if(ARG_REQUIRES)
+    set(_detail "${ARG_FEATURE} requires ${ARG_REQUIRES}")
+  endif()
+  set(_detail
+      "${_detail}, but none is available "
+      "(vendor=${CHRONO_GPU_VENDOR_RESOLVED}, CUDA=${CHRONO_CUDA_FOUND}, HIP=${CHRONO_HIP_FOUND}). "
+      "Disabling ${ARG_FEATURE}.")
+  string(REPLACE ";" "" _detail "${_detail}")
+
+  if(ARG_CLASS STREQUAL "IMPLIED")
+    message(STATUS "${_detail}")
+  elseif(CHRONO_STRICT_MODULE_REQUIREMENTS)
+    message(FATAL_ERROR
+      "${_detail}\n"
+      "  (CHRONO_STRICT_MODULE_REQUIREMENTS is ON, so this is fatal rather than a warning.)")
+  else()
+    message(WARNING "${_detail}")
+  endif()
+
+  if(ARG_OPTION)
+    set(${ARG_OPTION} OFF CACHE BOOL "" FORCE)
+  endif()
+endfunction()
+
+#-----------------------------------------------------------------------------
+# chrono_set_gpu_source_language(<backend> <sources...>)
+#
+# Relabels .cu sources for the selected backend. Chrono's GPU modules are NOT
+# dual-source: DEM and FSI::SPH ship a single set of .cu files that are simply
+# compiled as HIP instead of CUDA, so "choosing a backend" here means choosing
+# a compiler for the same sources.
+#
+# MUST be called before add_library(). Source-file properties are directory
+# scoped and the LANGUAGE property in particular (CMP0118) is only honoured
+# when set in the same directory that defines the target, so this is kept as a
+# separate call rather than folded into chrono_apply_gpu_backend() below --
+# which necessarily runs after the target exists.
+#-----------------------------------------------------------------------------
+
+function(chrono_set_gpu_source_language backend)
+  if(NOT ARGN)
+    return()
+  endif()
+  if(backend STREQUAL "HIP")
+    set_source_files_properties(${ARGN} PROPERTIES LANGUAGE HIP)
+  endif()
+  # CUDA needs no relabelling: .cu is already CUDA by default, and forcing the
+  # property would override any per-file choice a module made deliberately.
+endfunction()
+
+#-----------------------------------------------------------------------------
+# chrono_apply_gpu_backend(<target> <backend>
+#                          [DEFINE_VISIBILITY <PUBLIC|PRIVATE|INTERFACE>]
+#                          [LINK_VISIBILITY   <PUBLIC|PRIVATE|INTERFACE>])
+#
+# Applies everything that is MECHANICALLY IDENTICAL between GPU modules:
+# source language relabelling, the CHRONO_USE_* define, architectures, and the
+# runtime libraries. Module-specific choices (Thrust device-system defines,
+# extra INTERFACE defines) deliberately stay in the module.
+#
+# Before this existed, chrono_dem and chrono_fsi/sph carried
+# character-identical copies of the HIP_ARCHITECTURES workaround below --
+# including its comment. That workaround becomes MORE important once both
+# languages can be enabled in a single project, so having one copy of it
+# matters more than the line count saved.
+#-----------------------------------------------------------------------------
+
+function(chrono_apply_gpu_backend target backend)
+  cmake_parse_arguments(ARG "" "DEFINE_VISIBILITY;LINK_VISIBILITY" "" ${ARGN})
+
+  if(NOT ARG_DEFINE_VISIBILITY)
+    set(ARG_DEFINE_VISIBILITY PUBLIC)
+  endif()
+  if(NOT ARG_LINK_VISIBILITY)
+    set(ARG_LINK_VISIBILITY PUBLIC)
+  endif()
+
+  if(backend STREQUAL "CUDA")
+
+    target_compile_definitions(${target} ${ARG_DEFINE_VISIBILITY} CHRONO_USE_CUDA)
+    target_compile_options(${target} PRIVATE
+                           $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>)
+
+    target_link_libraries(${target} ${ARG_LINK_VISIBILITY}
+                          CUDA::cudart_static
+                          CUDA::nvrtc
+                          CUDA::cuda_driver
+                          CUDA::cublas
+                          CUDA::cusparse)
+
+    set_target_properties(${target} PROPERTIES CUDA_ARCHITECTURES "${CHRONO_CUDA_ARCHITECTURES}")
+
+  elseif(backend STREQUAL "HIP")
+
+    # Emit the platform macro that matches the platform HIP was actually
+    # configured for, instead of hardcoding AMD. Defining both
+    # __HIP_PLATFORM_AMD__ and __HIP_PLATFORM_NVIDIA__ is a hard error inside
+    # HIP's own headers, so a hardcoded AMD here would make HIP-on-NVIDIA
+    # unbuildable no matter what the rest of the build system decided.
+    #
+    # With CHRONO_ENABLE_HIP_ON_NVIDIA OFF, CHRONO_HIP_PLATFORM is always
+    # "amd", so this is behaviour-identical to the previous hardcoding today.
+    if(CHRONO_HIP_PLATFORM STREQUAL "nvidia")
+      set(_platform_define __HIP_PLATFORM_NVIDIA__)
+    else()
+      set(_platform_define __HIP_PLATFORM_AMD__)
+    endif()
+
+    target_compile_definitions(${target} ${ARG_DEFINE_VISIBILITY} CHRONO_USE_HIP ${_platform_define})
+
+    if(CHRONO_HIP_PLATFORM STREQUAL "nvidia")
+
+      # Deliberately do NOT link hip::host here.
+      #
+      # ROCm's exported hip::host target carries
+      # INTERFACE_COMPILE_DEFINITIONS "__HIP_PLATFORM_AMD__=1" unconditionally --
+      # it is baked into the ROCm package and does not consult
+      # CMAKE_HIP_PLATFORM. Linking it on the NVIDIA platform therefore puts
+      # BOTH platform macros on the command line, which HIP's own headers reject
+      # outright. The headers we actually need come from the ROCm include
+      # directory below, and the runtime comes from CUDA.
+      if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
+        target_include_directories(${target} PUBLIC "${CHRONO_ROCM_ROOT}/include")
+      endif()
+
+      # hip/nvidia_detail includes <cuda_runtime.h>. HIP translation units are
+      # compiled by nvcc and find it implicitly, but any ordinary CXX source in
+      # the same target that includes a HIP header does not, so add the CUDA
+      # include directory explicitly. Derive it from the HIP compiler, which on
+      # this platform IS nvcc, rather than assuming a fixed CUDA location.
+      get_filename_component(_hip_cc_bin "${CMAKE_HIP_COMPILER}" DIRECTORY)
+      get_filename_component(_hip_cc_root "${_hip_cc_bin}" DIRECTORY)
+      if(EXISTS "${_hip_cc_root}/include")
+        target_include_directories(${target} PRIVATE "${_hip_cc_root}/include")
+      endif()
+
+    else()
+
+      find_package(hip QUIET CONFIG HINTS "${CHRONO_ROCM_ROOT}")
+      if(TARGET hip::host)
+        target_link_libraries(${target} ${ARG_LINK_VISIBILITY} hip::host)
+      endif()
+      if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
+        target_include_directories(${target} PUBLIC "${CHRONO_ROCM_ROOT}/include")
+      endif()
+
+    endif()
+
+    # Mixed CXX/HIP targets can leak HIP_ARCHITECTURES into ordinary CXX
+    # compilations (for example stb_image.cpp), which makes the host compiler
+    # see --offload-arch. Keep the target-level property disabled and pass the
+    # GPU arch flags only to real HIP translation units.
+    set_target_properties(${target} PROPERTIES HIP_ARCHITECTURES OFF)
+    if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
+      foreach(_arch IN LISTS CHRONO_HIP_ARCHITECTURES)
+        if(CHRONO_HIP_PLATFORM STREQUAL "nvidia")
+          # --offload-arch is a clang/hipcc spelling. On the NVIDIA platform the
+          # HIP compiler is nvcc, which does not understand it and silently
+          # forwards it to the host compiler, producing
+          # "gcc: error: unrecognized command-line option '--offload-arch=...'".
+          # Translate to a CUDA gencode spec instead.
+          string(REGEX REPLACE "^sm_" "" _cc "${_arch}")
+          target_compile_options(${target} PRIVATE
+            $<$<COMPILE_LANGUAGE:HIP>:--generate-code=arch=compute_${_cc},code=sm_${_cc}>)
+        else()
+          target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:HIP>:--offload-arch=${_arch}>)
+          target_link_options(${target} PRIVATE $<$<LINK_LANGUAGE:HIP>:--offload-arch=${_arch}>)
+        endif()
+      endforeach()
+    endif()
+
+  elseif(NOT backend STREQUAL "NONE")
+
+    message(FATAL_ERROR "chrono_apply_gpu_backend(): unknown backend '${backend}'")
+
+  endif()
+endfunction()

--- a/cmake/ChronoGPUModule.cmake
+++ b/cmake/ChronoGPUModule.cmake
@@ -71,7 +71,7 @@ endif()
 #-----------------------------------------------------------------------------
 
 function(chrono_select_gpu_backend out_var)
-  cmake_parse_arguments(ARG "" "FEATURE;REQUIRES;NAME;PREFER" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "FEATURE;REQUIRES;NAME;PREFER;HIP_PLATFORM_NOTE" "HIP_PLATFORMS" ${ARGN})
 
   if(NOT ARG_FEATURE OR NOT ARG_REQUIRES)
     message(FATAL_ERROR "chrono_select_gpu_backend() requires FEATURE and REQUIRES")
@@ -100,6 +100,28 @@ function(chrono_select_gpu_backend out_var)
       "Expected CUDA, HIP, or CUDA_OR_HIP.")
   endif()
 
+  # A feature may accept HIP in principle but only on particular HIP platforms.
+  # chrono_dem and chrono_fsi/sph are the live example: their HIP support is
+  # written against the ROCm ecosystem (hipCUB/rocPRIM, rocThrust), which has no
+  # working equivalent when HIP targets NVIDIA. Without this, forcing them onto
+  # HIP there configures cleanly and then fails deep inside ROCm headers, which
+  # tells the user nothing about what they actually did wrong.
+  set(_hip_blocked FALSE)
+  if("HIP" IN_LIST _candidates AND ARG_HIP_PLATFORMS)
+    if(NOT "${CHRONO_HIP_PLATFORM}" IN_LIST ARG_HIP_PLATFORMS)
+      list(REMOVE_ITEM _candidates "HIP")
+      set(_hip_blocked TRUE)
+      # Say so even though the fallback is correct and automatic. Without this,
+      # a build where HIP is genuinely available -- and may even have been asked
+      # for globally -- reports this feature using CUDA with no indication that
+      # HIP was considered and ruled out, which is indistinguishable from the
+      # preference having been ignored.
+      message(STATUS
+        "  ${ARG_FEATURE}: HIP is available but not usable on HIP platform "
+        "'${CHRONO_HIP_PLATFORM}' (supported: ${ARG_HIP_PLATFORMS}); using another backend.")
+    endif()
+  endif()
+
   # --- Tier 1: per-feature override -----------------------------------------
   # An explicit request that cannot be satisfied is a user error, not an
   # invitation to silently substitute something else.
@@ -111,6 +133,17 @@ function(chrono_select_gpu_backend out_var)
         message(FATAL_ERROR "Invalid ${_override_var}='${_want}'. Expected AUTO, CUDA, or HIP.")
       endif()
       if(NOT "${_want}" IN_LIST _candidates)
+        if(_want STREQUAL "HIP" AND _hip_blocked)
+          # Distinguish "HIP is not available" from "HIP is available but this
+          # feature cannot use it on this platform". Reporting the first for the
+          # second sends the reader off to fix a ROCm install that was never the
+          # problem.
+          message(FATAL_ERROR
+            "${_override_var}=HIP was requested for ${ARG_FEATURE}, but its HIP support "
+            "only works with CMAKE_HIP_PLATFORM in '${ARG_HIP_PLATFORMS}' "
+            "(this build has '${CHRONO_HIP_PLATFORM}').\n"
+            "  ${ARG_HIP_PLATFORM_NOTE}")
+        endif()
         message(FATAL_ERROR
           "${_override_var}=${_want} was requested for ${ARG_FEATURE}, but ${_want} is not "
           "available in this configuration (CUDA=${CHRONO_CUDA_FOUND}, HIP=${CHRONO_HIP_FOUND}, "

--- a/cmake/ChronoGPUModule.cmake
+++ b/cmake/ChronoGPUModule.cmake
@@ -162,6 +162,17 @@ function(chrono_select_gpu_backend out_var)
   endif()
 
   if(_n EQUAL 1)
+    # Only one backend can satisfy this feature, so there is nothing to choose
+    # and a global preference simply does not apply here. Say so when the user
+    # expressed one, because this is the case where a build legitimately mixes
+    # backends -- asking for HIP globally still leaves Chrono::Sensor's OptiX
+    # renderer on CUDA, which is correct and worth stating rather than leaving
+    # the user to wonder whether their request was dropped.
+    if(NOT CHRONO_GPU_BACKEND STREQUAL "AUTO" AND NOT "${_candidates}" STREQUAL "${CHRONO_GPU_BACKEND}")
+      message(STATUS
+        "  ${ARG_FEATURE}: requires ${ARG_REQUIRES}, so it uses ${_candidates} rather than the "
+        "preferred ${CHRONO_GPU_BACKEND}.")
+    endif()
     set(${out_var} "${_candidates}" PARENT_SCOPE)
     return()
   endif()
@@ -342,15 +353,20 @@ function(chrono_apply_gpu_backend target backend)
         target_include_directories(${target} PUBLIC "${CHRONO_ROCM_ROOT}/include")
       endif()
 
-      # hip/nvidia_detail includes <cuda_runtime.h>. HIP translation units are
-      # compiled by nvcc and find it implicitly, but any ordinary CXX source in
-      # the same target that includes a HIP header does not, so add the CUDA
-      # include directory explicitly. Derive it from the HIP compiler, which on
-      # this platform IS nvcc, rather than assuming a fixed CUDA location.
+      # hip/nvidia_detail includes <cuda.h> and <cuda_runtime.h>. HIP translation
+      # units are compiled by nvcc and find those implicitly; ordinary CXX
+      # sources do not. Derive the location from the HIP compiler, which on this
+      # platform IS nvcc, rather than assuming a fixed CUDA install path.
+      #
+      # PUBLIC, deliberately matching the ROCm include directory above. These two
+      # travel together: any translation unit that can reach a HIP header through
+      # this target's public headers needs the CUDA headers that HIP header will
+      # itself include. Making the ROCm path public and this one private is what
+      # broke Chrono_vehicle_cosim -- it got <hip/...> and then failed on cuda.h.
       get_filename_component(_hip_cc_bin "${CMAKE_HIP_COMPILER}" DIRECTORY)
       get_filename_component(_hip_cc_root "${_hip_cc_bin}" DIRECTORY)
       if(EXISTS "${_hip_cc_root}/include")
-        target_include_directories(${target} PRIVATE "${_hip_cc_root}/include")
+        target_include_directories(${target} PUBLIC "${_hip_cc_root}/include")
       endif()
 
     else()

--- a/cmake/ChronoGPUModule.cmake
+++ b/cmake/ChronoGPUModule.cmake
@@ -350,7 +350,7 @@ function(chrono_apply_gpu_backend target backend)
       # outright. The headers we actually need come from the ROCm include
       # directory below, and the runtime comes from CUDA.
       if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
-        target_include_directories(${target} PUBLIC "${CHRONO_ROCM_ROOT}/include")
+        target_include_directories(${target} ${ARG_DEFINE_VISIBILITY} "${CHRONO_ROCM_ROOT}/include")
       endif()
 
       # hip/nvidia_detail includes <cuda.h> and <cuda_runtime.h>. HIP translation
@@ -358,15 +358,13 @@ function(chrono_apply_gpu_backend target backend)
       # sources do not. Derive the location from the HIP compiler, which on this
       # platform IS nvcc, rather than assuming a fixed CUDA install path.
       #
-      # PUBLIC, deliberately matching the ROCm include directory above. These two
-      # travel together: any translation unit that can reach a HIP header through
-      # this target's public headers needs the CUDA headers that HIP header will
-      # itself include. Making the ROCm path public and this one private is what
-      # broke Chrono_vehicle_cosim -- it got <hip/...> and then failed on cuda.h.
+      # Same visibility as the ROCm include directory above: these two travel
+      # together, since any translation unit that reaches a HIP header needs the
+      # CUDA headers that HIP header itself includes.
       get_filename_component(_hip_cc_bin "${CMAKE_HIP_COMPILER}" DIRECTORY)
       get_filename_component(_hip_cc_root "${_hip_cc_bin}" DIRECTORY)
       if(EXISTS "${_hip_cc_root}/include")
-        target_include_directories(${target} PUBLIC "${_hip_cc_root}/include")
+        target_include_directories(${target} ${ARG_DEFINE_VISIBILITY} "${_hip_cc_root}/include")
       endif()
 
     else()
@@ -376,7 +374,7 @@ function(chrono_apply_gpu_backend target backend)
         target_link_libraries(${target} ${ARG_LINK_VISIBILITY} hip::host)
       endif()
       if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
-        target_include_directories(${target} PUBLIC "${CHRONO_ROCM_ROOT}/include")
+        target_include_directories(${target} ${ARG_DEFINE_VISIBILITY} "${CHRONO_ROCM_ROOT}/include")
       endif()
 
     endif()

--- a/cmake/ChronoGPUToolchains.cmake
+++ b/cmake/ChronoGPUToolchains.cmake
@@ -1,0 +1,197 @@
+#=============================================================================
+# Chrono GPU backend resolution -- Layer 1: toolchains (helpers)
+#
+# Answers: WHICH GPU SDKs ARE USABLE FOR THE RESOLVED VENDOR?
+#
+# The important property of this layer, and the one the whole redesign rests
+# on, is that its outputs are INDEPENDENT FACTS rather than a single exclusive
+# choice:
+#
+#   CHRONO_CUDA_FOUND    TRUE | FALSE
+#   CHRONO_HIP_FOUND     TRUE | FALSE
+#   CHRONO_HIP_PLATFORM  amd | nvidia | ""
+#
+# Both found-flags may be TRUE at once. The previous design could not represent
+# that state, which is precisely why an NVIDIA machine that happened to have
+# ROCm installed (for PyTorch, or pulled in transitively, or in a multi-SDK CI
+# image) would silently configure a HIP/AMD build and then fail to compile.
+#
+# Consumers must NOT read these flags as "which backend am I". They say only
+# "this SDK is available". Deciding what any given module actually compiles as
+# is Layer 2's job -- see ChronoGPUModule.cmake.
+#
+# This file defines PURE FUNCTIONS only. The detection that actually enables
+# languages lives in ChronoGPUDetect.cmake, because enable_language() is only
+# valid at file scope -- calling it inside a function configures without
+# complaint and then fails at generate time with a missing internal variable.
+#=============================================================================
+
+include_guard(GLOBAL)
+
+set(CHRONO_CUDA_ARCHITECTURES "" CACHE STRING "Chrono CUDA architectures")
+set(CHRONO_HIP_ARCHITECTURES "" CACHE STRING "Chrono HIP architectures")
+set(CHRONO_ROCM_ROOT "" CACHE PATH "Explicit ROCm root for HIP builds")
+set(CHRONO_HIP_MIN_VERSION "5.7.0" CACHE STRING "Minimum HIP version required by Chrono")
+
+# HIP targeting NVIDIA hardware (CMAKE_HIP_PLATFORM=nvidia).
+#
+# Ships OFF, and that is a deliberate staging decision rather than a limitation
+# of the model: the architecture above can represent the state correctly today
+# while nothing in-tree exercises it yet. Two concrete blockers must clear
+# first -- the CMake version guard in ChronoGPUDetect.cmake, and the hardcoded
+# __HIP_PLATFORM_AMD__ in src/chrono/gpu/ChGpuPrimitives.h and ChGpuRuntime.h.
+# Flipping this default belongs in the same change that lands the first
+# HIP-source-only module, so it is reviewed against a real consumer rather than
+# speculatively.
+option(CHRONO_ENABLE_HIP_ON_NVIDIA
+       "Also look for HIP targeting NVIDIA hardware (requires CMake >= 3.28)" OFF)
+
+#-----------------------------------------------------------------------------
+# ROCm discovery
+#
+# Moved verbatim from src/CMakeLists.txt. Also used by Layer 0's SDK-inference
+# fallback, so that the two layers cannot disagree about where ROCm is.
+#-----------------------------------------------------------------------------
+
+function(chrono_read_hip_version hip_header out_var)
+  if(NOT EXISTS "${hip_header}")
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  file(STRINGS "${hip_header}" _major REGEX "^#define[ \t]+HIP_VERSION_MAJOR[ \t]+[0-9]+")
+  file(STRINGS "${hip_header}" _minor REGEX "^#define[ \t]+HIP_VERSION_MINOR[ \t]+[0-9]+")
+  file(STRINGS "${hip_header}" _patch REGEX "^#define[ \t]+HIP_VERSION_PATCH[ \t]+[0-9]+")
+
+  if(NOT _major OR NOT _minor OR NOT _patch)
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  string(REGEX REPLACE ".*HIP_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1" _maj "${_major}")
+  string(REGEX REPLACE ".*HIP_VERSION_MINOR[ \t]+([0-9]+).*" "\\1" _min "${_minor}")
+  string(REGEX REPLACE ".*HIP_VERSION_PATCH[ \t]+([0-9]+).*" "\\1" _pat "${_patch}")
+  set(${out_var} "${_maj}.${_min}.${_pat}" PARENT_SCOPE)
+endfunction()
+
+function(chrono_find_rocm out_root out_version)
+  set(_roots)
+  if(CHRONO_ROCM_ROOT)
+    list(APPEND _roots "${CHRONO_ROCM_ROOT}")
+  endif()
+  if(DEFINED ROCM_PATH AND NOT ROCM_PATH STREQUAL "")
+    list(APPEND _roots "${ROCM_PATH}")
+  endif()
+  if(DEFINED ENV{ROCM_PATH} AND NOT "$ENV{ROCM_PATH}" STREQUAL "")
+    list(APPEND _roots "$ENV{ROCM_PATH}")
+  endif()
+  if(DEFINED ENV{ROCM_HOME} AND NOT "$ENV{ROCM_HOME}" STREQUAL "")
+    list(APPEND _roots "$ENV{ROCM_HOME}")
+  endif()
+  if(DEFINED ENV{HIP_PATH} AND NOT "$ENV{HIP_PATH}" STREQUAL "")
+    list(APPEND _roots "$ENV{HIP_PATH}")
+  endif()
+  list(APPEND _roots /opt/rocm /usr/lib/rocm /usr/local/rocm)
+
+  foreach(_root IN LISTS _roots)
+    if(NOT _root)
+      continue()
+    endif()
+    set(_header "")
+    if(EXISTS "${_root}/include/hip/hip_version.h")
+      set(_header "${_root}/include/hip/hip_version.h")
+    elseif(EXISTS "${_root}/hip/include/hip/hip_version.h")
+      set(_header "${_root}/hip/include/hip/hip_version.h")
+    endif()
+    if(_header)
+      chrono_read_hip_version("${_header}" _ver)
+      if(_ver)
+        set(${out_root} "${_root}" PARENT_SCOPE)
+        set(${out_version} "${_ver}" PARENT_SCOPE)
+        return()
+      endif()
+    endif()
+  endforeach()
+
+  set(${out_root} "" PARENT_SCOPE)
+  set(${out_version} "" PARENT_SCOPE)
+endfunction()
+
+#-----------------------------------------------------------------------------
+# Architecture policy
+#
+# "native" asks the compiler to detect the GPU installed in THIS machine. In a
+# cross-target build there is no such GPU, so the request is not merely
+# suboptimal -- it is unanswerable, and both nvcc and hipcc respond to it with
+# errors that point nowhere near the actual cause.
+#
+# This is the highest-value guard in the redesign for anyone doing distribution
+# builds: it turns a confusing mid-compile failure into a configure-time error
+# that names the variable to set.
+#-----------------------------------------------------------------------------
+
+function(chrono_guard_cross_target_arch lang var_name)
+  if(NOT CHRONO_GPU_CROSS_TARGET)
+    return()
+  endif()
+
+  set(_context
+      "Chrono is being built for ${CHRONO_GPU_VENDOR_RESOLVED}, but no "
+      "${CHRONO_GPU_VENDOR_RESOLVED} GPU was detected on this machine "
+      "(host GPU: ${CHRONO_GPU_HOST_VENDOR}).")
+  string(REPLACE ";" "" _context "${_context}")
+
+  if("${${var_name}}" STREQUAL "native")
+    # Genuinely unanswerable: "native" asks the compiler to interrogate a local
+    # device that by definition is not here. Refusing beats emitting a compiler
+    # error that points nowhere near the cause.
+    message(FATAL_ERROR
+      "${_context}\n"
+      "  ${lang} 'native' architecture detection cannot work in a cross-target build.\n"
+      "  Set ${var_name} explicitly, for example -D${var_name}=\"<arch>\".")
+  elseif("${${var_name}}" STREQUAL "")
+    # Merely unspecified, which is NOT the same thing. Building GPU code inside
+    # a container with no GPU attached is an entirely normal CI pattern, and it
+    # worked before this change, so this must not become a hard failure. Each
+    # caller keeps its own existing handling for empty architectures.
+    message(WARNING
+      "${_context}\n"
+      "  No ${lang} architectures are set, and none can be detected locally. "
+      "Set ${var_name} explicitly to choose what this build targets.")
+  endif()
+endfunction()
+
+#-----------------------------------------------------------------------------
+# chrono_report_missing_gpu_toolchain()
+#
+# Signpost the dead end.
+#
+# Resolving a vendor and then finding no matching toolchain produces a build
+# with every GPU module silently absent. That is the CORRECT outcome under a
+# hardware-first policy -- binaries built with the other vendor's SDK could not
+# run on this machine -- but "correct" and "obvious" are different things, and
+# the legitimate version of this scenario (building here to deploy elsewhere)
+# is exactly what the explicit override exists for. Say so, by name.
+#-----------------------------------------------------------------------------
+
+function(chrono_report_missing_gpu_toolchain)
+  if(CHRONO_GPU_VENDOR_RESOLVED STREQUAL "NONE")
+    return()
+  endif()
+  if(CHRONO_CUDA_FOUND OR CHRONO_HIP_FOUND)
+    return()
+  endif()
+
+  if(CHRONO_GPU_VENDOR_RESOLVED STREQUAL "NVIDIA")
+    set(_other "AMD")
+  else()
+    set(_other "NVIDIA")
+  endif()
+
+  message(WARNING
+    "Building for ${CHRONO_GPU_VENDOR_RESOLVED}, but no usable "
+    "${CHRONO_GPU_VENDOR_RESOLVED} GPU toolchain was found. All GPU-dependent "
+    "Chrono modules will be disabled.\n"
+    "  If you meant to build for ${_other} hardware (for example, to deploy "
+    "elsewhere), configure with -DCHRONO_GPU_VENDOR=${_other}.")
+endfunction()

--- a/cmake/ChronoGPUVendor.cmake
+++ b/cmake/ChronoGPUVendor.cmake
@@ -1,0 +1,327 @@
+#=============================================================================
+# Chrono GPU backend resolution -- Layer 0: vendor
+#
+# Answers exactly one question: WHICH HARDWARE VENDOR ARE WE COMPILING FOR?
+#
+# This is deliberately a "declared-or-inferred" fact rather than a strictly
+# probed one, because build-time and run-time hardware visibility legitimately
+# differ (CI runners, containers, cross-compilation, distribution builds).
+#
+# Two distinct facts are published:
+#
+#   CHRONO_GPU_VENDOR_RESOLVED  what we COMPILE FOR.  Authoritative.
+#   CHRONO_GPU_HOST_VENDOR      what is PHYSICALLY PRESENT on the build host.
+#                               Advisory / diagnostic only -- it must never
+#                               gate a module.
+#
+# When they disagree we are producing binaries that cannot run here. That is a
+# legitimate and supported mode (building on an NVIDIA workstation to ship for
+# an AMD cluster), but it has consequences -- notably that "native" GPU
+# architecture detection is meaningless -- so it is named explicitly:
+#
+#   CHRONO_GPU_CROSS_TARGET     TRUE when the target vendor is not known to be
+#                               present on this machine.
+#
+# Resolution order (first match wins):
+#   1. explicit CHRONO_GPU_VENDOR  -> used verbatim, no detection runs at all
+#   2. build-host hardware probe   -> skipped when cross-compiling
+#   3. installed SDK inference     -> weak evidence, used only as a fallback
+#   4. NONE
+#=============================================================================
+
+include_guard(GLOBAL)
+
+# For chrono_find_rocm(), reused by the SDK-inference fallback below so that
+# Layer 0 and Layer 1 cannot disagree about where ROCm is.
+include(ChronoGPUToolchains)
+
+set(CHRONO_GPU_VENDOR "AUTO" CACHE STRING
+    "GPU hardware vendor to build for: AUTO, NVIDIA, AMD, NONE")
+set_property(CACHE CHRONO_GPU_VENDOR PROPERTY STRINGS AUTO NVIDIA AMD NONE)
+
+#-----------------------------------------------------------------------------
+# Hardware probes
+#
+# Non-negotiable property: a probe can never break a build. Every one of them
+# is best-effort (ERROR_QUIET, an explicit TIMEOUT, return codes checked), and
+# a wrong answer can only ever produce a wrong DEFAULT -- never a hard failure,
+# because an explicit CHRONO_GPU_VENDOR bypasses all of this.
+#
+# Results are cached as INTERNAL so repeat configures do not re-spawn
+# subprocesses. Blow away the build tree to re-probe.
+#-----------------------------------------------------------------------------
+
+function(_chrono_probe_nvidia_hardware out_found)
+  if(DEFINED CHRONO_PROBED_NVIDIA_HW)
+    set(${out_found} ${CHRONO_PROBED_NVIDIA_HW} PARENT_SCOPE)
+    return()
+  endif()
+
+  set(_found FALSE)
+
+  # Tier A -- driver device nodes. Free: no subprocess, no SDK, no filesystem
+  # walk. These exist if and only if the NVIDIA kernel driver is loaded, which
+  # includes containers started with `--gpus`.
+  if(EXISTS "/dev/nvidiactl" OR EXISTS "/dev/nvidia0")
+    set(_found TRUE)
+  endif()
+
+  # Tier B -- vendor tool. The TIMEOUT is mandatory, not defensive padding:
+  # nvidia-smi can block indefinitely against a wedged driver or an
+  # unreachable MIG configuration, and that would hang `cmake` itself.
+  if(NOT _found)
+    find_program(_chrono_nvidia_smi NAMES nvidia-smi)
+    mark_as_advanced(_chrono_nvidia_smi)
+    if(_chrono_nvidia_smi)
+      execute_process(COMMAND "${_chrono_nvidia_smi}" -L
+                      RESULT_VARIABLE _rc
+                      OUTPUT_VARIABLE _txt
+                      ERROR_QUIET
+                      TIMEOUT 5)
+      if(_rc EQUAL 0 AND _txt MATCHES "GPU [0-9]+:")
+        set(_found TRUE)
+      endif()
+    endif()
+  endif()
+
+  # Tier C -- driver library, for containers where the device nodes are masked
+  # but the driver is injected.
+  #
+  # CRITICAL: reject the CUDA toolkit's stubs/libcuda.so. That file exists
+  # purely to satisfy the linker on machines with no driver at all, so treating
+  # it as evidence of hardware is exactly backwards. Chrono's own build scripts
+  # put the stubs directory on CMAKE_LIBRARY_PATH, so this is a live risk here
+  # rather than a theoretical one.
+  if(NOT _found)
+    find_library(_chrono_libcuda NAMES cuda libcuda.so.1)
+    mark_as_advanced(_chrono_libcuda)
+    if(_chrono_libcuda AND NOT _chrono_libcuda MATCHES "/stubs/")
+      set(_found TRUE)
+    endif()
+  endif()
+
+  set(CHRONO_PROBED_NVIDIA_HW ${_found} CACHE INTERNAL "NVIDIA hardware probe result")
+  set(${out_found} ${_found} PARENT_SCOPE)
+endfunction()
+
+function(_chrono_probe_amd_hardware out_found out_gfx)
+  if(DEFINED CHRONO_PROBED_AMD_HW)
+    set(${out_found} ${CHRONO_PROBED_AMD_HW} PARENT_SCOPE)
+    set(${out_gfx} "${CHRONO_PROBED_AMD_GFX}" PARENT_SCOPE)
+    return()
+  endif()
+
+  set(_found FALSE)
+  set(_gfx "")
+
+  # Tier A -- /dev/kfd is the amdgpu compute (KFD) device: specific, decisive,
+  # and present exactly when ROCm compute is usable.
+  #
+  # Deliberately NOT used: /dev/dri/renderD*. Intel and NVIDIA create renderD
+  # nodes too, so it is a false-positive generator, not a signal.
+  if(EXISTS "/dev/kfd")
+    set(_found TRUE)
+  endif()
+
+  # Tier B -- rocminfo. Also reports the gfx target, which is a far better seed
+  # for CHRONO_HIP_ARCHITECTURES than "native".
+  if(NOT _found OR _gfx STREQUAL "")
+    find_program(_chrono_rocminfo NAMES rocminfo)
+    mark_as_advanced(_chrono_rocminfo)
+    if(_chrono_rocminfo)
+      execute_process(COMMAND "${_chrono_rocminfo}"
+                      RESULT_VARIABLE _rc
+                      OUTPUT_VARIABLE _txt
+                      ERROR_QUIET
+                      TIMEOUT 5)
+      if(_rc EQUAL 0 AND _txt MATCHES "(gfx[0-9a-f]+)")
+        set(_found TRUE)
+        set(_gfx "${CMAKE_MATCH_1}")
+      endif()
+    endif()
+  endif()
+
+  set(CHRONO_PROBED_AMD_HW ${_found} CACHE INTERNAL "AMD hardware probe result")
+  set(CHRONO_PROBED_AMD_GFX "${_gfx}" CACHE INTERNAL "AMD gfx target probe result")
+  set(${out_found} ${_found} PARENT_SCOPE)
+  set(${out_gfx} "${_gfx}" PARENT_SCOPE)
+endfunction()
+
+#-----------------------------------------------------------------------------
+# SDK inference -- the fallback evidence source
+#
+# This answers a different and weaker question than the hardware probe: not
+# "what can run here" but "what can this toolchain compile for". It is used
+# only when the hardware probe finds nothing or is inapplicable.
+#
+# Kept deliberately shallow (existence checks only, no version parsing, no
+# compiler invocation) because Layer 1 does the real toolchain validation and
+# is entitled to disagree with the guess made here.
+#-----------------------------------------------------------------------------
+
+function(_chrono_infer_vendor_from_sdks out_vendor)
+  set(_have_cuda FALSE)
+  set(_have_rocm FALSE)
+
+  find_program(_chrono_nvcc NAMES nvcc HINTS ENV CUDA_PATH ENV CUDA_HOME
+               PATH_SUFFIXES bin)
+  mark_as_advanced(_chrono_nvcc)
+  if(_chrono_nvcc OR DEFINED ENV{CUDA_PATH} OR EXISTS "/usr/local/cuda/bin/nvcc")
+    set(_have_cuda TRUE)
+  endif()
+
+  # Reuse Layer 1's ROCm search so the two layers cannot disagree about where
+  # ROCm is or whether it is usable at all.
+  chrono_find_rocm(_rocm_root _rocm_ver)
+  if(_rocm_root AND _rocm_ver)
+    set(_have_rocm TRUE)
+  endif()
+
+  if(_have_cuda AND _have_rocm)
+    set(${out_vendor} "BOTH" PARENT_SCOPE)
+  elseif(_have_cuda)
+    set(${out_vendor} "NVIDIA" PARENT_SCOPE)
+  elseif(_have_rocm)
+    set(${out_vendor} "AMD" PARENT_SCOPE)
+  else()
+    set(${out_vendor} "NONE" PARENT_SCOPE)
+  endif()
+endfunction()
+
+#-----------------------------------------------------------------------------
+# chrono_resolve_gpu_vendor()
+#
+# Publishes, in the caller's scope:
+#   CHRONO_GPU_VENDOR_RESOLVED   NVIDIA | AMD | NONE
+#   CHRONO_GPU_HOST_VENDOR       NVIDIA | AMD | BOTH | NONE | UNKNOWN
+#   CHRONO_GPU_CROSS_TARGET      TRUE | FALSE
+#   CHRONO_GPU_HOST_GFX          probed AMD gfx target, or ""
+#-----------------------------------------------------------------------------
+
+function(chrono_resolve_gpu_vendor)
+  if(NOT CHRONO_GPU_VENDOR MATCHES "^(AUTO|NVIDIA|AMD|NONE)$")
+    message(FATAL_ERROR
+      "Invalid CHRONO_GPU_VENDOR='${CHRONO_GPU_VENDOR}'. Expected AUTO, NVIDIA, AMD, or NONE.")
+  endif()
+
+  #---------------------------------------------------------------------------
+  # Host probe.
+  #
+  # Run unconditionally -- even when the vendor was set explicitly -- because
+  # its purpose is not to decide the vendor but to tell us whether what we are
+  # about to build can actually RUN here. That question still has an answer
+  # (and still matters) when the vendor was declared by hand.
+  #
+  # Skipped only when cross-compiling: then the build host's GPU is not weak
+  # evidence, it is actively misleading. A CPU-only build server cross-
+  # compiling for an MI300X cluster would confidently report the wrong thing.
+  #---------------------------------------------------------------------------
+  set(_host "UNKNOWN")
+  set(_gfx "")
+
+  if(CMAKE_CROSSCOMPILING)
+    message(STATUS "  Cross-compiling: skipping build-host GPU hardware probe.")
+  elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    # No CUDA and no ROCm on macOS. Probing would only produce noise.
+    set(_host "NONE")
+  else()
+    _chrono_probe_nvidia_hardware(_nv_hw)
+    _chrono_probe_amd_hardware(_amd_hw _gfx)
+
+    if(_nv_hw AND _amd_hw)
+      set(_host "BOTH")
+    elseif(_nv_hw)
+      set(_host "NVIDIA")
+    elseif(_amd_hw)
+      set(_host "AMD")
+    else()
+      set(_host "NONE")
+    endif()
+  endif()
+
+  #---------------------------------------------------------------------------
+  # Target vendor resolution.
+  #---------------------------------------------------------------------------
+  set(_resolved "NONE")
+  set(_how "")
+
+  if(NOT CHRONO_GPU_VENDOR STREQUAL "AUTO")
+
+    set(_resolved "${CHRONO_GPU_VENDOR}")
+    set(_how "explicitly requested")
+
+  else()
+
+    if(CMAKE_CROSSCOMPILING)
+      message(WARNING
+        "Cross-compiling with CHRONO_GPU_VENDOR=AUTO. The target vendor will be "
+        "guessed from which SDKs are installed, which is thin evidence. Set "
+        "-DCHRONO_GPU_VENDOR=<NVIDIA|AMD|NONE> explicitly.")
+    endif()
+
+    if(_host STREQUAL "NVIDIA" OR _host STREQUAL "AMD")
+      set(_resolved "${_host}")
+      set(_how "detected hardware")
+    elseif(_host STREQUAL "BOTH")
+      # Both vendors physically present. There is no defensible automatic
+      # answer here -- either choice silently discards half the machine's
+      # capability -- and since the explicit override is a documented,
+      # first-class path, demanding it costs the user almost nothing and
+      # removes a silent wrong guess.
+      message(FATAL_ERROR
+        "Both NVIDIA and AMD GPUs were detected on this machine. Chrono builds "
+        "for one vendor per build tree, and there is no safe default here.\n"
+        "  Configure with -DCHRONO_GPU_VENDOR=NVIDIA or -DCHRONO_GPU_VENDOR=AMD.")
+    else()
+      # No usable hardware evidence: fall back to what the toolchain can
+      # compile for.
+      _chrono_infer_vendor_from_sdks(_sdk)
+      if(_sdk STREQUAL "BOTH")
+        set(_resolved "NVIDIA")
+        set(_how "installed SDKs (ambiguous)")
+        message(WARNING
+          "No GPU hardware was detected, and BOTH the CUDA toolkit and ROCm are "
+          "installed. Defaulting to NVIDIA. Set -DCHRONO_GPU_VENDOR explicitly to "
+          "remove this ambiguity.")
+      elseif(NOT _sdk STREQUAL "NONE")
+        set(_resolved "${_sdk}")
+        set(_how "installed SDKs")
+      else()
+        set(_resolved "NONE")
+        set(_how "no GPU hardware or SDK found")
+      endif()
+    endif()
+
+  endif()
+
+  #---------------------------------------------------------------------------
+  # Cross-target determination.
+  #
+  # TRUE means: we are building for a vendor we cannot demonstrate is present.
+  # Layer 1 uses this to refuse "native" architecture detection, and the test
+  # suite uses it to avoid registering GPU tests that cannot possibly pass.
+  #
+  # UNKNOWN host counts as cross-target. That is the conservative direction:
+  # the cost is having to name an architecture explicitly, whereas trusting an
+  # unverified host means emitting a confusing compiler error much later.
+  #---------------------------------------------------------------------------
+  set(_cross FALSE)
+  if(NOT _resolved STREQUAL "NONE")
+    if(_host STREQUAL "BOTH" OR _host STREQUAL "${_resolved}")
+      set(_cross FALSE)
+    else()
+      set(_cross TRUE)
+    endif()
+  endif()
+
+  set(CHRONO_GPU_VENDOR_RESOLVED "${_resolved}" PARENT_SCOPE)
+  set(CHRONO_GPU_HOST_VENDOR "${_host}" PARENT_SCOPE)
+  set(CHRONO_GPU_CROSS_TARGET ${_cross} PARENT_SCOPE)
+  set(CHRONO_GPU_HOST_GFX "${_gfx}" PARENT_SCOPE)
+
+  message(STATUS "  GPU target vendor:       ${_resolved} (${_how})")
+  message(STATUS "  GPU hardware on host:    ${_host}")
+  if(_cross)
+    message(STATUS "  Cross-target build:      YES -- binaries will not run on this machine")
+  endif()
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -299,228 +299,43 @@ endif()
 
 #-----------------------------------------------------------------------------
 # GPU backend support (CUDA and HIP)
+#
+# Resolved in three layers -- see cmake/ChronoGPU*.cmake:
+#
+#   Layer 0  vendor      which hardware are we building for?   (ChronoGPUVendor)
+#   Layer 1  toolchains  which SDKs are usable for it?         (ChronoGPUToolchains)
+#   Layer 2  features    what does each feature compile as?    (ChronoGPUModule)
+#
+# ChronoGPUDetect must be include()d here at file scope rather than called as a
+# function: it runs enable_language(), which is only valid at file scope.
 #-----------------------------------------------------------------------------
 
-set(CHRONO_GPU_BACKEND "AUTO" CACHE STRING "GPU backend for Chrono GPU modules: AUTO, CUDA, HIP")
-set_property(CACHE CHRONO_GPU_BACKEND PROPERTY STRINGS AUTO CUDA HIP)
-set(CHRONO_CUDA_ARCHITECTURES "" CACHE STRING "Chrono CUDA architectures")
-set(CHRONO_HIP_ARCHITECTURES "" CACHE STRING "Chrono HIP architectures")
-mark_as_advanced(FORCE CMAKE_CUDA_ARCHITECTURES)
-mark_as_advanced(FORCE CMAKE_HIP_ARCHITECTURES)
+include(ChronoGPUDetect)
+include(ChronoGPUModule)
 
-set(CHRONO_ROCM_ROOT "" CACHE PATH "Explicit ROCm root for HIP builds")
-set(CHRONO_HIP_MIN_VERSION "5.7.0" CACHE STRING "Minimum HIP version required by Chrono")
-
-function(chrono_read_hip_version hip_header out_var)
-  if(NOT EXISTS "${hip_header}")
-    set(${out_var} "" PARENT_SCOPE)
-    return()
-  endif()
-
-  file(STRINGS "${hip_header}" _major REGEX "^#define[ 	]+HIP_VERSION_MAJOR[ 	]+[0-9]+")
-  file(STRINGS "${hip_header}" _minor REGEX "^#define[ 	]+HIP_VERSION_MINOR[ 	]+[0-9]+")
-  file(STRINGS "${hip_header}" _patch REGEX "^#define[ 	]+HIP_VERSION_PATCH[ 	]+[0-9]+")
-
-  if(NOT _major OR NOT _minor OR NOT _patch)
-    set(${out_var} "" PARENT_SCOPE)
-    return()
-  endif()
-
-  string(REGEX REPLACE ".*HIP_VERSION_MAJOR[ 	]+([0-9]+).*" "\\1" _maj "${_major}")
-  string(REGEX REPLACE ".*HIP_VERSION_MINOR[ 	]+([0-9]+).*" "\\1" _min "${_minor}")
-  string(REGEX REPLACE ".*HIP_VERSION_PATCH[ 	]+([0-9]+).*" "\\1" _pat "${_patch}")
-  set(${out_var} "${_maj}.${_min}.${_pat}" PARENT_SCOPE)
-endfunction()
-
-function(chrono_find_rocm out_root out_version)
-  set(_roots)
-  if(CHRONO_ROCM_ROOT)
-    list(APPEND _roots "${CHRONO_ROCM_ROOT}")
-  endif()
-  if(DEFINED ROCM_PATH AND NOT ROCM_PATH STREQUAL "")
-    list(APPEND _roots "${ROCM_PATH}")
-  endif()
-  if(DEFINED ENV{ROCM_PATH} AND NOT "$ENV{ROCM_PATH}" STREQUAL "")
-    list(APPEND _roots "$ENV{ROCM_PATH}")
-  endif()
-  if(DEFINED ENV{ROCM_HOME} AND NOT "$ENV{ROCM_HOME}" STREQUAL "")
-    list(APPEND _roots "$ENV{ROCM_HOME}")
-  endif()
-  if(DEFINED ENV{HIP_PATH} AND NOT "$ENV{HIP_PATH}" STREQUAL "")
-    list(APPEND _roots "$ENV{HIP_PATH}")
-  endif()
-  list(APPEND _roots /opt/rocm /usr/lib/rocm /usr/local/rocm)
-
-  foreach(_root IN LISTS _roots)
-    if(NOT _root)
-      continue()
-    endif()
-    set(_header "")
-    if(EXISTS "${_root}/include/hip/hip_version.h")
-      set(_header "${_root}/include/hip/hip_version.h")
-    elseif(EXISTS "${_root}/hip/include/hip/hip_version.h")
-      set(_header "${_root}/hip/include/hip/hip_version.h")
-    endif()
-    if(_header)
-      chrono_read_hip_version("${_header}" _ver)
-      if(_ver)
-        set(${out_root} "${_root}" PARENT_SCOPE)
-        set(${out_version} "${_ver}" PARENT_SCOPE)
-        return()
-      endif()
-    endif()
-  endforeach()
-
-  set(${out_root} "" PARENT_SCOPE)
-  set(${out_version} "" PARENT_SCOPE)
-endfunction()
-
-include(CheckLanguage)
-
-set(CHRONO_CUDA_FOUND FALSE)
-set(CHRONO_HIP_FOUND FALSE)
-set(CHRONO_GPU_FOUND FALSE)
-set(CHRONO_GPU_BACKEND_RESOLVED "NONE")
-set(CHRONO_ROCM_VERSION "")
-
-message(STATUS "Searching for GPU backends")
-
-set(_chrono_try_hip FALSE)
-set(_chrono_try_cuda FALSE)
-if(CHRONO_GPU_BACKEND STREQUAL "HIP")
-  set(_chrono_try_hip TRUE)
-elseif(CHRONO_GPU_BACKEND STREQUAL "CUDA")
-  set(_chrono_try_cuda TRUE)
-elseif(CHRONO_GPU_BACKEND STREQUAL "AUTO")
-  chrono_find_rocm(_chrono_rocm_root _chrono_rocm_ver)
-  if(_chrono_rocm_root AND _chrono_rocm_ver VERSION_GREATER_EQUAL CHRONO_HIP_MIN_VERSION)
-    set(_chrono_try_hip TRUE)
-  else()
-    set(_chrono_try_cuda TRUE)
-  endif()
-else()
-  message(FATAL_ERROR "Invalid CHRONO_GPU_BACKEND='${CHRONO_GPU_BACKEND}'. Expected AUTO, CUDA, or HIP.")
-endif()
-
-if(_chrono_try_hip)
-  chrono_find_rocm(_chrono_rocm_root _chrono_rocm_ver)
-  if(_chrono_rocm_root)
-    list(PREPEND CMAKE_PREFIX_PATH "${_chrono_rocm_root}")
-    if(NOT DEFINED CMAKE_HIP_COMPILER_ROCM_ROOT)
-      set(CMAKE_HIP_COMPILER_ROCM_ROOT "${_chrono_rocm_root}" CACHE PATH "ROCm root path")
-    endif()
-    if(NOT DEFINED CMAKE_HIP_PLATFORM)
-      set(CMAKE_HIP_PLATFORM "amd" CACHE STRING "HIP platform")
-    endif()
-    check_language(HIP)
-    if(CMAKE_HIP_COMPILER)
-      enable_language(HIP)
-      set(CHRONO_HIP_FOUND TRUE)
-      set(CHRONO_GPU_FOUND TRUE)
-      set(CHRONO_GPU_BACKEND_RESOLVED "HIP")
-      set(CHRONO_ROCM_ROOT "${_chrono_rocm_root}" CACHE PATH "Explicit ROCm root for HIP builds" FORCE)
-      set(CHRONO_ROCM_VERSION "${_chrono_rocm_ver}")
-      if(CHRONO_HIP_ARCHITECTURES STREQUAL "" AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.21")
-        set(CHRONO_HIP_ARCHITECTURES "native" CACHE STRING "Chrono HIP architectures" FORCE)
-      endif()
-      if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
-        set(CMAKE_HIP_ARCHITECTURES ${CHRONO_HIP_ARCHITECTURES} CACHE STRING "HIP architectures" FORCE)
-      endif()
-      message(STATUS "  HIP compiler:            ${CMAKE_HIP_COMPILER}")
-      message(STATUS "  ROCm version:            ${CHRONO_ROCM_VERSION}")
-      message(STATUS "  ROCm root dir:           ${CHRONO_ROCM_ROOT}")
-      if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
-        message(STATUS "  HIP archs:               ${CHRONO_HIP_ARCHITECTURES}")
-      endif()
-    else()
-      message(STATUS "  WARNING: HIP requested but no HIP compiler was found.")
-    endif()
-  else()
-    message(STATUS "  WARNING: HIP requested but ROCm was not found.")
-  endif()
-endif()
-
-if(NOT CHRONO_HIP_FOUND AND (_chrono_try_cuda OR CHRONO_GPU_BACKEND STREQUAL "AUTO"))
-  message(STATUS "Searching for CUDA")
-  check_language(CUDA)
-
-  if(CMAKE_CUDA_COMPILER)
-
-    enable_language(CUDA)
-    find_package(CUDAToolkit)
-    message(STATUS "  CUDA compiler:           ${CMAKE_CUDA_COMPILER}")
-    message(STATUS "  CUDA toolkit version:    ${CUDAToolkit_VERSION}")
-    message(STATUS "  CUDA toolkit root dir:   ${CUDAToolkit_LIBRARY_ROOT}")
-
-    if(CHRONO_CUDA_ARCHITECTURES STREQUAL "")
-      if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.23")
-        set(CHRONO_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR}" CACHE STRING "Chrono CUDA architectures" FORCE)
-        message(STATUS "  CUDA archs (set to):     ${CHRONO_CUDA_ARCHITECTURES}")
-      endif()
-    else()
-      message(STATUS "  CUDA archs (from cache): ${CHRONO_CUDA_ARCHITECTURES}")
-    endif()
-
-    # Make sure we do not build for CUDA architecture 50 (no support for atomicAdd in double precision)
-    list(REMOVE_ITEM CHRONO_CUDA_ARCHITECTURES "50" "50-real")
-    message(STATUS "  CUDA archs (filtered):   ${CHRONO_CUDA_ARCHITECTURES}")
-
-    if(CHRONO_CUDA_ARCHITECTURES STREQUAL "")
-      set(CHRONO_CUDA_FOUND FALSE)
-      message("  WARNING: CUDA architectures not found. Set CHRONO_CUDA_ARCHITECTURES")
-    else()
-      set(CHRONO_CUDA_FOUND TRUE)
-      set(CHRONO_GPU_FOUND TRUE)
-      set(CHRONO_GPU_BACKEND_RESOLVED "CUDA")
-      message(STATUS "  CUDA found and enabled.")
-      set(CMAKE_CUDA_ARCHITECTURES ${CHRONO_CUDA_ARCHITECTURES} CACHE STRING "CUDA architectures" FORCE)
-      if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-        set(CUDA_SEPARABLE_COMPILATION OFF)
-      endif()
-    endif()
-
-  else()
-    
-    set(CHRONO_CUDA_FOUND FALSE)
-    mark_as_advanced(FORCE CHRONO_CUDA_ARCHITECTURES)
-    message("  WARNING  CUDA not found. CUDA features will be disabled.")
-  
-  endif()
-
-endif()
-
-set(CHRONO_GPU_BACKEND ${CHRONO_GPU_BACKEND_RESOLVED})
-
-# Hide (mark as advanced) variables
-
-if(CHRONO_CUDA_FOUND)
-  mark_as_advanced(FORCE CHRONO_HIP_ARCHITECTURES)
-  mark_as_advanced(FORCE CHRONO_HIP_MIN_VERSION)
-  mark_as_advanced(FORCE CHRONO_ROCM_ROOT)
-endif()
-
-if(CHRONO_HIP_FOUND)
-  mark_as_advanced(FORCE CHRONO_CUDA_ARCHITECTURES)
-endif()
-
-# HIP + Eigen alignment compatibility
+# AMD + Eigen alignment compatibility
 #
 # Some host-side Chrono classes contain fixed-size Eigen objects. With AVX,
 # Eigen may require 32-byte alignment; a few allocation paths used by demos,
 # visualization, or MBS coupling do not guarantee that in all environments.
-# In HIP builds this can abort demo_FSI-SPH_CouetteFlow before any SPH kernel is
-# reached. Limiting Eigen's maximum static alignment to 16 bytes avoids the
+# In ROCm builds this can abort demo_FSI-SPH_CouetteFlow before any SPH kernel
+# is reached. Limiting Eigen's maximum static alignment to 16 bytes avoids the
 # fragile 32-byte over-alignment requirement while keeping ordinary
-# SSE-friendly vectorization and without touching CUDA/NVIDIA builds.
-
-if(CHRONO_HIP_FOUND)
-  set(CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES "16" CACHE STRING "Maximum Eigen alignment in HIP builds; set to 0 to fully disable fixed-size Eigen over-alignment")
+# SSE-friendly vectorization.
+#
+# KEYED ON VENDOR, NOT ON CHRONO_HIP_FOUND. This applies to the Eigen3::Eigen
+# INTERFACE target, so it changes the ABI of EVERY Chrono target in the build.
+# Under the old exclusive model "HIP was found" and "this is an AMD build" were
+# the same statement; they no longer are, and firing this on a CUDA build that
+# merely has ROCm installed alongside would be a silent, whole-build ABI change.
+if(CHRONO_GPU_VENDOR_RESOLVED STREQUAL "AMD")
+  set(CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES "16" CACHE STRING "Maximum Eigen alignment in AMD/HIP builds; set to 0 to fully disable fixed-size Eigen over-alignment")
 
   target_compile_definitions(Eigen3::Eigen INTERFACE
     EIGEN_MAX_ALIGN_BYTES=${CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES}
     EIGEN_MAX_STATIC_ALIGN_BYTES=${CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES})
 
-  message(STATUS "  HIP Eigen max alignment: ${CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES} bytes")
+  message(STATUS "  AMD Eigen max alignment: ${CHRONO_HIP_EIGEN_MAX_ALIGN_BYTES} bytes")
 endif()
 
 #-----------------------------------------------------------------------------
@@ -531,7 +346,10 @@ message(STATUS "Searching for Thrust")
 
 find_package(Thrust)
 
-if(CHRONO_HIP_FOUND AND Thrust_FOUND AND CHRONO_ROCM_ROOT)
+# Also keyed on vendor rather than on CHRONO_HIP_FOUND, for the same reason as
+# the Eigen clamp above: dropping Thrust because it resolved inside a ROCm
+# installation must not happen on an NVIDIA build that merely has ROCm present.
+if(CHRONO_GPU_VENDOR_RESOLVED STREQUAL "AMD" AND Thrust_FOUND AND CHRONO_ROCM_ROOT)
   file(REAL_PATH "${THRUST_INCLUDE_DIR}" _chrono_thrust_include_real)
   file(REAL_PATH "${CHRONO_ROCM_ROOT}" _chrono_rocm_root_real)
   string(FIND "${_chrono_thrust_include_real}" "${_chrono_rocm_root_real}/" _chrono_rocm_thrust_pos)

--- a/src/chrono/gpu/ChGpuPrimitives.h
+++ b/src/chrono/gpu/ChGpuPrimitives.h
@@ -30,7 +30,11 @@ static constexpr float float_max = std::numeric_limits<float>::max();
 static constexpr int int_max = std::numeric_limits<int>::max();
 
 #elif defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__)
-    #ifndef __HIP_PLATFORM_AMD__
+    // Default to the AMD platform only when neither platform macro is already
+    // set. Defining __HIP_PLATFORM_AMD__ unconditionally breaks HIP targeting
+    // NVIDIA, where __HIP_PLATFORM_NVIDIA__ is already defined and HIP's own
+    // headers reject having both.
+    #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIP_PLATFORM_NVIDIA__)
         #define __HIP_PLATFORM_AMD__
     #endif
     #include <hip/hip_runtime.h>

--- a/src/chrono/gpu/ChGpuRuntime.h
+++ b/src/chrono/gpu/ChGpuRuntime.h
@@ -180,7 +180,11 @@ inline gpuError gpuEventElapsedTime(float* ms, gpuEvent start, gpuEvent stop) {
 
 #elif defined(__HIPCC__) || defined(__HIP_DEVICE_COMPILE__) || defined(CHRONO_USE_HIP) || defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_NVIDIA__)
 
-    #ifndef __HIP_PLATFORM_AMD__
+    // Default to the AMD platform only when neither platform macro is already
+    // set. Defining __HIP_PLATFORM_AMD__ unconditionally breaks HIP targeting
+    // NVIDIA, where __HIP_PLATFORM_NVIDIA__ is already defined and HIP's own
+    // headers reject having both.
+    #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIP_PLATFORM_NVIDIA__)
         #define __HIP_PLATFORM_AMD__
     #endif
     #include <hip/hip_runtime.h>
@@ -284,6 +288,17 @@ inline gpuError gpuMemAdvise(const void* ptr, std::size_t bytes, gpuMemoryAdvise
     }
     return err;
 }
+
+    #if defined(__HIP_PLATFORM_NVIDIA__) && defined(CUDART_VERSION) && (CUDART_VERSION >= 13000)
+// CUDA 13 changed cudaMemAdvise to take a cudaMemLocation, and callers written
+// against it build that struct. The CUDA branch of this header already offers
+// both spellings; the HIP branch offered only the device-ordinal one, so those
+// callers failed to compile when HIP targets NVIDIA. Forward to the ordinal
+// form, which HIP provides on both platforms.
+inline gpuError gpuMemAdvise(const void* ptr, std::size_t bytes, gpuMemoryAdvise advice, cudaMemLocation location) {
+    return gpuMemAdvise(ptr, bytes, advice, location.id);
+}
+    #endif
 
 inline gpuError gpuStreamCreate(gpuStream* stream) {
     return hipStreamCreate(stream);

--- a/src/chrono_dem/CMakeLists.txt
+++ b/src/chrono_dem/CMakeLists.txt
@@ -14,10 +14,22 @@ endif()
 
 message(STATUS "\n==== Chrono DEM module ====\n")
 
-# Return now if neither CUDA nor HIP is available
-if(NOT CHRONO_CUDA_FOUND AND NOT CHRONO_HIP_FOUND)
-    message("Chrono::DEM requires CUDA or HIP, but neither backend was found; disabling Chrono::DEM")
-    set(CH_ENABLE_MODULE_DEM OFF CACHE BOOL "Enable the Chrono::DEM module" FORCE)
+# Select the GPU backend for this module.
+#
+# Chrono::DEM is not dual-source: it ships one set of .cu kernels that are
+# compiled either as CUDA or as HIP. PREFER CUDA therefore means "use the
+# vendor-native SDK for these sources" and not "pick between two source trees".
+chrono_select_gpu_backend(CHRONO_DEM_BACKEND
+                          FEATURE  "Chrono::DEM"
+                          NAME     DEM
+                          REQUIRES CUDA_OR_HIP
+                          PREFER   CUDA)
+
+if(CHRONO_DEM_BACKEND STREQUAL "NONE")
+    chrono_gpu_feature_unavailable(FEATURE  "Chrono::DEM"
+                                   REQUIRES "CUDA or HIP"
+                                   OPTION   CH_ENABLE_MODULE_DEM
+                                   CLASS    EXPLICIT)
     return()
 endif()
 
@@ -28,7 +40,8 @@ if(EIGEN3_VERSION VERSION_LESS "3.3.6")
     return()
 endif()
 
-if(CHRONO_HIP_FOUND)
+message(STATUS "Chrono::DEM GPU backend: ${CHRONO_DEM_BACKEND}")
+if(CHRONO_DEM_BACKEND STREQUAL "HIP")
   message(STATUS "Chrono HIP architectures: ${CHRONO_HIP_ARCHITECTURES}")
 else()
   message(STATUS "Chrono CUDA architectures: ${CHRONO_CUDA_ARCHITECTURES}")
@@ -93,9 +106,7 @@ set(DEM_GPU_SOURCE_FILES
     gpu/ChDemSMC.cu
     gpu/ChDemSMCtrimesh.cu
     )
-if(CHRONO_HIP_FOUND)
-    set_source_files_properties(${DEM_GPU_SOURCE_FILES} PROPERTIES LANGUAGE HIP)
-endif()
+chrono_set_gpu_source_language(${CHRONO_DEM_BACKEND} ${DEM_GPU_SOURCE_FILES})
 
 # --------------- DEM UTILITIES
 
@@ -129,6 +140,9 @@ endif()
 
 set(DEPENDENCIES_DEM ${DEPENDENCIES_DEM} PARENT_SCOPE)
 
+# Export the resolved backend for ChronoConfig.cmake (see cmake/ChronoConfig.cmake.in).
+set(CHRONO_DEM_BACKEND ${CHRONO_DEM_BACKEND} PARENT_SCOPE)
+
 # ------------------------------------------------------------------------------
 # Add the Chrono_dem library
 # ------------------------------------------------------------------------------
@@ -161,44 +175,11 @@ if(MSVC)
   target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/wd4100>)
 endif()
 
-if(CHRONO_CUDA_FOUND)
-  target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>)
-  target_compile_definitions(Chrono_dem PUBLIC CHRONO_USE_CUDA)
-endif()
-
 target_compile_definitions(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:CXX>:CH_API_COMPILE_DEM>)
-if(CHRONO_HIP_FOUND)
-  target_compile_definitions(Chrono_dem PUBLIC CHRONO_USE_HIP __HIP_PLATFORM_AMD__)
-endif()
 
 target_link_libraries(Chrono_dem PRIVATE Chrono_core)
 
-if(CHRONO_CUDA_FOUND)
-  target_link_libraries(Chrono_dem PUBLIC CUDA::cudart_static)
-  target_link_libraries(Chrono_dem PUBLIC CUDA::nvrtc)
-  target_link_libraries(Chrono_dem PUBLIC CUDA::cuda_driver)
-  target_link_libraries(Chrono_dem PUBLIC CUDA::cublas)
-  target_link_libraries(Chrono_dem PUBLIC CUDA::cusparse)
-  set_target_properties(Chrono_dem PROPERTIES CUDA_ARCHITECTURES "${CHRONO_CUDA_ARCHITECTURES}")
-elseif(CHRONO_HIP_FOUND)
-  find_package(hip QUIET CONFIG HINTS "${CHRONO_ROCM_ROOT}")
-  if(TARGET hip::host)
-    target_link_libraries(Chrono_dem PUBLIC hip::host)
-  endif()
-  if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
-    target_include_directories(Chrono_dem PUBLIC "${CHRONO_ROCM_ROOT}/include")
-  endif()
-  # Mixed CXX/HIP targets can leak HIP_ARCHITECTURES into ordinary CXX compilations
-  # (for example stb_image.cpp), which makes the host compiler see --offload-arch.
-  # Keep the target-level property disabled and pass the GPU arch flags only to real HIP TUs.
-  set_target_properties(Chrono_dem PROPERTIES HIP_ARCHITECTURES OFF)
-  if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
-    foreach(_chrono_hip_arch IN LISTS CHRONO_HIP_ARCHITECTURES)
-      target_compile_options(Chrono_dem PRIVATE $<$<COMPILE_LANGUAGE:HIP>:--offload-arch=${_chrono_hip_arch}>)
-      target_link_options(Chrono_dem PRIVATE $<$<LINK_LANGUAGE:HIP>:--offload-arch=${_chrono_hip_arch}>)
-    endforeach()
-  endif()
-endif()
+chrono_apply_gpu_backend(Chrono_dem ${CHRONO_DEM_BACKEND})
 
 install(TARGETS Chrono_dem
         EXPORT ChronoTargets
@@ -235,13 +216,11 @@ if(CH_ENABLE_MODULE_VSG)
     target_link_libraries(Chrono_dem_vsg PRIVATE Chrono_core Chrono_dem)
     target_link_libraries(Chrono_dem_vsg PUBLIC Chrono_vsg)
 
-    if(CHRONO_CUDA_FOUND)
-      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cudart_static)
-      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::nvrtc)
-      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cuda_driver)
-      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cublas)
-      target_link_libraries(Chrono_dem_vsg PRIVATE CUDA::cusparse)
-    endif()
+    # Keyed on the backend Chrono_dem actually resolved to, not on "a CUDA
+    # toolkit exists somewhere": those are no longer the same statement.
+    chrono_apply_gpu_backend(Chrono_dem_vsg ${CHRONO_DEM_BACKEND}
+                             DEFINE_VISIBILITY PRIVATE
+                             LINK_VISIBILITY   PRIVATE)
 
     install(TARGETS Chrono_dem_vsg
             EXPORT ChronoTargets

--- a/src/chrono_dem/CMakeLists.txt
+++ b/src/chrono_dem/CMakeLists.txt
@@ -19,11 +19,18 @@ message(STATUS "\n==== Chrono DEM module ====\n")
 # Chrono::DEM is not dual-source: it ships one set of .cu kernels that are
 # compiled either as CUDA or as HIP. PREFER CUDA therefore means "use the
 # vendor-native SDK for these sources" and not "pick between two source trees".
+# HIP_PLATFORMS amd: the GPU kernels use hipCUB, whose CUB backend does not
+# currently compose with the CCCL shipped in recent CUDA toolkits. "HIP" here
+# means HIP-for-ROCm specifically, and saying so lets an impossible request fail
+# at configure time with a reason instead of inside a ROCm header.
 chrono_select_gpu_backend(CHRONO_DEM_BACKEND
                           FEATURE  "Chrono::DEM"
                           NAME     DEM
                           REQUIRES CUDA_OR_HIP
-                          PREFER   CUDA)
+                          PREFER   CUDA
+                          HIP_PLATFORMS amd
+                          HIP_PLATFORM_NOTE
+                            "Chrono::DEM's HIP kernels depend on hipCUB/rocPRIM, which is a ROCm-only stack. On NVIDIA hardware, build it as CUDA (the default).")
 
 if(CHRONO_DEM_BACKEND STREQUAL "NONE")
     chrono_gpu_feature_unavailable(FEATURE  "Chrono::DEM"

--- a/src/chrono_dem/CMakeLists.txt
+++ b/src/chrono_dem/CMakeLists.txt
@@ -19,20 +19,14 @@ message(STATUS "\n==== Chrono DEM module ====\n")
 # Chrono::DEM is not dual-source: it ships one set of .cu kernels that are
 # compiled either as CUDA or as HIP. PREFER CUDA therefore means "use the
 # vendor-native SDK for these sources" and not "pick between two source trees".
-# HIP_PLATFORMS amd: the GPU kernels use hipCUB. Its rocPRIM backend is fine,
-# but its CUB backend -- the one selected when HIP targets NVIDIA -- does not
-# build against the CCCL shipped with CUDA 13: device_spmv.hpp includes a header
-# CCCL 3 removed, and device_scan.hpp references hipcub::Equality, which only the
-# rocPRIM backend defines. Both are upstream hipCUB issues, so "HIP" here means
-# HIP-for-ROCm until a hipCUB release supports CCCL 3.
+# HIP_PLATFORMS amd nvidia: the kernels use hipCUB on ROCm and plain CUB when
+# HIP targets NVIDIA (see ChDemSMC.cuh), so neither platform is excluded.
 chrono_select_gpu_backend(CHRONO_DEM_BACKEND
                           FEATURE  "Chrono::DEM"
                           NAME     DEM
                           REQUIRES CUDA_OR_HIP
                           PREFER   CUDA
-                          HIP_PLATFORMS amd
-                          HIP_PLATFORM_NOTE
-                            "Chrono::DEM's HIP kernels use hipCUB, whose CUB backend does not build against CUDA 13's CCCL. On NVIDIA hardware, build it as CUDA (the default).")
+                          HIP_PLATFORMS amd nvidia)
 
 if(CHRONO_DEM_BACKEND STREQUAL "NONE")
     chrono_gpu_feature_unavailable(FEATURE  "Chrono::DEM"

--- a/src/chrono_dem/CMakeLists.txt
+++ b/src/chrono_dem/CMakeLists.txt
@@ -19,10 +19,12 @@ message(STATUS "\n==== Chrono DEM module ====\n")
 # Chrono::DEM is not dual-source: it ships one set of .cu kernels that are
 # compiled either as CUDA or as HIP. PREFER CUDA therefore means "use the
 # vendor-native SDK for these sources" and not "pick between two source trees".
-# HIP_PLATFORMS amd: the GPU kernels use hipCUB, whose CUB backend does not
-# currently compose with the CCCL shipped in recent CUDA toolkits. "HIP" here
-# means HIP-for-ROCm specifically, and saying so lets an impossible request fail
-# at configure time with a reason instead of inside a ROCm header.
+# HIP_PLATFORMS amd: the GPU kernels use hipCUB. Its rocPRIM backend is fine,
+# but its CUB backend -- the one selected when HIP targets NVIDIA -- does not
+# build against the CCCL shipped with CUDA 13: device_spmv.hpp includes a header
+# CCCL 3 removed, and device_scan.hpp references hipcub::Equality, which only the
+# rocPRIM backend defines. Both are upstream hipCUB issues, so "HIP" here means
+# HIP-for-ROCm until a hipCUB release supports CCCL 3.
 chrono_select_gpu_backend(CHRONO_DEM_BACKEND
                           FEATURE  "Chrono::DEM"
                           NAME     DEM
@@ -30,7 +32,7 @@ chrono_select_gpu_backend(CHRONO_DEM_BACKEND
                           PREFER   CUDA
                           HIP_PLATFORMS amd
                           HIP_PLATFORM_NOTE
-                            "Chrono::DEM's HIP kernels depend on hipCUB/rocPRIM, which is a ROCm-only stack. On NVIDIA hardware, build it as CUDA (the default).")
+                            "Chrono::DEM's HIP kernels use hipCUB, whose CUB backend does not build against CUDA 13's CCCL. On NVIDIA hardware, build it as CUDA (the default).")
 
 if(CHRONO_DEM_BACKEND STREQUAL "NONE")
     chrono_gpu_feature_unavailable(FEATURE  "Chrono::DEM"

--- a/src/chrono_dem/gpu/ChDemSMC.cuh
+++ b/src/chrono_dem/gpu/ChDemSMC.cuh
@@ -16,10 +16,15 @@
 
 #pragma once
 
-#if defined(CHRONO_USE_HIP)
+#if defined(CHRONO_USE_HIP) && !defined(__HIP_PLATFORM_NVIDIA__)
     #include <hipcub/hipcub.hpp>
 namespace cub = hipcub;
 #else
+    // Plain CUB, for CUDA and equally for HIP targeting NVIDIA. On that platform
+    // hipCUB is only a thin wrapper over the very CUB this translation unit is
+    // already compiling against, so going through it buys nothing -- and hipCUB's
+    // CUB backend is still written against the CCCL 2.x API surface, so it does
+    // not build against the CCCL that ships with CUDA 13.
     #include <cub/cub.cuh>
 #endif
 #include <thrust/functional.h>

--- a/src/chrono_fsi/CMakeLists.txt
+++ b/src/chrono_fsi/CMakeLists.txt
@@ -78,6 +78,7 @@ add_subdirectory(sph)
 add_subdirectory(tdpf)
 
 set(DEPENDENCIES_FSI_SPH  ${DEPENDENCIES_FSI_SPH}  PARENT_SCOPE)
+set(CHRONO_FSISPH_BACKEND ${CHRONO_FSISPH_BACKEND} PARENT_SCOPE)
 set(DEPENDENCIES_FSI_TDPF ${DEPENDENCIES_FSI_TDPF} PARENT_SCOPE)
 
 #-------------------------------------------------------------------------------

--- a/src/chrono_fsi/sph/CMakeLists.txt
+++ b/src/chrono_fsi/sph/CMakeLists.txt
@@ -320,14 +320,25 @@ elseif(CHRONO_FSISPH_BACKEND STREQUAL "HIP")
 
   target_compile_definitions(Chrono_fsisph INTERFACE CHRONO_FSI_SPH_USE_HIP_RUNTIME)
 
-  # Keep the device Thrust backend local to this target. Public consumers are
-  # ordinary C++ translation units that only need ROCm headers for declarations
-  # reachable from public headers -- they must not inherit the compile
-  # definitions that would force Thrust onto a device backend.
+  # Keep the device Thrust backend local to this target, and export NOTHING.
+  #
+  # No installed Chrono::FSI::SPH header includes <thrust/...>; only the private
+  # .cuh sources do. So a consumer never needs a Thrust configuration from us,
+  # and any value we exported would be wrong for someone:
+  #
+  #   THRUST_DEVICE_SYSTEM_HIP  names rocThrust, which a consumer compiled by a
+  #                             non-HIP compiler cannot use at all;
+  #   THRUST_DEVICE_SYSTEM_CPP  silently demotes a consumer's OWN device Thrust
+  #                             to host code. Chrono::Sensor links us PUBLIC and
+  #                             calls thrust::device_vector on CUDA device
+  #                             pointers; under _CPP that becomes a host memcpy
+  #                             from device memory, which segfaults at runtime
+  #                             rather than failing to build.
+  #
+  # Exporting nothing leaves each consumer on Thrust's own default, which is
+  # what it gets when Chrono::FSI::SPH is not in the link at all.
   target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_DEVICE_SYSTEM=${CHRONO_FSISPH_THRUST_DEVICE}")
   target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
-  target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP")
-  target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
 
 endif()
 

--- a/src/chrono_fsi/sph/CMakeLists.txt
+++ b/src/chrono_fsi/sph/CMakeLists.txt
@@ -23,14 +23,29 @@ if(EIGEN3_VERSION VERSION_LESS "3.3.6")
     return()
 endif()
 
-# Return now if neither CUDA nor HIP is available
-if(NOT CHRONO_CUDA_FOUND AND NOT CHRONO_HIP_FOUND)
-    message(WARNING "Chrono::FSI::SPH requires CUDA or HIP, but neither backend was found; disabling Chrono::FSI::SPH")
-    set(CH_ENABLE_MODULE_FSI_SPH OFF CACHE BOOL "Enable the Chrono::SPH FSI module" FORCE)
+# Select the GPU backend for this submodule.
+#
+# CLASS IMPLIED below: unlike the other GPU modules, this one is enabled
+# automatically via cmake_dependent_option(... ON) whenever Chrono::FSI is on.
+# The user never explicitly asked for it, so dropping it quietly when no GPU
+# backend exists is the correct behaviour rather than a warning they cannot act
+# on.
+chrono_select_gpu_backend(CHRONO_FSISPH_BACKEND
+                          FEATURE  "Chrono::FSI::SPH"
+                          NAME     FSI_SPH
+                          REQUIRES CUDA_OR_HIP
+                          PREFER   CUDA)
+
+if(CHRONO_FSISPH_BACKEND STREQUAL "NONE")
+    chrono_gpu_feature_unavailable(FEATURE  "Chrono::FSI::SPH"
+                                   REQUIRES "CUDA or HIP"
+                                   OPTION   CH_ENABLE_MODULE_FSI_SPH
+                                   CLASS    IMPLIED)
     return()
 endif()
 
-if(CHRONO_HIP_FOUND)
+message(STATUS "  Chrono::FSI::SPH GPU backend: ${CHRONO_FSISPH_BACKEND}")
+if(CHRONO_FSISPH_BACKEND STREQUAL "HIP")
     message(STATUS "  Chrono HIP architectures: ${CHRONO_HIP_ARCHITECTURES}")
 else()
     message(STATUS "  Chrono CUDA architectures: ${CHRONO_CUDA_ARCHITECTURES}")
@@ -164,9 +179,7 @@ set(FSISPH_GPU_SOURCE_FILES
     utils/SphUtilsDevice.cu
     utils/SphUtilsPrint.cu
 )
-if(CHRONO_HIP_FOUND)
-    set_source_files_properties(${FSISPH_GPU_SOURCE_FILES} PROPERTIES LANGUAGE HIP)
-endif()
+chrono_set_gpu_source_language(${CHRONO_FSISPH_BACKEND} ${FSISPH_GPU_SOURCE_FILES})
 
 # --------------- 3rd party STB FILES
 
@@ -201,6 +214,9 @@ if(CH_ENABLE_MODULE_VSG)
 endif()
 
 set(DEPENDENCIES_FSI_SPH ${DEPENDENCIES_FSI_SPH} PARENT_SCOPE)
+
+# Export the resolved backend for ChronoConfig.cmake (see cmake/ChronoConfig.cmake.in).
+set(CHRONO_FSISPH_BACKEND ${CHRONO_FSISPH_BACKEND} PARENT_SCOPE)
 
 #-----------------------------------------------------------------------------
 # Generate and install configuration file
@@ -245,58 +261,54 @@ if(MSVC)
   set_target_properties(Chrono_fsisph PROPERTIES MSVC_RUNTIME_LIBRARY ${CH_MSVC_RUNTIME_LIBRARY})
 endif()
 
-if(CHRONO_CUDA_FOUND)
-  target_compile_options(Chrono_fsisph PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>)
-endif()
-
 target_link_libraries(Chrono_fsisph PRIVATE Chrono_core)
 target_link_libraries(Chrono_fsisph PUBLIC Chrono_fsi)
 
 target_compile_definitions(Chrono_fsisph PRIVATE CH_API_COMPILE_FSI)
-if(CHRONO_HIP_FOUND)
-  target_compile_definitions(Chrono_fsisph PRIVATE CHRONO_USE_HIP)
-  target_compile_definitions(Chrono_fsisph INTERFACE CHRONO_FSI_SPH_USE_HIP_RUNTIME)
+
+# Visibility of the GPU runtime is backend-dependent for this target, and the
+# two cases are not symmetric:
+#
+#   CUDA  PUBLIC. Public headers switch on CHRONO_USE_CUDA and then include
+#         <cuda_runtime.h>, so any consumer that inherits the definition must
+#         also inherit the CUDA include directories that come with
+#         CUDA::cudart_static. Making the definition public but the link
+#         private breaks every downstream target (Chrono_parsers first).
+#
+#   HIP   PRIVATE. Public consumers are ordinary C++ translation units; the HIP
+#         target's compile definitions would force Thrust onto the rocPRIM
+#         backend in code that never asked for it.
+if(CHRONO_FSISPH_BACKEND STREQUAL "CUDA")
+  set(_fsisph_gpu_visibility PUBLIC)
+else()
+  set(_fsisph_gpu_visibility PRIVATE)
 endif()
 
-if(CHRONO_CUDA_FOUND)
-  target_compile_definitions(Chrono_fsisph PUBLIC CHRONO_USE_CUDA)
-  target_link_libraries(Chrono_fsisph PUBLIC CUDA::cudart_static)
-  target_link_libraries(Chrono_fsisph PUBLIC CUDA::nvrtc)
-  target_link_libraries(Chrono_fsisph PUBLIC CUDA::cuda_driver)
-  target_link_libraries(Chrono_fsisph PUBLIC CUDA::cublas)
-  target_link_libraries(Chrono_fsisph PUBLIC CUDA::cusparse)
+chrono_apply_gpu_backend(Chrono_fsisph ${CHRONO_FSISPH_BACKEND}
+                         DEFINE_VISIBILITY ${_fsisph_gpu_visibility}
+                         LINK_VISIBILITY   ${_fsisph_gpu_visibility})
+
+# Module-specific Thrust wiring, which genuinely differs between the two
+# backends and so deliberately stays here rather than moving into the helper.
+if(CHRONO_FSISPH_BACKEND STREQUAL "CUDA")
 
   target_link_libraries(Chrono_fsisph PUBLIC Thrust::Thrust)
   target_compile_definitions(Chrono_fsisph PUBLIC "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA")
   target_compile_definitions(Chrono_fsisph PUBLIC "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
 
-  set_target_properties(Chrono_fsisph PROPERTIES CUDA_ARCHITECTURES "${CHRONO_CUDA_ARCHITECTURES}")
-elseif(CHRONO_HIP_FOUND)
-  find_package(hip QUIET CONFIG HINTS "${CHRONO_ROCM_ROOT}")
-  if(TARGET hip::host)
-    # Keep HIP compiler/runtime flags local to the fsisph target.
-    # Public consumers are regular C++ translation units that only need the ROCm
-    # headers for declarations from public headers, not the HIP target's compile
-    # definitions/options that can force Thrust onto the rocPRIM backend.
-    target_link_libraries(Chrono_fsisph PRIVATE hip::host)
-  endif()
-  if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
-    target_include_directories(Chrono_fsisph PUBLIC "${CHRONO_ROCM_ROOT}/include")
-  endif()
+elseif(CHRONO_FSISPH_BACKEND STREQUAL "HIP")
+
+  target_compile_definitions(Chrono_fsisph INTERFACE CHRONO_FSI_SPH_USE_HIP_RUNTIME)
+
+  # Keep the HIP device Thrust backend local to this target. Public consumers
+  # are ordinary C++ translation units that only need ROCm headers for
+  # declarations reachable from public headers -- they must not inherit the
+  # compile definitions that would force Thrust onto the rocPRIM backend.
   target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP")
   target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
   target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP")
   target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
-  # Mixed CXX/HIP targets can leak HIP_ARCHITECTURES into ordinary CXX compilations
-  # (for example stb_image.cpp), which makes the host compiler see --offload-arch.
-  # Keep the target-level property disabled and pass the GPU arch flags only to real HIP TUs.
-  set_target_properties(Chrono_fsisph PROPERTIES HIP_ARCHITECTURES OFF)
-  if(NOT CHRONO_HIP_ARCHITECTURES STREQUAL "")
-    foreach(_chrono_hip_arch IN LISTS CHRONO_HIP_ARCHITECTURES)
-      target_compile_options(Chrono_fsisph PRIVATE $<$<COMPILE_LANGUAGE:HIP>:--offload-arch=${_chrono_hip_arch}>)
-      target_link_options(Chrono_fsisph PRIVATE $<$<LINK_LANGUAGE:HIP>:--offload-arch=${_chrono_hip_arch}>)
-    endforeach()
-  endif()
+
 endif()
 
 install(TARGETS Chrono_fsisph
@@ -336,31 +348,21 @@ if(CH_ENABLE_MODULE_VSG)
     target_link_libraries(Chrono_fsisph_vsg PRIVATE Chrono_core Chrono_fsisph)
     target_link_libraries(Chrono_fsisph_vsg PUBLIC Chrono_vsg)
 
-    if(CHRONO_CUDA_FOUND)
-      target_compile_definitions(Chrono_fsisph_vsg PRIVATE CHRONO_USE_CUDA)
-      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cudart_static)
-      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::nvrtc)
-      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cuda_driver)
-      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cublas)
-      target_link_libraries(Chrono_fsisph_vsg PRIVATE CUDA::cusparse)
+    chrono_apply_gpu_backend(Chrono_fsisph_vsg ${CHRONO_FSISPH_BACKEND}
+                             DEFINE_VISIBILITY PRIVATE
+                             LINK_VISIBILITY   PRIVATE)
 
+    if(CHRONO_FSISPH_BACKEND STREQUAL "CUDA")
       target_link_libraries(Chrono_fsisph_vsg PRIVATE Thrust::Thrust)
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA")
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
-    elseif(CHRONO_HIP_FOUND)
+    elseif(CHRONO_FSISPH_BACKEND STREQUAL "HIP")
       # Compile the VSG plugin source with the HIP compiler: it includes FSI
       # data-manager headers that reference rocThrust/rocPRIM device types,
       # which do not compile as plain C++ (same treatment as FSISPH_GPU_SOURCE_FILES).
       set_source_files_properties(visualization/ChSphVisualizationVSG.cpp PROPERTIES LANGUAGE HIP)
-      target_compile_definitions(Chrono_fsisph_vsg PRIVATE CHRONO_USE_HIP)
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP")
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
-      if(TARGET hip::host)
-        target_link_libraries(Chrono_fsisph_vsg PRIVATE hip::host)
-      endif()
-      if(CHRONO_ROCM_ROOT AND EXISTS "${CHRONO_ROCM_ROOT}/include")
-        target_include_directories(Chrono_fsisph_vsg PRIVATE "${CHRONO_ROCM_ROOT}/include")
-      endif()
     endif()
 
     install(TARGETS Chrono_fsisph_vsg

--- a/src/chrono_fsi/sph/CMakeLists.txt
+++ b/src/chrono_fsi/sph/CMakeLists.txt
@@ -30,11 +30,16 @@ endif()
 # The user never explicitly asked for it, so dropping it quietly when no GPU
 # backend exists is the correct behaviour rather than a warning they cannot act
 # on.
+# HIP_PLATFORMS amd: the HIP path selects Thrust's HIP device system, which is
+# rocThrust and exists only in the ROCm stack.
 chrono_select_gpu_backend(CHRONO_FSISPH_BACKEND
                           FEATURE  "Chrono::FSI::SPH"
                           NAME     FSI_SPH
                           REQUIRES CUDA_OR_HIP
-                          PREFER   CUDA)
+                          PREFER   CUDA
+                          HIP_PLATFORMS amd
+                          HIP_PLATFORM_NOTE
+                            "Chrono::FSI::SPH's HIP path uses rocThrust, which is a ROCm-only stack. On NVIDIA hardware, build it as CUDA (the default).")
 
 if(CHRONO_FSISPH_BACKEND STREQUAL "NONE")
     chrono_gpu_feature_unavailable(FEATURE  "Chrono::FSI::SPH"

--- a/src/chrono_fsi/sph/CMakeLists.txt
+++ b/src/chrono_fsi/sph/CMakeLists.txt
@@ -30,16 +30,16 @@ endif()
 # The user never explicitly asked for it, so dropping it quietly when no GPU
 # backend exists is the correct behaviour rather than a warning they cannot act
 # on.
-# HIP_PLATFORMS amd: the HIP path selects Thrust's HIP device system, which is
-# rocThrust and exists only in the ROCm stack.
+# HIP_PLATFORMS amd nvidia: Thrust's device system is selected from the HIP
+# platform (rocThrust on AMD, CUDA's own Thrust when HIP targets NVIDIA), so
+# neither platform is excluded. The NVIDIA platform was verified to build; the
+# AMD platform is the pre-existing, unchanged path.
 chrono_select_gpu_backend(CHRONO_FSISPH_BACKEND
                           FEATURE  "Chrono::FSI::SPH"
                           NAME     FSI_SPH
                           REQUIRES CUDA_OR_HIP
                           PREFER   CUDA
-                          HIP_PLATFORMS amd
-                          HIP_PLATFORM_NOTE
-                            "Chrono::FSI::SPH's HIP path uses rocThrust, which is a ROCm-only stack. On NVIDIA hardware, build it as CUDA (the default).")
+                          HIP_PLATFORMS amd nvidia)
 
 if(CHRONO_FSISPH_BACKEND STREQUAL "NONE")
     chrono_gpu_feature_unavailable(FEATURE  "Chrono::FSI::SPH"
@@ -305,11 +305,22 @@ elseif(CHRONO_FSISPH_BACKEND STREQUAL "HIP")
 
   target_compile_definitions(Chrono_fsisph INTERFACE CHRONO_FSI_SPH_USE_HIP_RUNTIME)
 
-  # Keep the HIP device Thrust backend local to this target. Public consumers
-  # are ordinary C++ translation units that only need ROCm headers for
-  # declarations reachable from public headers -- they must not inherit the
-  # compile definitions that would force Thrust onto the rocPRIM backend.
-  target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP")
+  # Thrust's device system follows the HIP PLATFORM, not merely the fact that
+  # the backend is HIP. THRUST_DEVICE_SYSTEM_HIP means rocThrust, which exists
+  # only in the ROCm stack; when HIP targets NVIDIA the translation units are
+  # compiled by nvcc and the correct device system is CUDA. Selecting HIP there
+  # sends the CUDA toolkit's own CCCL looking for a HIP system it does not have.
+  if(CHRONO_HIP_PLATFORM STREQUAL "nvidia")
+    set(_fsisph_thrust_device THRUST_DEVICE_SYSTEM_CUDA)
+  else()
+    set(_fsisph_thrust_device THRUST_DEVICE_SYSTEM_HIP)
+  endif()
+
+  # Keep the device Thrust backend local to this target. Public consumers are
+  # ordinary C++ translation units that only need ROCm headers for declarations
+  # reachable from public headers -- they must not inherit the compile
+  # definitions that would force Thrust onto a device backend.
+  target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_DEVICE_SYSTEM=${_fsisph_thrust_device}")
   target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
   target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP")
   target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")

--- a/src/chrono_fsi/sph/CMakeLists.txt
+++ b/src/chrono_fsi/sph/CMakeLists.txt
@@ -49,6 +49,21 @@ if(CHRONO_FSISPH_BACKEND STREQUAL "NONE")
     return()
 endif()
 
+# Thrust's device system follows the HIP PLATFORM, not merely the fact that the
+# backend is HIP. THRUST_DEVICE_SYSTEM_HIP means rocThrust, which exists only in
+# the ROCm stack; when HIP targets NVIDIA the translation units are compiled by
+# nvcc and the correct device system is CUDA. Selecting HIP there sends the CUDA
+# toolkit's own CCCL looking for a system it does not ship.
+#
+# Computed once here because every target that compiles SPH device code must
+# agree on it -- Chrono_fsisph and the VSG plugin both do, and having the VSG
+# plugin decide separately is exactly how it ended up out of step.
+if(CHRONO_HIP_PLATFORM STREQUAL "nvidia")
+  set(CHRONO_FSISPH_THRUST_DEVICE THRUST_DEVICE_SYSTEM_CUDA)
+else()
+  set(CHRONO_FSISPH_THRUST_DEVICE THRUST_DEVICE_SYSTEM_HIP)
+endif()
+
 message(STATUS "  Chrono::FSI::SPH GPU backend: ${CHRONO_FSISPH_BACKEND}")
 if(CHRONO_FSISPH_BACKEND STREQUAL "HIP")
     message(STATUS "  Chrono HIP architectures: ${CHRONO_HIP_ARCHITECTURES}")
@@ -305,22 +320,11 @@ elseif(CHRONO_FSISPH_BACKEND STREQUAL "HIP")
 
   target_compile_definitions(Chrono_fsisph INTERFACE CHRONO_FSI_SPH_USE_HIP_RUNTIME)
 
-  # Thrust's device system follows the HIP PLATFORM, not merely the fact that
-  # the backend is HIP. THRUST_DEVICE_SYSTEM_HIP means rocThrust, which exists
-  # only in the ROCm stack; when HIP targets NVIDIA the translation units are
-  # compiled by nvcc and the correct device system is CUDA. Selecting HIP there
-  # sends the CUDA toolkit's own CCCL looking for a HIP system it does not have.
-  if(CHRONO_HIP_PLATFORM STREQUAL "nvidia")
-    set(_fsisph_thrust_device THRUST_DEVICE_SYSTEM_CUDA)
-  else()
-    set(_fsisph_thrust_device THRUST_DEVICE_SYSTEM_HIP)
-  endif()
-
   # Keep the device Thrust backend local to this target. Public consumers are
   # ordinary C++ translation units that only need ROCm headers for declarations
   # reachable from public headers -- they must not inherit the compile
   # definitions that would force Thrust onto a device backend.
-  target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_DEVICE_SYSTEM=${_fsisph_thrust_device}")
+  target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_DEVICE_SYSTEM=${CHRONO_FSISPH_THRUST_DEVICE}")
   target_compile_definitions(Chrono_fsisph PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
   target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP")
   target_compile_definitions(Chrono_fsisph INTERFACE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
@@ -377,7 +381,7 @@ if(CH_ENABLE_MODULE_VSG)
       # data-manager headers that reference rocThrust/rocPRIM device types,
       # which do not compile as plain C++ (same treatment as FSISPH_GPU_SOURCE_FILES).
       set_source_files_properties(visualization/ChSphVisualizationVSG.cpp PROPERTIES LANGUAGE HIP)
-      target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP")
+      target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_DEVICE_SYSTEM=${CHRONO_FSISPH_THRUST_DEVICE}")
       target_compile_definitions(Chrono_fsisph_vsg PRIVATE "THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP")
     endif()
 

--- a/src/chrono_sensor/CMakeLists.txt
+++ b/src/chrono_sensor/CMakeLists.txt
@@ -744,6 +744,25 @@ if(CH_USE_SENSOR_OPTIX)
 
   target_link_libraries(Chrono_sensor PUBLIC CUDA::cudart_static)
 
+  # Declare the backend that goes with the link above.
+  #
+  # With OptiX enabled, Chrono::Sensor exports CUDA to its consumers: it links
+  # CUDA::cudart_static PUBLIC, and ChSensorBuffer.h -- an installed header --
+  # includes <cuda_fp16.h> under CHRONO_HAS_OPTIX. Every consumer therefore
+  # compiles against CUDA's vector types whether it asked to or not.
+  #
+  # CHRONO_USE_CUDA is what tells chrono/gpu/ChGpuPrimitives.h that those types
+  # already exist. Without it that header takes its "no GPU SDK here" branch and
+  # defines its own int2/float3/make_int2/..., which then collide with CUDA's.
+  # Exporting the headers but not the macro is the same visibility mismatch the
+  # GPU modules avoid by construction; sensor predates that helper and links
+  # CUDA by hand, so it has to say so by hand too.
+  #
+  # This is deliberately just the define: chrono_apply_gpu_backend() would also
+  # link cuBLAS, cuSPARSE and NVRTC, which sensor does not want, and would set
+  # CUDA_ARCHITECTURES a second time.
+  target_compile_definitions(Chrono_sensor PUBLIC CHRONO_USE_CUDA)
+
   target_link_libraries(Chrono_sensor PRIVATE CUDA::nppc)
   target_link_libraries(Chrono_sensor PRIVATE CUDA::nppig)
   target_link_libraries(Chrono_sensor PRIVATE CUDA::nppidei)

--- a/src/chrono_sensor/CMakeLists.txt
+++ b/src/chrono_sensor/CMakeLists.txt
@@ -40,26 +40,41 @@ mark_as_advanced(CLEAR glfw3_DIR)
 set(CH_USE_SENSOR_OPTIX OFF CACHE BOOL "Enable legacy OptiX-dependent Chrono::Sensor features")
 set(CH_USE_SENSOR_VULKAN_RT ON CACHE BOOL "Enable Vulkan ray-tracing Chrono::Sensor features")
 
+# GPU requirements are declared PER FEATURE here, not per module.
+#
+# Chrono::Sensor itself requires no GPU backend at all: its default renderer is
+# Vulkan RT, which is vendor-neutral and builds fine on AMD. Only the optional
+# OptiX renderer is CUDA-and-NVIDIA-only. Attaching "requires CUDA" to the
+# module rather than to the feature would wrongly disable the entire module on
+# AMD hardware that can run most of it.
 if(CH_USE_SENSOR_OPTIX)
 
-  if(CHRONO_HIP_FOUND)
-    message(STATUS "WARNING: Chrono::Sensor / OptiX is CUDA-only and not supported with HIP; disabling OptiX-dependent features")
-    set(CH_USE_SENSOR_OPTIX FALSE CACHE BOOL "Enable OptiX-dependent Chrono::Sensor features" FORCE)
-  elseif(CHRONO_CUDA_FOUND)
+  chrono_select_gpu_backend(CHRONO_SENSOR_OPTIX_BACKEND
+                            FEATURE  "Chrono::Sensor OptiX renderer"
+                            NAME     SENSOR_OPTIX
+                            REQUIRES CUDA)
+
+  if(CHRONO_SENSOR_OPTIX_BACKEND STREQUAL "NONE")
+
+    chrono_gpu_feature_unavailable(FEATURE  "Chrono::Sensor OptiX renderer"
+                                   REQUIRES "CUDA"
+                                   OPTION   CH_USE_SENSOR_OPTIX
+                                   CLASS    EXPLICIT)
+
+  else()
+
     message(STATUS "Chrono CUDA architectures: ${CHRONO_CUDA_ARCHITECTURES}")
-  
+
     message(STATUS "Looking for OptiX")
     find_package(OptiX)
-  
+
     if(OptiX_INCLUDE)
       message(STATUS "  OptiX include directory: ${OptiX_INCLUDE}")
     else()
-      message("WARNING: OptiX was not found; disabling OptiX-dependent Chrono::Sensor features")
+      message(WARNING "OptiX was not found; disabling OptiX-dependent Chrono::Sensor features")
       set(CH_USE_SENSOR_OPTIX FALSE CACHE BOOL "Enable OptiX-dependent Chrono::Sensor features" FORCE)
     endif()
-  else()
-    message(STATUS "WARNING: CUDA was not found; disabling OptiX-dependent Chrono::Sensor features")
-    set(CH_USE_SENSOR_OPTIX FALSE CACHE BOOL "Enable OptiX-dependent Chrono::Sensor features" FORCE)
+
   endif()
 
 endif()


### PR DESCRIPTION
# Resolve GPU backends from hardware, not from whichever SDK is installed

Branch `feat/gpu-backend-hardware-first`, 10 commits on `8fb70582a`.

## Problem

`src/CMakeLists.txt` searched HIP first and searched CUDA only `if(NOT CHRONO_HIP_FOUND)`. The
two facts were mutually exclusive, so a discoverable ROCm decided the build regardless of
hardware. On an NVIDIA machine with `hipcc` on `PATH`, stock main produces:

```
-DCHRONO_USE_HIP -D__HIP_PLATFORM_AMD__=1 -DEIGEN_MAX_ALIGN_BYTES=16 --offload-arch=native
gcc: error: unrecognized command-line option '--offload-arch=native'
```

CUDA never searched; AMD platform macro on an nvcc command line; an AMD-only flag reaching the
host compiler; the Eigen alignment clamp (a whole-build ABI setting) firing on an NVIDIA build.
Reaching it needs ROCm on `PATH`, not merely installed — a sourced ROCm profile, a ROCm CI image,
or ROCm in a default `PATH` location.

## Change

| Layer | Question | Result |
|---|---|---|
| Vendor | what hardware are we building for? | `NVIDIA` / `AMD` / `NONE` |
| Toolchains | which SDKs are usable? | `CHRONO_CUDA_FOUND`, `CHRONO_HIP_FOUND` — **independent** |
| Feature | what does each feature compile as? | per-feature `CUDA` / `HIP` / `NONE` |

| Option | Default | Purpose |
|---|---|---|
| `CHRONO_GPU_VENDOR` | `AUTO` | build for hardware not in this machine |
| `CHRONO_GPU_BACKEND` | `AUTO` | preference when a feature could use either |
| `CHRONO_<MOD>_GPU_BACKEND` | unset | per-feature override; fatal if unmet |
| `CHRONO_STRICT_MODULE_REQUIREMENTS` | `OFF` | fatal instead of silent disable; for CI |
| `CHRONO_ENABLE_HIP_ON_NVIDIA` | `OFF` | opt-in to compiling HIP sources with nvcc |

`CHRONO_GPU_BACKEND` keeps its spelling and values; it now expresses a preference instead of
suppressing the search for the other backend.

Requirements are declared per **feature**, not per module — Chrono::Sensor needs no GPU backend,
only its OptiX renderer requires CUDA. `ChronoConfig.cmake` exports per-component backends and
enables only the languages the requested components need.

## Compatibility

Single-SDK machines are unaffected. Four intentional changes:

1. A machine with both SDKs builds for its hardware instead of for HIP.
2. Chrono::Sensor builds on AMD without OptiX instead of the module being disabled.
3. Unmet backend requests are reported — global preference warns and falls back, per-module
   override is fatal. Previously `-DCHRONO_GPU_BACKEND=HIP` could silently produce CUDA.
4. `Chrono_sensor` defines `CHRONO_USE_CUDA` `PUBLIC` with OptiX enabled. It already linked
   `CUDA::cudart_static` `PUBLIC` and included `<cuda_fp16.h>` from an installed header; only
   the macro was missing. Read by two headers (`ChGpuPrimitives.h`, `ChGpuRuntime.h`).

Unchanged from main: an unmet feature requirement still writes its option to the cache with
`FORCE`, so one configure without the SDK leaves it off until re-passed with `-D`.

## Diff

```
 cmake/ChronoGPUVendor.cmake       327 ++  new   hardware probes, vendor resolution
 cmake/ChronoGPUToolchains.cmake   197 ++  new   ROCm discovery, arch guards (mostly moved)
 cmake/ChronoGPUDetect.cmake       295 ++  new   orchestration; enable_language() lives here
 cmake/ChronoGPUModule.cmake       425 ++  new   per-feature selection and application
 src/CMakeLists.txt                238 --  net -182; two include()s replace lines 300-542
 src/chrono_dem, chrono_fsi/sph    241     declare requirements, apply resolved backend
 src/chrono_sensor/CMakeLists.txt   54     OptiX declares REQUIRES CUDA at feature level
 cmake/ChronoConfig.cmake.in        49     export per-component backend
 src/chrono/gpu/ChGpu{Primitives,Runtime}.h, chrono_dem/gpu/ChDemSMC.cuh   30   see below
```

## Non-CMake files

One conditional each, ROCm path byte-identical. They exist because the build can now request
HIP-on-NVIDIA, which does not compile without them.

| File | Change |
|---|---|
| `ChGpuPrimitives.h`, `ChGpuRuntime.h` | `#ifndef __HIP_PLATFORM_AMD__ / #define` → `#if !defined(AMD) && !defined(NVIDIA)`. The old form leaves both platform macros set, which HIP's headers reject. |
| `ChGpuRuntime.h` | CUDA 13 `cudaMemLocation` overload of `gpuMemAdvise` added to the HIP branch; the CUDA branch already had both. |
| `ChDemSMC.cuh` | hipCUB on ROCm, CUB when HIP targets NVIDIA. hipCUB's CUB backend targets CCCL 2.x; CUDA 13 ships CCCL 3. |

## Testing

RTX 4080, CUDA 13.2, ROCm 7.2.4, CMake 4.4.0, Ubuntu 22.04. No `HIP_PLATFORM`/`ROCM_PATH`/
`HIP_PATH` set, no ROCm on `PATH`.

| Flags | Resolution | Build |
|---|---|---|
| *none* | NVIDIA, `CUDA=TRUE HIP=FALSE`, DEM + FSI::SPH → CUDA | 0 failures, 19 libs, 230 demos |
| `-DCHRONO_ENABLE_HIP_ON_NVIDIA=ON` | `CUDA=TRUE HIP=TRUE`, HIP compiler = nvcc, `-arch=native` | 0 failures |
| `+ -DCHRONO_{DEM,FSI_SPH}_GPU_BACKEND=HIP` | DEM + FSI::SPH → HIP, rest CUDA | 0 failures, 19 libs, 230 demos |

The last is the configuration stock main cannot express. Demos run in all three, OptiX enabled;
`demo_SEN_vulkan_validation` cross-checks Vulkan RT against OptiX in-process at PSNR 52.7 dB, no
pixel differing by more than 2 code units.

Chrono::ROS is the only module in the tree that compiles against Chrono::Sensor's installed
headers, so it is where a wrong `CHRONO_USE_CUDA` visibility would surface — the sensor demos
cannot test that, being part of the same module. It builds and links.

**AMD:** DEM, FSI::SPH and CRM terrain verified on AMD hardware — every HIP-capable path not
requiring run-time visualization (VSG unavailable on that cluster). Chrono::Sensor builds and runs
there on Vulkan RT with OptiX absent (compatibility item 2), reporting the same mean level as the
NVIDIA host. ROCm-only machines are what this change touches least: vendor resolves to AMD and
every feature resolves to HIP exactly as before.

Modules enabled: DEM, FEA, FEA_MULTIPHYSICS, FSI, FSI_SPH, IRRLICHT, MULTICORE, PARSERS,
PERIDYNAMICS, ROBOT_MODELS, ROS, SENSOR, VEHICLE, VEHICLE_COSIM, VEHICLE_MODELS, VSG.

Not tested:

- Windows / MSVC.
- `find_package(Chrono COMPONENTS ...)` against an installed tree — the per-component backend
  export is only exercised in-build.
- A machine with neither SDK present, where the vendor resolves to `NONE`.
- CUDA older than 11.5, where nvcc has no `-arch=native`; only `native` architectures were used.
- Demos were spot-checked per configuration (sensor, FSI::SPH, SCM), not run exhaustively.
