### PR TITLE
Fix tapered Timoshenko beam section length mismatch (wrong shear correction factors)

### DIFF
--- a/src/chrono/fea/ChBeamSectionTaperedTimoshenko.h
+++ b/src/chrono/fea/ChBeamSectionTaperedTimoshenko.h
@@ -255,7 +255,11 @@ class ChApi ChBeamSectionTaperedTimoshenkoAdvancedGeneric {
     virtual ~ChBeamSectionTaperedTimoshenkoAdvancedGeneric() {}
 
     /// Set the length of beam element with two sections
-    void SetLength(double mv) { length = mv; };
+    void SetLength(double mv) {
+      if (mv != length)
+        compute_ave_sec_par = false;
+      length = mv;
+    };
     /// Get the length of beam element with two sections
     double GetLength() const { return length; };
 

--- a/src/chrono/fea/ChElementBeamTaperedTimoshenko.cpp
+++ b/src/chrono/fea/ChElementBeamTaperedTimoshenko.cpp
@@ -915,6 +915,7 @@ void ChElementBeamTaperedTimoshenko::SetupInitial(ChSystem* system) {
 
     // Compute rest length, mass:
     this->length = (nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos()).Length();
+    this->tapered_section->SetLength(this->length);
     this->mass = 0.5 * this->length * this->tapered_section->GetSectionA()->GetMassPerUnitLength() +
                  0.5 * this->length * this->tapered_section->GetSectionB()->GetMassPerUnitLength();
 


### PR DESCRIPTION
### Description
`ChElementBeamTaperedTimoshenko` and its section class, `ChBeamSectionTaperedTimoshenkoAdvancedGeneric`, each keep their own independent length, and nothing ensures that they stay in sync.

| | Owner | Where it's set | Used for |
|---|---|---|---|
| **Element-level length** | `ChElementBeamTaperedTimoshenko::length` | `SetupInitial()`, computed from the actual node positions. Always correct | `EA/L`, `GJ/L`, and most of the bending/shear stiffness terms |
| **Section-level length** | `ChBeamSectionTaperedTimoshenkoAdvancedGeneric::length` | Manually, via `SetLength()`. Defaults to `1.0` | The shear-correction factors `phiy`/`phiz` (`12·EI/(GA·L²)`) |

Because the section has no way of knowing how long its element actually is, `phiy`/`phiz` are silently computed using a default length of `1.0` m unless the user explicitly calls `SetLength()` with the element's length. When using a beam builder that subdivides a segment into `N` elements, the user should additionally remember to pass `segment length / N` instead of the full segment length.

This is error-prone and easy to get wrong or forget entirely, corrupting the shear correction factors (`phiy`/`phiz`).

Since the element already computes its true length from the node positions, it makes more sense to use that computed value directly instead of relying on the user to set it manually and keep it in sync by hand.

For reference, this mismatch seems to be present in the official demo as well: `src/demos/fea/demo_FEA_beams_rotor.cpp`

```
            auto tapered_section = chrono_types::make_shared<ChBeamSectionTaperedTimoshenkoAdvancedGeneric>();
            tapered_section->SetSectionA(section);
            tapered_section->SetSectionB(section);

            ChBuilderBeamTaperedTimoshenko builder;
            builder.BuildBeam(fea_mesh,                     // the mesh to put the elements in
                              tapered_section,              // section of the beam
                              6,                            // number of sections (spans)
                              ChVector3d(0, beam_Rmin, 1),  // the 'A' point in space (beginning of beam)
                              ChVector3d(0, beam_Rmax, 1),  // the 'B' point in space (end of beam)
                              ChVector3d(0, 0, 1)           // the 'Y' up direction of the section for the beam
            );                                              // order (3 = cubic, etc)
```

As can be observed, `tapered_section->SetLength()` is never called. Every sub-element built by `ChBuilderBeamTaperedTimoshenko::BuildBeam()` ends up computing the shear correction factors for the default length of `1.0` instead of the actual length.

There is a second, related problem. `ChBeamSectionTaperedTimoshenkoAdvancedGeneric::ComputeAverageSectionParameters()` caches `phiy`/`phiz` behind a `compute_ave_sec_par` flag, which is computed once and never refreshed afterwards. If `SetLength()` is called again on an already-used section object with a different length, the cached shear-correction factors keep reflecting the old length instead of being recomputed.

### Related discussion
This problem with the shear correction factors was initially documented here: https://groups.google.com/g/projectchrono/c/ztqTkJUT_0g/m/HsY_NzjjAQAJ

The code-to-code verification is also illustrated below without and with the fix proposed:
<img width="405" height="460" alt="image" src="https://github.com/user-attachments/assets/819c69f9-b379-45bc-a11c-73994c127f53" />

As can be observed, the agreement between Chrono and SubDyn (OpenFAST) using Timoshenko beam elements is excellent. For reference, the tip deflections along the x-axis of the cantilever beam are:
Chrono Euler-Bernoulli: 0.881 m
Chrono Timoshenko: 0.890 m
SubDyn Timoshenko: 0.890 m