### PR TITLE
vehicle: add held-key (game-style) keyboard driving to ChInteractiveDriver

### DIFF
--- a/src/chrono_vehicle/driver/ChInteractiveDriver.cpp
+++ b/src/chrono_vehicle/driver/ChInteractiveDriver.cpp
@@ -36,6 +36,13 @@ namespace vehicle {
 ChInteractiveDriver::ChInteractiveDriver(ChVehicle& vehicle)
     : ChDriver(vehicle),
       m_mode(InputMode::KEYBOARD),
+      m_keyboard_mode(KeyboardMode::CUMULATIVE),
+      m_keyboard_mode_user_set(false),
+      m_key_throttle(false),
+      m_key_brake(false),
+      m_key_steer_left(false),
+      m_key_steer_right(false),
+      m_key_clutch(false),
       m_steering_target(0),
       m_throttle_target(0),
       m_braking_target(0),
@@ -55,6 +62,7 @@ ChInteractiveDriver::ChInteractiveDriver(ChVehicle& vehicle)
 void ChInteractiveDriver::SetInputMode(InputMode mode) {
     switch (mode) {
         case InputMode::KEYBOARD:
+            ReleaseAllKeys();
             m_throttle_target = 0;
             m_steering_target = 0;
             m_braking_target = 0;
@@ -72,6 +80,69 @@ void ChInteractiveDriver::SetInputMode(InputMode mode) {
             break;
     }
 }
+
+void ChInteractiveDriver::SetKeyboardMode(KeyboardMode mode) {
+    m_keyboard_mode_user_set = true;
+    if (mode == m_keyboard_mode)
+        return;
+    ReleaseAllKeys();
+    m_steering_target = 0;
+    m_throttle_target = 0;
+    m_braking_target = 0;
+    m_clutch_target = 0;
+    m_keyboard_mode = mode;
+}
+
+void ChInteractiveDriver::SetDefaultKeyboardMode(KeyboardMode mode) {
+    if (m_keyboard_mode_user_set)
+        return;
+    bool user_set = m_keyboard_mode_user_set;
+    SetKeyboardMode(mode);
+    m_keyboard_mode_user_set = user_set;
+}
+
+// -----------------------------------------------------------------------------
+
+void ChInteractiveDriver::SetKeyState(InputKey key, bool pressed) {
+    switch (key) {
+        case InputKey::THROTTLE:
+            m_key_throttle = pressed;
+            break;
+        case InputKey::BRAKE:
+            m_key_brake = pressed;
+            break;
+        case InputKey::STEER_LEFT:
+            m_key_steer_left = pressed;
+            break;
+        case InputKey::STEER_RIGHT:
+            m_key_steer_right = pressed;
+            break;
+        case InputKey::CLUTCH:
+            m_key_clutch = pressed;
+            break;
+    }
+}
+
+void ChInteractiveDriver::ReleaseAllKeys() {
+    m_key_throttle = false;
+    m_key_brake = false;
+    m_key_steer_left = false;
+    m_key_steer_right = false;
+    m_key_clutch = false;
+}
+
+void ChInteractiveDriver::UpdateTargetsFromHeldKeys() {
+    // The brake pedal takes precedence over the accelerator pedal.
+    m_throttle_target = (m_key_throttle && !m_key_brake) ? 1.0 : 0.0;
+    m_braking_target = m_key_brake ? 1.0 : 0.0;
+
+    // Steering self-centers when neither (or both) steering keys are held.
+    m_steering_target = (m_key_steer_left ? 1.0 : 0.0) - (m_key_steer_right ? 1.0 : 0.0);
+
+    m_clutch_target = m_key_clutch ? 1.0 : 0.0;
+}
+
+// -----------------------------------------------------------------------------
 
 void ChInteractiveDriver::SetGains(double steering_gain,
                                    double throttle_gain,
@@ -114,10 +185,15 @@ void ChInteractiveDriver::DecreaseClutch() {
 }
 
 void ChInteractiveDriver::SteeringCenter() {
+    m_key_steer_left = false;
+    m_key_steer_right = false;
     m_steering_target = 0.0;
 }
 
 void ChInteractiveDriver::ReleasePedals() {
+    m_key_throttle = false;
+    m_key_brake = false;
+    m_key_clutch = false;
     m_throttle_target = 0.0;
     m_braking_target = 0.0;
     m_clutch_target = 0.0;
@@ -129,6 +205,10 @@ void ChInteractiveDriver::Advance(double step) {
     // Do nothing if not in KEYBOARD mode.
     if (m_mode != InputMode::KEYBOARD)
         return;
+
+    // With held-key semantics, the targets are a pure function of the keys currently down.
+    if (m_keyboard_mode == KeyboardMode::HELD)
+        UpdateTargetsFromHeldKeys();
 
     // Integrate dynamics, taking as many steps as required to reach the value 'step'
     double t = 0;

--- a/src/chrono_vehicle/driver/ChInteractiveDriver.h
+++ b/src/chrono_vehicle/driver/ChInteractiveDriver.h
@@ -47,6 +47,21 @@ class CH_VEHICLE_API ChInteractiveDriver : public ChDriver {
         JOYSTICK   ///< driver inputs from joystick
     };
 
+    /// Semantics of the keyboard driving controls (used only in InputMode::KEYBOARD).
+    enum class KeyboardMode {
+        CUMULATIVE,  ///< each keypress nudges the input by a fixed increment; historical Chrono::Vehicle behavior
+        HELD         ///< inputs follow the keys currently held down, as in a driving game (see SetKeyState)
+    };
+
+    /// Driving controls tracked in KeyboardMode::HELD.
+    enum class InputKey {
+        THROTTLE,     ///< accelerator pedal (default key 'W')
+        BRAKE,        ///< brake pedal (default key 'S')
+        STEER_LEFT,   ///< steer left (default key 'A')
+        STEER_RIGHT,  ///< steer right (default key 'D')
+        CLUTCH        ///< clutch pedal (default key 'E'; manual transmission only)
+    };
+
     /// Construct an interactive driver.
     ChInteractiveDriver(ChVehicle& vehicle);
 
@@ -60,41 +75,65 @@ class CH_VEHICLE_API ChInteractiveDriver : public ChDriver {
 
     InputMode GetInputMode() const { return m_mode; }
 
+    /// Select the semantics of the keyboard driving controls.
+    /// Takes precedence over any default proposed by an input backend (see SetDefaultKeyboardMode).
+    void SetKeyboardMode(KeyboardMode mode);
+
+    KeyboardMode GetKeyboardMode() const { return m_keyboard_mode; }
+
+    /// Propose a keyboard mode, to be called by an input backend that knows which modes it can support.
+    /// Has no effect if the application already made an explicit call to SetKeyboardMode.
+    void SetDefaultKeyboardMode(KeyboardMode mode);
+
+    /// Report that a driving control key was pressed (true) or released (false).
+    /// Used only in KeyboardMode::HELD. Calls are idempotent, so key auto-repeat is harmless.
+    void SetKeyState(InputKey key, bool pressed);
+
+    /// Report that all driving control keys are released.
+    /// Call this when the input backend can no longer observe the keyboard (e.g., on loss of window focus), so
+    /// that inputs do not stay pinned at their last value.
+    void ReleaseAllKeys();
+
     /// Set the increment in throttle input for each recorded keypress (default 1/50).
+    /// Used only in KeyboardMode::CUMULATIVE.
     void SetThrottleDelta(double delta) { m_throttle_delta = delta; }
 
     /// Set the increment in steering input for each recorded keypress (default 1/50).
+    /// Used only in KeyboardMode::CUMULATIVE.
     void SetSteeringDelta(double delta) { m_steering_delta = delta; }
 
     /// Set the increment in braking input for each recorded keypress (default 1/50).
+    /// Used only in KeyboardMode::CUMULATIVE.
     void SetBrakingDelta(double delta) { m_braking_delta = delta; }
 
     /// Set the increment in clutch input for each recorded keypress (default 1/50).
+    /// Used only in KeyboardMode::CUMULATIVE.
     void SetClutchDelta(double delta) { m_clutch_delta = delta; }
 
     /// Set the step size for integration of the internal driver dynamics.
     void SetStepsize(double val) { m_stepsize = val; }
 
-    /// Set gains for internal dynamics.
-    /// Default values are 4.0.
+    /// Set gains for internal dynamics (default values are 4.0).
+    /// Each input approaches its target exponentially with time constant 1/gain; in KeyboardMode::HELD this also
+    /// sets how fast a held key ramps an input up or down.
     void SetGains(double steering_gain = 1, double throttle_gain = 1, double braking_gain = 1, double clutch_gain = 1);
 
-    /// Increase Throttle
+    /// Increase Throttle (KeyboardMode::CUMULATIVE)
     void IncreaseThrottle();
 
-    /// Decrease Throttle
+    /// Decrease Throttle (KeyboardMode::CUMULATIVE)
     void DecreaseThrottle();
 
-    /// Steering Left
+    /// Steering Left (KeyboardMode::CUMULATIVE)
     void SteeringLeft();
 
-    /// Steering Right
+    /// Steering Right (KeyboardMode::CUMULATIVE)
     void SteeringRight();
 
-    /// Increase Clutch
+    /// Increase Clutch (KeyboardMode::CUMULATIVE)
     void IncreaseClutch();
 
-    /// Decrease Clutch
+    /// Decrease Clutch (KeyboardMode::CUMULATIVE)
     void DecreaseClutch();
 
     /// Center Steering
@@ -110,9 +149,20 @@ class CH_VEHICLE_API ChInteractiveDriver : public ChDriver {
     virtual void Advance(double step) override;
 
   protected:
+    /// Recompute the input targets from the set of keys currently held down (KeyboardMode::HELD).
+    void UpdateTargetsFromHeldKeys();
+
     InputMode m_mode;  ///< current mode of the driver
 
     // Variables for mode=KEYBOARD
+    KeyboardMode m_keyboard_mode;   ///< semantics of the keyboard driving controls
+    bool m_keyboard_mode_user_set;  ///< application explicitly selected a keyboard mode
+    bool m_key_throttle;            ///< throttle key currently held down
+    bool m_key_brake;               ///< brake key currently held down
+    bool m_key_steer_left;          ///< steer-left key currently held down
+    bool m_key_steer_right;         ///< steer-right key currently held down
+    bool m_key_clutch;              ///< clutch key currently held down
+
     double m_steering_target;  ///< current target value for steering input
     double m_throttle_target;  ///< current target value for throttle input
     double m_braking_target;   ///< current target value for braking input

--- a/src/chrono_vehicle/visualization/ChVehicleVisualSystemIrrlicht.cpp
+++ b/src/chrono_vehicle/visualization/ChVehicleVisualSystemIrrlicht.cpp
@@ -292,7 +292,33 @@ bool ChVehicleEventReceiver::ProcessKeyboardEvents(const SEvent& event,
         transmission_manual = vehicle->GetTransmission()->asManual();   // nullptr for an automatic transmission
     }
 
-    if (event.KeyInput.PressedDown) {
+    // In KeyboardMode::HELD, Irrlicht reports both press and release through KeyInput.PressedDown; the state
+    // updates below are idempotent, so auto-repeat presses and repeated releases are harmless.
+    if (driver->GetKeyboardMode() == ChInteractiveDriver::KeyboardMode::HELD) {
+        bool pressed = event.KeyInput.PressedDown;
+        switch (event.KeyInput.Key) {
+            case KEY_KEY_A:
+                driver->SetKeyState(ChInteractiveDriver::InputKey::STEER_LEFT, pressed);
+                return true;
+            case KEY_KEY_D:
+                driver->SetKeyState(ChInteractiveDriver::InputKey::STEER_RIGHT, pressed);
+                return true;
+            case KEY_KEY_W:
+                driver->SetKeyState(ChInteractiveDriver::InputKey::THROTTLE, pressed);
+                return true;
+            case KEY_KEY_S:
+                driver->SetKeyState(ChInteractiveDriver::InputKey::BRAKE, pressed);
+                return true;
+            case KEY_KEY_E:
+                if (transmission_manual) {
+                    driver->SetKeyState(ChInteractiveDriver::InputKey::CLUTCH, pressed);
+                    return true;
+                }
+                break;
+            default:
+                break;
+        }
+    } else if (event.KeyInput.PressedDown) {
         switch (event.KeyInput.Key) {
             case KEY_KEY_A:
                 driver->SteeringLeft();
@@ -321,7 +347,9 @@ bool ChVehicleEventReceiver::ProcessKeyboardEvents(const SEvent& event,
                     break;
             }
         }
-    } else {
+    }
+
+    if (!event.KeyInput.PressedDown) {
         switch (event.KeyInput.Key) {
             case KEY_KEY_C:
                 driver->SteeringCenter();
@@ -494,7 +522,7 @@ bool ChVehicleEventReceiver::ProcessJoystickEvents(const SEvent& event,
 // -----------------------------------------------------------------------------
 
 ChVehicleVisualSystemIrrlicht::ChVehicleVisualSystemIrrlicht()
-    : ChVisualSystemIrrlicht(), m_renderStats(true), m_HUD_x(600), m_HUD_y(20) {
+    : ChVisualSystemIrrlicht(), m_keyboard_mode(ChInteractiveDriver::KeyboardMode::CUMULATIVE), m_window_focused(true), m_renderStats(true), m_HUD_x(600), m_HUD_y(20) {
     // Set default window size and title
     SetWindowSize(1000, 800);
     SetWindowTitle("Chrono::Vehicle");
@@ -532,6 +560,21 @@ void ChVehicleVisualSystemIrrlicht::SetJoystickDebug(bool val) {
 void ChVehicleVisualSystemIrrlicht::SetButtonCallback(int button, void (*cbfun)()) {
     m_joystick->callback_function = cbfun;
     m_joystick->callback_button = button;
+}
+
+void ChVehicleVisualSystemIrrlicht::SetKeyboardMode(ChInteractiveDriver::KeyboardMode mode) {
+    m_keyboard_mode = mode;
+    if (auto driver = dynamic_cast<ChInteractiveDriver*>(GetDriver()))
+        driver->SetKeyboardMode(mode);
+}
+
+void ChVehicleVisualSystemIrrlicht::AttachDriver(ChDriver* driver) {
+    ChVehicleVisualSystem::AttachDriver(driver);
+
+    // The Irrlicht device reports key releases, so held-key driving controls can be supported. This only
+    // proposes a default; an explicit call to ChInteractiveDriver::SetKeyboardMode always wins.
+    if (auto idriver = dynamic_cast<ChInteractiveDriver*>(driver))
+        idriver->SetDefaultKeyboardMode(m_keyboard_mode);
 }
 
 void ChVehicleVisualSystemIrrlicht::AttachVehicle(ChVehicle* vehicle) {
@@ -572,6 +615,17 @@ void ChVehicleVisualSystemIrrlicht::Initialize() {
 // needed to advance by the specified duration.
 // -----------------------------------------------------------------------------
 void ChVehicleVisualSystemIrrlicht::Advance(double step) {
+    // A key release while the render window lacks focus would never reach this handler, leaving the input
+    // pinned; release all driving control keys as soon as focus is lost.
+    if (GetDevice()) {
+        bool focused = GetDevice()->isWindowFocused();
+        if (m_window_focused && !focused) {
+            if (auto driver = dynamic_cast<ChInteractiveDriver*>(GetDriver()))
+                driver->ReleaseAllKeys();
+        }
+        m_window_focused = focused;
+    }
+
     // Update the ChChaseCamera: take as many integration steps as needed to
     // exactly reach the value 'step'
     double t = 0;

--- a/src/chrono_vehicle/visualization/ChVehicleVisualSystemIrrlicht.h
+++ b/src/chrono_vehicle/visualization/ChVehicleVisualSystemIrrlicht.h
@@ -35,6 +35,7 @@
 #include "chrono_vehicle/ChVehicleVisualSystem.h"
 #include "chrono_vehicle/ChDriver.h"
 #include "chrono_vehicle/ChConfigVehicle.h"
+#include "chrono_vehicle/driver/ChInteractiveDriver.h"
 
 namespace chrono {
 namespace vehicle {
@@ -70,8 +71,16 @@ class CH_VEHICLE_API ChVehicleVisualSystemIrrlicht : public ChVehicleVisualSyste
     /// Feed button number and callback function to implement a custom callback.
     void SetButtonCallback(int button, void (*cbfun)());
 
+    /// Select the semantics of the keyboard driving controls (default: ChInteractiveDriver::KeyboardMode::CUMULATIVE,
+    /// unchanged from the ChInteractiveDriver default).
+    /// Overrides the default proposed to an attached ChInteractiveDriver; see ChInteractiveDriver::SetKeyboardMode.
+    void SetKeyboardMode(ChInteractiveDriver::KeyboardMode mode);
+
     /// Attach a vehicle to this Irrlicht vehicle visualization system.
     virtual void AttachVehicle(vehicle::ChVehicle* vehicle) override;
+
+    /// Attach a driver to this Irrlicht vehicle visualization system.
+    virtual void AttachDriver(ChDriver* driver) override;
 
     /// Set the upper-left point of HUD elements.
     void SetHUDLocation(int HUD_x, int HUD_y) {
@@ -117,12 +126,14 @@ class CH_VEHICLE_API ChVehicleVisualSystemIrrlicht : public ChVehicleVisualSyste
 
     void renderStats();
 
-    ChChaseCameraEventReceiver* m_camera_control;  ///< event receiver for chase-cam control
-    ChVehicleEventReceiver* m_vehicle_control;     ///< event receiver for vehicle control
-    ChJoystickIRR* m_joystick;                     ///< joystick setup
-    bool m_renderStats;                            ///< turn on/off rendering of stats
-    int m_HUD_x;                                   ///< x-coordinate of upper-left corner of HUD elements
-    int m_HUD_y;                                   ///< y-coordinate of upper-left corner of HUD elements
+    ChChaseCameraEventReceiver* m_camera_control;       ///< event receiver for chase-cam control
+    ChVehicleEventReceiver* m_vehicle_control;          ///< event receiver for vehicle control
+    ChJoystickIRR* m_joystick;                          ///< joystick setup
+    ChInteractiveDriver::KeyboardMode m_keyboard_mode;  ///< semantics of the keyboard driving controls
+    bool m_window_focused;                              ///< keyboard focus state of the render window
+    bool m_renderStats;                                 ///< turn on/off rendering of stats
+    int m_HUD_x;                                        ///< x-coordinate of upper-left corner of HUD elements
+    int m_HUD_y;                                        ///< y-coordinate of upper-left corner of HUD elements
 
     friend class ChChaseCameraEventReceiver;
     friend class ChVehicleEventReceiver;

--- a/src/chrono_vehicle/visualization/ChVehicleVisualSystemVSG.cpp
+++ b/src/chrono_vehicle/visualization/ChVehicleVisualSystemVSG.cpp
@@ -52,6 +52,11 @@ class ChVehicleKeyboardHandlerVSG : public vsg3d::ChEventHandlerVSG {
                 break;
         }
 
+        // In KeyboardMode::HELD, driving keys are tracked by press/release rather than as discrete keypresses;
+        // idempotent state updates absorb auto-repeat presses.
+        if (ProcessDrivingKey(driver, keyPress.keyBase, true))
+            return;
+
         switch (keyPress.keyBase) {
             case vsg::KEY_Left:
                 m_vsys->m_camera->Turn(-1);
@@ -164,7 +169,58 @@ class ChVehicleKeyboardHandlerVSG : public vsg3d::ChEventHandlerVSG {
         }
     }
 
+    // Release of a driving control key (used only with held-key semantics).
+    void process(vsg::KeyReleaseEvent& keyRelease) override {
+        if (!m_vsys->m_vehicle)
+            return;
+        auto driver = dynamic_cast<ChInteractiveDriver*>(m_vsys->GetDriver());
+        ProcessDrivingKey(driver, keyRelease.keyBase, false);
+    }
+
+    // A key release while the render window lacks focus would never reach this handler, leaving the input
+    // pinned; drop all held keys as soon as focus is lost.
+    //
+    // VSG only reports focus changes on XCB and Win32; as of VSG 1.1.11 its macOS backend never fires
+    // FocusOutEvent, so this safety net does not trigger there and a key held across an app switch stays held
+    // until pressed and released again.
+    void process(vsg::FocusOutEvent& focusOut) override {
+        if (auto driver = dynamic_cast<ChInteractiveDriver*>(m_vsys->GetDriver()))
+            driver->ReleaseAllKeys();
+    }
+
   private:
+    // Update the state of a driving control key. Returns true if consumed (KeyboardMode::HELD only); in
+    // KeyboardMode::CUMULATIVE the caller handles these keys as discrete keypresses.
+    bool ProcessDrivingKey(ChInteractiveDriver* driver, vsg::KeySymbol key, bool pressed) {
+        if (!driver || driver->GetKeyboardMode() != ChInteractiveDriver::KeyboardMode::HELD)
+            return false;
+
+        switch (key) {
+            case vsg::KEY_a:
+                driver->SetKeyState(ChInteractiveDriver::InputKey::STEER_LEFT, pressed);
+                return true;
+            case vsg::KEY_d:
+                driver->SetKeyState(ChInteractiveDriver::InputKey::STEER_RIGHT, pressed);
+                return true;
+            case vsg::KEY_w:
+                driver->SetKeyState(ChInteractiveDriver::InputKey::THROTTLE, pressed);
+                return true;
+            case vsg::KEY_s:
+                driver->SetKeyState(ChInteractiveDriver::InputKey::BRAKE, pressed);
+                return true;
+            case vsg::KEY_e:
+                if (m_transmission_manual) {
+                    driver->SetKeyState(ChInteractiveDriver::InputKey::CLUTCH, pressed);
+                    return true;
+                }
+                break;
+            default:
+                break;
+        }
+
+        return false;
+    }
+
     ChVehicleVisualSystemVSG* m_vsys;
     ChAutomaticTransmission* m_transmission_auto;
     ChManualTransmission* m_transmission_manual;
@@ -181,7 +237,7 @@ class ChVehicleGuiComponentVSG : public vsg3d::ChGuiComponentVSG {
     ChVehicleVisualSystemVSG* m_vsys;
 };
 
-void ShowHelp() {
+void ShowHelp(ChInteractiveDriver::KeyboardMode keyboard_mode) {
     if (ImGui::CollapsingHeader("Chase camera controls", ImGuiTreeNodeFlags_DefaultOpen)) {
         ImGui::BulletText("Selection of camera mode");
         ImGui::Indent();
@@ -209,8 +265,14 @@ void ShowHelp() {
     if (ImGui::CollapsingHeader("Vehicle controls", ImGuiTreeNodeFlags_DefaultOpen)) {
         ImGui::BulletText("Drive and steering controls");
         ImGui::Indent();
-        ImGui::TextUnformatted("W/S: acceleration/deceleration (combined throttle/brake controls)");
-        ImGui::TextUnformatted("A/D: steering (left/right)");
+        if (keyboard_mode == ChInteractiveDriver::KeyboardMode::HELD) {
+            ImGui::TextUnformatted("W: accelerate while held (throttle falls back to 0 on release)");
+            ImGui::TextUnformatted("S: brake while held (brake falls back to 0 on release)");
+            ImGui::TextUnformatted("A/D: steer left/right while held (steering self-centers on release)");
+        } else {
+            ImGui::TextUnformatted("W/S: acceleration/deceleration (combined throttle/brake controls)");
+            ImGui::TextUnformatted("A/D: steering (left/right)");
+        }
         ImGui::TextUnformatted("C: center steering wheel (set steering=0)");
         ImGui::TextUnformatted("R: release pedals (set throttle=brake=clutch=0)");
         ImGui::Unindent();
@@ -461,7 +523,8 @@ void ChVehicleGuiComponentVSG::render(vsg::CommandBuffer& cb) {
                                 ImVec2(0.5f, 0.5f));
         ImGui::SetNextWindowSize(ImVec2(io.DisplaySize.x * 0.75f, io.DisplaySize.y * 0.75f), ImGuiCond_Always);
         ImGui::Begin("Help", &show_help, ImGuiWindowFlags_NoCollapse);
-        ShowHelp();
+        auto driver = dynamic_cast<ChInteractiveDriver*>(m_vsys->GetDriver());
+        ShowHelp(driver ? driver->GetKeyboardMode() : ChInteractiveDriver::KeyboardMode::CUMULATIVE);
         ImGui::End();
     }
 
@@ -470,12 +533,27 @@ void ChVehicleGuiComponentVSG::render(vsg::CommandBuffer& cb) {
 
 // -----------------------------------------------------------------------------
 
-ChVehicleVisualSystemVSG::ChVehicleVisualSystemVSG() : ChVisualSystemVSG() {
+ChVehicleVisualSystemVSG::ChVehicleVisualSystemVSG() : ChVisualSystemVSG(), m_keyboard_mode(ChInteractiveDriver::KeyboardMode::CUMULATIVE) {
     // Disable global visibility controls
     m_show_visibility_controls = false;
 }
 
 ChVehicleVisualSystemVSG::~ChVehicleVisualSystemVSG() {}
+
+void ChVehicleVisualSystemVSG::SetKeyboardMode(ChInteractiveDriver::KeyboardMode mode) {
+    m_keyboard_mode = mode;
+    if (auto driver = dynamic_cast<ChInteractiveDriver*>(GetDriver()))
+        driver->SetKeyboardMode(mode);
+}
+
+void ChVehicleVisualSystemVSG::AttachDriver(ChDriver* driver) {
+    ChVehicleVisualSystem::AttachDriver(driver);
+
+    // VSG reports key releases and window focus loss, so held-key driving controls can be supported. This only
+    // proposes a default; an explicit call to ChInteractiveDriver::SetKeyboardMode always wins.
+    if (auto idriver = dynamic_cast<ChInteractiveDriver*>(driver))
+        idriver->SetDefaultKeyboardMode(m_keyboard_mode);
+}
 
 void ChVehicleVisualSystemVSG::Initialize() {
     if (m_initialized)

--- a/src/chrono_vehicle/visualization/ChVehicleVisualSystemVSG.h
+++ b/src/chrono_vehicle/visualization/ChVehicleVisualSystemVSG.h
@@ -26,6 +26,7 @@
 #include "chrono_vehicle/ChApiVehicle.h"
 #include "chrono_vehicle/ChConfigVehicle.h"
 #include "chrono_vehicle/ChVehicleVisualSystem.h"
+#include "chrono_vehicle/driver/ChInteractiveDriver.h"
 
 #include "chrono_vsg/ChVisualSystemVSG.h"
 
@@ -46,6 +47,14 @@ class CH_VEHICLE_API ChVehicleVisualSystemVSG : public ChVehicleVisualSystem, pu
     /// Initialize the visualization system.
     virtual void Initialize() override;
 
+    /// Select the semantics of the keyboard driving controls (default: ChInteractiveDriver::KeyboardMode::CUMULATIVE,
+    /// unchanged from the ChInteractiveDriver default).
+    /// Overrides the default proposed to an attached ChInteractiveDriver; see ChInteractiveDriver::SetKeyboardMode.
+    void SetKeyboardMode(ChInteractiveDriver::KeyboardMode mode);
+
+    /// Attach a driver to this VSG vehicle visualization system.
+    virtual void AttachDriver(ChDriver* driver) override;
+
     /// Advance the dynamics of the chase camera.
     /// The integration of the underlying ODEs is performed using as many steps as needed to advance
     /// by the specified duration.
@@ -53,6 +62,8 @@ class CH_VEHICLE_API ChVehicleVisualSystemVSG : public ChVehicleVisualSystem, pu
 
   protected:
     virtual void AppendGUIStats() {}
+
+    ChInteractiveDriver::KeyboardMode m_keyboard_mode;  ///< semantics of the keyboard driving controls
 
     friend class ChVehicleGuiComponentVSG;
     friend class ChVehicleKeyboardHandlerVSG;

--- a/src/chrono_vsg/ChEventHandlerVSG.h
+++ b/src/chrono_vsg/ChEventHandlerVSG.h
@@ -16,6 +16,7 @@
 #define CH_EVENT_HANDLER_VSG_H
 
 #include <vsg/ui/KeyEvent.h>
+#include <vsg/ui/WindowEvent.h>
 
 #include "chrono_vsg/ChApiVSG.h"
 
@@ -37,6 +38,15 @@ class CH_VSG_API ChEventHandlerVSG {
     virtual void process(vsg::ButtonReleaseEvent& ev) {}
     virtual void process(vsg::MoveEvent& ev) {}
     virtual void process(vsg::TouchEvent& ev) {}
+
+    /// The render window acquired keyboard focus.
+    virtual void process(vsg::FocusInEvent& ev) {}
+
+    /// The render window lost keyboard focus.
+    /// A handler that tracks which keys are currently held down should treat this as a release of all of them:
+    /// key events are delivered to whichever window has focus, so any release that happens from now on is never
+    /// seen here.
+    virtual void process(vsg::FocusOutEvent& ev) {}
 };
 
 /// @} vsg_module

--- a/src/chrono_vsg/ChVisualSystemVSG.cpp
+++ b/src/chrono_vsg/ChVisualSystemVSG.cpp
@@ -119,6 +119,8 @@ class EventHandlerWrapper : public vsg::Inherit<vsg::Visitor, EventHandlerWrappe
     void apply(vsg::ButtonReleaseEvent& buttonRelease) override { m_component->process(buttonRelease); }
     void apply(vsg::MoveEvent& moveEvent) override { m_component->process(moveEvent); }
     void apply(vsg::TouchEvent& touchEvent) override { m_component->process(touchEvent); }
+    void apply(vsg::FocusInEvent& focusIn) override { m_component->process(focusIn); }
+    void apply(vsg::FocusOutEvent& focusOut) override { m_component->process(focusOut); }
 
   private:
     std::shared_ptr<ChEventHandlerVSG> m_component;


### PR DESCRIPTION
Keyboard driving in `ChInteractiveDriver` is cumulative: each recorded W/A/S/D keypress nudges the corresponding input by a fixed increment, and it stays there until nudged again. Releasing a key does nothing. Measured on `demo_SEN_Gator`, holding W for 1.5 s moves the throttle target to 0.020 and holding longer does nothing more; four keypresses leave it pinned at 0.080 for the rest of the run. That ratchets, it doesn't drive, and it trips up anyone coming from a driving game where letting go of the key lets the car coast.

This adds `KeyboardMode::HELD`, in which driver inputs are a pure function of the keys currently held down: W drives the throttle target to 1 while held and to 0 on release, S drives the brake and takes precedence over the accelerator, A/D steer left/right, and steering self-centers when neither (or both) is held. The ramp toward these targets is still the same first-order dynamics `ChInteractiveDriver` already integrates (`SetGains`), so it's a function of elapsed time, not frame rate.

`CUMULATIVE` remains the default everywhere -- on `ChInteractiveDriver` itself and in what the Irrlicht and VSG vehicle visualization systems propose to an attached driver (`SetDefaultKeyboardMode`). Nothing changes out of the box for any existing demo. `HELD` is available on request: call `SetKeyboardMode()` on the driver or on either visualization system, and that explicit choice always wins over the proposed default.

Both backends absorb keyboard auto-repeat and duplicate release events through idempotent state updates, and release all keys when the render window loses keyboard focus (a release delivered to a different window would otherwise never be seen and the input would stay pinned). VSG only reports focus-out events on the XCB and Win32 backends; as of VSG 1.1.11 it never fires on macOS, so that safety net doesn't apply there (noted at the call site). VSG's `ChEventHandlerVSG` didn't forward focus events at all before this, so a small prerequisite commit adds that (empty-by-default virtuals, no existing handler changes behavior).

## Testing

Verified manually against `demo_SEN_Gator` (Irrlicht) and a Sedan demo (VSG). Irrlicht: a 1.5 s hold of W produced one press at t=0 and one release at t=1500.3 ms, tracked correctly. VSG: nine holds of W/A/S/D produced exactly nine press and nine release events, with recovered hold durations of 1499.9 ms (1500 ms hold) and 59.9 ms (60 ms tap). On a Sedan with default gains, holding W ramps the throttle to 0.3302 / 0.6329 / 0.8652 / 0.9290 / 0.9976 at 0.10 / 0.25 / 0.50 / 0.66 / 1.50 s after the press, matching `1 - exp(-4t)` to within 7e-4; on release it decays as `exp(-4t)` to 0.3677 / 0.1350 / 0.0182 at 0.25 / 0.50 / 1.00 s and reaches exactly zero. A 4x larger step size reproduces the same curve to four decimal places, confirming the ramp depends on elapsed time rather than step count.

No unit tests: `src/tests/unit_tests/vehicle` has no coverage of `ChInteractiveDriver` today (`utest_VEH_destructors.cpp` and `utest_VEH_tire_contact.cpp` don't touch it), so I didn't want to hold this change to a higher bar than what's already there. Happy to add tests for both modes if that's wanted.
