### PR TITLE
Fix Vulkan RT parity, seeding, and readback

### DIFF
--- a/src/chrono_sensor/ChSensorManager.h
+++ b/src/chrono_sensor/ChSensorManager.h
@@ -47,7 +47,7 @@ namespace sensor {
 /// @addtogroup sensor
 /// @{
 
-/// What a cuRAND buffer is used for. One constant per independent random-number stream in the sensor
+/// What an independent random-number stream is used for. One constant per stream in the sensor
 /// module, and part of the key that keeps those streams from coinciding.
 ///
 /// Closed on purpose: a new stochastic filter must add its own constant here rather than borrow or
@@ -66,6 +66,8 @@ enum class RngUsage : unsigned int {
     OptixSegmentationRaygen = 7,///< ChFilterOptixRender, segmentation camera
     OptixDepthRaygen = 8,       ///< ChFilterOptixRender, depth camera
     OptixNormalRaygen = 9,      ///< ChFilterOptixRender, normal camera
+    VulkanCameraRaygen = 10,    ///< ChFilterVulkanRTRender, camera
+    VulkanPhysCameraRaygen = 11,///< ChFilterVulkanRTRender, physical camera
     Count                       ///< sentinel; keep last
 };
 
@@ -222,7 +224,7 @@ class CH_SENSOR_API ChSensorManager {
     /// @param sensor the sensor owning the buffer; must already be registered via AddSensor
     /// @param usage what the buffer is for
     /// @param filter_stream_index the calling filter's ChFilter::GetRngStreamIndex()
-    /// @return the 64-bit seed to pass to init_cuda_rng
+    /// @return the 64-bit seed used to initialize the backend RNG stream
     /// @throws std::runtime_error if the sensor is null or was never registered, if the calling filter
     /// has no stream index, if `usage` is RngUsage::Unknown or a value at or past RngUsage::Count, or
     /// if any field of the stream key exceeds its bit width. Every one of these would otherwise

--- a/src/chrono_sensor/vulkan/ChFilterVulkanRTRender.cpp
+++ b/src/chrono_sensor/vulkan/ChFilterVulkanRTRender.cpp
@@ -18,6 +18,7 @@
 #include "chrono_sensor/vulkan/ChVulkanRTUtils.h"
 #include "chrono_sensor/vulkan/ChVulkanRTBuffer.h"
 #include "chrono_sensor/ChConfigSensor.h"
+#include "chrono_sensor/ChSensorManager.h"
 
 #include <algorithm>
 #include <array>
@@ -132,14 +133,33 @@ struct TextureSample4 {
 };
 
 struct EvaluatedMaterial {
-    ChVector3f diffuse = ChVector3f(0.5f, 0.5f, 0.5f);
-    ChVector3f specular = ChVector3f(0.2f, 0.2f, 0.2f);
-    ChVector3f emissive = ChVector3f(0.f, 0.f, 0.f);
-    float opacity = 1.f;
-    float roughness = 1.f;
-    float metallic = 0.f;
-    bool use_specular_workflow = false;
+    ChVector3f diffuse;
+    ChVector3f specular;
+    ChVector3f emissive;
+    float opacity;
+    float roughness;
+    float metallic;
+    bool use_specular_workflow;
 };
+
+const EvaluatedMaterial& DefaultEvaluatedMaterial() {
+    static const EvaluatedMaterial defaults = [] {
+        const auto material = ChVisualMaterial::Default();
+        const auto& kd = material->GetDiffuseColor();
+        const auto& ks = material->GetSpecularColor();
+        const auto& ke = material->GetEmissiveColor();
+        EvaluatedMaterial out{};
+        out.diffuse = ChVector3f(kd.R, kd.G, kd.B);
+        out.specular = ChVector3f(ks.R, ks.G, ks.B);
+        out.emissive = ChVector3f(ke.R, ke.G, ke.B);
+        out.opacity = material->GetOpacity();
+        out.roughness = material->GetRoughness();
+        out.metallic = material->GetMetallic();
+        out.use_specular_workflow = material->GetUseSpecularWorkflow();
+        return out;
+    }();
+    return defaults;
+}
 
 inline uint8_t ToByte(float v) {
     v = std::max(0.f, std::min(1.f, v));
@@ -205,16 +225,29 @@ inline float HashUnitFloat(uint32_t x) {
     return static_cast<float>(HashU32(x) & 0x00ffffffu) / static_cast<float>(0x01000000u);
 }
 
-inline float OptixJitterComponent(unsigned int x, unsigned int y, unsigned int sample_idx, unsigned int axis) {
-    return HashUnitFloat((x + 1u) * 73856093u ^ (y + 1u) * 19349663u ^ (sample_idx + 1u) * 83492791u ^ axis * 2654435761u);
+inline uint32_t CameraRngKey(unsigned long long rng_seed) {
+    const uint32_t lo = static_cast<uint32_t>(rng_seed);
+    const uint32_t hi = static_cast<uint32_t>(rng_seed >> 32);
+    return HashU32(lo ^ hi * 0x9e3779b9u);
+}
+
+inline float OptixJitterComponent(unsigned int x,
+                                  unsigned int y,
+                                  unsigned int sample_idx,
+                                  unsigned int axis,
+                                  uint32_t frame_index,
+                                  unsigned long long rng_seed) {
+    return HashUnitFloat((x + 1u) * 73856093u ^ (y + 1u) * 19349663u ^
+                         (sample_idx + 1u) * 83492791u ^ axis * 2654435761u ^
+                         (frame_index + 1u) * 2246822519u ^ CameraRngKey(rng_seed));
 }
 
 inline float NormalDistOptix(float ndh, float roughness) {
-    // Keep the same microfacet normalization used by OptiX shader_utils.cuh::NormalDist():
-    // the 1/pi factor is intentionally omitted there and must not be reintroduced here.
-    const float rough_sqr = std::max(0.02f, roughness) * std::max(0.02f, roughness);
+    // Match OptiX shader_utils.cuh::NormalDist() exactly. In particular, do not
+    // impose a Vulkan-only roughness or denominator floor at mirror-like values.
+    const float rough_sqr = roughness * roughness;
     const float den = ndh * ndh * (rough_sqr - 1.f) + 1.f;
-    return rough_sqr / std::max(1e-5f, den * den);
+    return rough_sqr / (den * den);
 }
 
 inline float HammonSmithOptix(float ndv, float ndl, float roughness) {
@@ -530,12 +563,12 @@ TextureSample4 SampleEnvironmentTexture(
 }
 
 EvaluatedMaterial EvaluateMaterial(const ChVulkanRTRenderCache* cache, const RayHit& hit) {
-    EvaluatedMaterial out;
+    EvaluatedMaterial out = DefaultEvaluatedMaterial();
     out.diffuse = hit.material.diffuse;
     out.specular = hit.material.specular;
     out.emissive = hit.material.emissive;
     out.opacity = ClampFloat(hit.material.opacity, 0.f, 1.f);
-    out.roughness = ClampFloat(hit.material.roughness, 0.02f, 1.f);
+    out.roughness = ClampFloat(hit.material.roughness, 0.f, 1.f);
     out.metallic = ClampFloat(hit.material.metallic, 0.f, 1.f);
     out.use_specular_workflow = hit.material.use_specular_workflow;
 
@@ -562,7 +595,7 @@ EvaluatedMaterial EvaluateMaterial(const ChVulkanRTRenderCache* cache, const Ray
         if (!hit.material.roughness_texture.empty()) {
             const auto tex = SampleTexture(cache, hit.material.roughness_texture, hit.uv, hit.material.tex_scale_u, hit.material.tex_scale_v);
             if (tex.valid)
-                out.roughness = ClampFloat(tex.r, 0.02f, 1.f);
+                out.roughness = ClampFloat(tex.r, 0.f, 1.f);
         }
         if (!hit.material.metallic_texture.empty()) {
             const auto tex = SampleTexture(cache, hit.material.metallic_texture, hit.uv, hit.material.tex_scale_u, hit.material.tex_scale_v);
@@ -1343,11 +1376,15 @@ ChVector3f Shade(const ChVulkanRTRenderCache* cache,
                 }
                 if (light.type == LightType::SPOT_LIGHT) {
                     const ChVector3d spot_dir = NormalizeSafe(ChVector3d(light.dir));
-                    const double angle = std::acos(std::max(-1.0, std::min(1.0, spot_dir.Dot(-light_dir))));
-                    if (2.0 * angle > static_cast<double>(light.angle)) {
+                    const double cos_angle =
+                        std::max(-1.0, std::min(1.0, spot_dir.Dot(-light_dir)));
+                    if (cos_angle < std::cos(0.5 * static_cast<double>(light.angle))) {
                         attenuation = 0.f;
                     } else if (!light.const_color && light.angle_atten_rate >= 0.f) {
-                        float angle_attenuation = ClampFloat(light.angle_atten_rate * (light.angle - 2.f * static_cast<float>(angle)), 0.f, 1.f);
+                        // Keep the OptiX-compatible soft falloff in angle space.
+                        const double angle = std::acos(cos_angle);
+                        float angle_attenuation = ClampFloat(
+                            light.angle_atten_rate * (light.angle - 2.f * static_cast<float>(angle)), 0.f, 1.f);
                         attenuation *= angle_attenuation * angle_attenuation;
                     }
                 } else if (light.type == LightType::RECTANGLE_LIGHT || light.type == LightType::DISK_LIGHT) {
@@ -1794,7 +1831,7 @@ struct ChVulkanRTGpuLight {
     float pos_range[4];    // pos xyz, range
     float dir_type[4];     // dir xyz, LightType as float
     float color_atten[4];  // color rgb, attenuation scale
-    float params[4];       // angle, angle_falloff_start, angle_atten_rate, area/radius
+    float params[4];       // angle, angle_falloff_start, angle_atten_rate, spot cos-half-angle or area/radius
 };
 
 struct ChVulkanRTGpuSceneData {
@@ -1815,8 +1852,12 @@ struct ChVulkanRTGpuPushConstants {
     uint32_t height;
     uint32_t pipeline;
     uint32_t flags;
-    uint32_t frame_index;  // VulkanCameraFrameRng: decorrelate stochastic camera launches.
+    uint32_t frame_index;  // Decorrelate stochastic camera launches.
+    uint32_t rng_seed_lo;  // Low half of ChSensorManager-derived stream seed.
+    uint32_t rng_seed_hi;  // High half of ChSensorManager-derived stream seed.
 };
+static_assert(sizeof(ChVulkanRTGpuPushConstants) <= 128,
+              "Vulkan RT push constants exceed Vulkan's guaranteed 128-byte minimum");
 
 struct ChVulkanRTGpuFrame {
     std::shared_ptr<ChVulkanSensor> sensor;
@@ -1842,6 +1883,7 @@ struct ChVulkanRTGpuFrame {
     uint32_t ray_recursions = 1;
     uint32_t sample_factor = 1;
     uint32_t frame_index = 0;
+    unsigned long long rng_seed = 0;
     SensorHostRGBA8Buffer* rgba8 = nullptr;
     SensorHostRGBDHalf4Buffer* rgbd = nullptr;
     SensorHostDepthBuffer* depth = nullptr;
@@ -1937,7 +1979,9 @@ ChVulkanRTGpuLight MakeGpuLight(const ChVulkanRTLight& light) {
     out.params[0] = light.angle;
     out.params[1] = light.angle_falloff_start;
     out.params[2] = light.angle_atten_rate;
-    out.params[3] = light.radius > 0.f ? light.radius : light.area;
+    out.params[3] = (light.type == LightType::SPOT_LIGHT)
+                        ? static_cast<float>(std::cos(0.5 * static_cast<double>(light.angle)))
+                        : (light.radius > 0.f ? light.radius : light.area);
     return out;
 }
 
@@ -2027,6 +2071,8 @@ struct ChVulkanRTGpuRenderer {
         const uint32_t sample_factor = std::min<uint32_t>(32u, std::max<uint32_t>(1u, frame.sample_factor));
         pc.flags = (frame.use_gi ? 1u : 0u) | (recursion_count << 8) | (sample_factor << 16);
         pc.frame_index = frame.frame_index;
+        pc.rng_seed_lo = static_cast<uint32_t>(frame.rng_seed);
+        pc.rng_seed_hi = static_cast<uint32_t>(frame.rng_seed >> 32);
 
         RecordAndSubmitRender(pc, frame.width, frame.height, frame.pipeline);
         CopyOutputToHost(frame);
@@ -2290,11 +2336,12 @@ struct ChVulkanRTGpuRenderer {
     void EnsureBuffer(std::unique_ptr<ChVulkanRTBuffer>& buffer,
                       VkDeviceSize size,
                       VkBufferUsageFlags usage,
-                      VkMemoryPropertyFlags memory_flags) {
+                      VkMemoryPropertyFlags memory_flags,
+                      VkMemoryPropertyFlags preferred_flags = 0) {
         if (size == 0)
             size = 1;
         if (!buffer || buffer->GetSize() < size) {
-            buffer = std::make_unique<ChVulkanRTBuffer>(m_device, size, usage, memory_flags);
+            buffer = std::make_unique<ChVulkanRTBuffer>(m_device, size, usage, memory_flags, preferred_flags);
             m_descriptors_dirty = true;
         }
     }
@@ -3028,7 +3075,8 @@ struct ChVulkanRTGpuRenderer {
         EnsureBuffer(m_output_staging_buffer,
                      needed,
                      VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                     VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
     }
 
     void WriteDescriptors() {
@@ -3313,6 +3361,23 @@ void ChFilterVulkanRTRender::Initialize(std::shared_ptr<ChSensor> pSensor, std::
     }
 
     m_sensor = vulkan_sensor;
+
+    // Use the same manager/sensor/filter stream derivation as OptiX. With a
+    // pinned ChSensorManager seed this is repeatable; otherwise it is clock-seeded.
+    switch (vulkan_sensor->GetPipelineType()) {
+        case VulkanPipelineType::CAMERA:
+            m_rng_seed = ChSensorManager::GetDeterministicSeed(
+                pSensor, RngUsage::VulkanCameraRaygen, GetRngStreamIndex());
+            break;
+        case VulkanPipelineType::PHYS_CAMERA:
+            m_rng_seed = ChSensorManager::GetDeterministicSeed(
+                pSensor, RngUsage::VulkanPhysCameraRaygen, GetRngStreamIndex());
+            break;
+        default:
+            m_rng_seed = 0;
+            break;
+    }
+
     const unsigned int width = vulkan_sensor->GetWidth();
     const unsigned int height = vulkan_sensor->GetHeight();
     const size_t count = static_cast<size_t>(width) * static_cast<size_t>(height);
@@ -3494,8 +3559,10 @@ void ChFilterVulkanRTRender::Apply() {
         gpu_frame.use_gi = CameraUseGI(sensor);
         gpu_frame.ray_recursions = static_cast<uint32_t>(std::max(1, m_ray_recursions));
         gpu_frame.sample_factor = CameraSampleFactor(sensor);
-        // VulkanCameraFrameRng: OptiX persists and advances per-pixel RNG state across launches.
+        // Frame index advances the stream across launches; m_rng_seed selects the
+        // run/manager/sensor/filter stream according to ChSensorManager's seeding API.
         gpu_frame.frame_index = static_cast<uint32_t>(sensor->GetNumLaunches());
+        gpu_frame.rng_seed = m_rng_seed;
         gpu_frame.max_depth = CameraMaxDepth(sensor);
         gpu_frame.max_distance = gpu_frame.max_depth;
         gpu_frame.clip_near = 0.001f;
@@ -3642,6 +3709,7 @@ void ChFilterVulkanRTRender::Apply() {
     const unsigned int sample_factor = is_color_pipeline ? CameraSampleFactor(sensor) : 1u;
     const ChVulkanRTRenderCache* cache = m_render_cache.get();
     const int camera_hit_limit = OptiXCameraHitLimit(m_ray_recursions);
+    const uint32_t camera_frame_index = static_cast<uint32_t>(sensor->GetNumLaunches());
 
     auto render_pixel = [&](unsigned int x, unsigned int y) {
         const size_t idx = static_cast<size_t>(y) * width + x;
@@ -3654,8 +3722,14 @@ void ChFilterVulkanRTRender::Apply() {
                 for (unsigned int sx = 0; sx < sample_factor; ++sx) {
                     const unsigned int sample_idx = sy * sample_factor + sx;
                     const bool center_sample = (sample_idx + 1u == spp);
-                    const double jx = (sample_factor == 1u || center_sample) ? 0.5 : static_cast<double>(OptixJitterComponent(x, y, sample_idx, 0u));
-                    const double jy = (sample_factor == 1u || center_sample) ? 0.5 : static_cast<double>(OptixJitterComponent(x, y, sample_idx, 1u));
+                    const double jx = (sample_factor == 1u || center_sample)
+                                          ? 0.5
+                                          : static_cast<double>(OptixJitterComponent(
+                                                x, y, sample_idx, 0u, camera_frame_index, m_rng_seed));
+                    const double jy = (sample_factor == 1u || center_sample)
+                                          ? 0.5
+                                          : static_cast<double>(OptixJitterComponent(
+                                                x, y, sample_idx, 1u, camera_frame_index, m_rng_seed));
                     const double fx = static_cast<double>(x) + jx;
                     const double fy = static_cast<double>(y) + jy;
                     double uv_x = 2.0 * fx / static_cast<double>(width) - 1.0;

--- a/src/chrono_sensor/vulkan/ChFilterVulkanRTRender.h
+++ b/src/chrono_sensor/vulkan/ChFilterVulkanRTRender.h
@@ -71,6 +71,7 @@ class CH_SENSOR_API ChFilterVulkanRTRender : public ChFilter {
     std::shared_ptr<SensorHostRadarBuffer> m_buffer_radar;
 
     float m_time_stamp = 0.f;
+    unsigned long long m_rng_seed = 0;
     int m_ray_recursions = 1;
 
     friend class ChVulkanRTEngine;

--- a/src/chrono_sensor/vulkan/ChVulkanRTBuffer.cpp
+++ b/src/chrono_sensor/vulkan/ChVulkanRTBuffer.cpp
@@ -26,7 +26,8 @@ namespace sensor {
 ChVulkanRTBuffer::ChVulkanRTBuffer(std::shared_ptr<ChVulkanRTDevice> device,
                                    VkDeviceSize size,
                                    VkBufferUsageFlags usage,
-                                   VkMemoryPropertyFlags memory_flags)
+                                   VkMemoryPropertyFlags memory_flags,
+                                   VkMemoryPropertyFlags preferred_flags)
     : m_device_owner(std::move(device)), m_size(size) {
     VkBufferCreateInfo buffer_info = {};
     buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -46,7 +47,8 @@ ChVulkanRTBuffer::ChVulkanRTBuffer(std::shared_ptr<ChVulkanRTDevice> device,
     alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
     alloc_info.pNext = (usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) ? &flags_info : nullptr;
     alloc_info.allocationSize = requirements.size;
-    alloc_info.memoryTypeIndex = m_device_owner->FindMemoryType(requirements.memoryTypeBits, memory_flags);
+    alloc_info.memoryTypeIndex =
+        m_device_owner->FindMemoryType(requirements.memoryTypeBits, memory_flags, preferred_flags);
 
     CH_VULKAN_CHECK(vkAllocateMemory(m_device_owner->GetDevice(), &alloc_info, nullptr, &m_memory));
     CH_VULKAN_CHECK(vkBindBufferMemory(m_device_owner->GetDevice(), m_buffer, m_memory, 0));

--- a/src/chrono_sensor/vulkan/ChVulkanRTBuffer.h
+++ b/src/chrono_sensor/vulkan/ChVulkanRTBuffer.h
@@ -37,7 +37,8 @@ class CH_SENSOR_API ChVulkanRTBuffer {
     ChVulkanRTBuffer(std::shared_ptr<ChVulkanRTDevice> device,
                      VkDeviceSize size,
                      VkBufferUsageFlags usage,
-                     VkMemoryPropertyFlags memory_flags);
+                     VkMemoryPropertyFlags memory_flags,
+                     VkMemoryPropertyFlags preferred_flags = 0);
     ~ChVulkanRTBuffer();
 
     ChVulkanRTBuffer(const ChVulkanRTBuffer&) = delete;

--- a/src/chrono_sensor/vulkan/ChVulkanRTDevice.cpp
+++ b/src/chrono_sensor/vulkan/ChVulkanRTDevice.cpp
@@ -236,12 +236,23 @@ void ChVulkanRTDevice::LoadDeviceFunctions() {
 #undef LOAD_VK_DEVICE_FUNCTION
 }
 
-uint32_t ChVulkanRTDevice::FindMemoryType(uint32_t type_bits, VkMemoryPropertyFlags required_flags) const {
-    for (uint32_t i = 0; i < m_memory_properties.memoryTypeCount; ++i) {
-        const bool type_supported = (type_bits & (1u << i)) != 0;
-        const bool flags_supported = (m_memory_properties.memoryTypes[i].propertyFlags & required_flags) == required_flags;
-        if (type_supported && flags_supported)
-            return i;
+uint32_t ChVulkanRTDevice::FindMemoryType(uint32_t type_bits,
+                                          VkMemoryPropertyFlags required_flags,
+                                          VkMemoryPropertyFlags preferred_flags) const {
+    // First try required + preferred, then fall back to required only. This makes
+    // HOST_CACHED an optimization rather than a portability requirement.
+    for (int pass = 0; pass < 2; ++pass) {
+        const VkMemoryPropertyFlags wanted =
+            required_flags | ((pass == 0) ? preferred_flags : VkMemoryPropertyFlags{0});
+        for (uint32_t i = 0; i < m_memory_properties.memoryTypeCount; ++i) {
+            const bool type_supported = (type_bits & (1u << i)) != 0;
+            const bool flags_supported =
+                (m_memory_properties.memoryTypes[i].propertyFlags & wanted) == wanted;
+            if (type_supported && flags_supported)
+                return i;
+        }
+        if (preferred_flags == 0)
+            break;
     }
 
     std::ostringstream out;

--- a/src/chrono_sensor/vulkan/ChVulkanRTDevice.h
+++ b/src/chrono_sensor/vulkan/ChVulkanRTDevice.h
@@ -51,7 +51,11 @@ class CH_SENSOR_API ChVulkanRTDevice {
     const VkPhysicalDeviceProperties& GetPhysicalDeviceProperties() const { return m_properties; }
     const ChVulkanRTCapabilities& GetCapabilities() const { return m_capabilities; }
 
-    uint32_t FindMemoryType(uint32_t type_bits, VkMemoryPropertyFlags required_flags) const;
+    /// Choose a memory type carrying all required flags, preferring extra flags when available.
+    /// If no supported type also carries preferred_flags, retry with required_flags only.
+    uint32_t FindMemoryType(uint32_t type_bits,
+                            VkMemoryPropertyFlags required_flags,
+                            VkMemoryPropertyFlags preferred_flags = 0) const;
 
     PFN_vkGetBufferDeviceAddressKHR vkGetBufferDeviceAddressKHR = nullptr;
     PFN_vkCreateAccelerationStructureKHR vkCreateAccelerationStructureKHR = nullptr;

--- a/src/chrono_sensor/vulkan/ChVulkanRTScene.cpp
+++ b/src/chrono_sensor/vulkan/ChVulkanRTScene.cpp
@@ -33,6 +33,74 @@ namespace sensor {
 
 namespace {
 
+struct ChVulkanRTCanonicalMaterialDefaults {
+    ChVector3f diffuse;
+    ChVector3f ambient;
+    ChVector3f specular;
+    ChVector3f emissive;
+    float opacity;
+    float roughness;
+    float metallic;
+    float emissive_power;
+    float shininess;
+    bool use_specular_workflow;
+    float tex_scale_u;
+    float tex_scale_v;
+    unsigned short int class_id;
+    unsigned short int instance_id;
+};
+
+const ChVulkanRTCanonicalMaterialDefaults& GetCanonicalMaterialDefaults() {
+    static const ChVulkanRTCanonicalMaterialDefaults defaults = [] {
+        const auto material = ChVisualMaterial::Default();
+        const auto& kd = material->GetDiffuseColor();
+        const auto& ka = material->GetAmbientColor();
+        const auto& ks = material->GetSpecularColor();
+        const auto& ke = material->GetEmissiveColor();
+        const auto& tex_scale = material->GetTextureScale();
+
+        ChVulkanRTCanonicalMaterialDefaults out;
+        out.diffuse = ChVector3f(kd.R, kd.G, kd.B);
+        out.ambient = ChVector3f(ka.R, ka.G, ka.B);
+        out.specular = ChVector3f(ks.R, ks.G, ks.B);
+        out.emissive = ChVector3f(ke.R, ke.G, ke.B);
+        out.opacity = material->GetOpacity();
+        out.roughness = material->GetRoughness();
+        out.metallic = material->GetMetallic();
+        out.emissive_power = material->GetEmissivePower();
+        out.shininess = material->GetSpecularExponent();
+        out.use_specular_workflow = material->GetUseSpecularWorkflow();
+        out.tex_scale_u = tex_scale.x();
+        out.tex_scale_v = tex_scale.y();
+        out.class_id = material->GetClassID();
+        out.instance_id = material->GetInstanceID();
+        return out;
+    }();
+    return defaults;
+}
+
+}  // namespace
+
+ChVulkanRTMaterial::ChVulkanRTMaterial() {
+    const auto& defaults = GetCanonicalMaterialDefaults();
+    diffuse = defaults.diffuse;
+    ambient = defaults.ambient;
+    specular = defaults.specular;
+    emissive = defaults.emissive;
+    opacity = defaults.opacity;
+    roughness = defaults.roughness;
+    metallic = defaults.metallic;
+    emissive_power = defaults.emissive_power;
+    shininess = defaults.shininess;
+    use_specular_workflow = defaults.use_specular_workflow;
+    tex_scale_u = defaults.tex_scale_u;
+    tex_scale_v = defaults.tex_scale_v;
+    class_id = defaults.class_id;
+    instance_id = defaults.instance_id;
+}
+
+namespace {
+
 constexpr double CH_VKRT_SCENE_EPS = 1e-12;
 constexpr float CH_VKRT_PI = 3.14159265358979323846f;
 
@@ -65,7 +133,7 @@ ChVulkanRTMaterial MaterialFromVisual(const std::shared_ptr<ChVisualMaterial>& v
     mat.specular = ChVector3f(ks.R, ks.G, ks.B);
     mat.emissive = ChVector3f(ke.R, ke.G, ke.B);
     mat.opacity = std::max(0.f, std::min(1.f, visual_mat->GetOpacity()));
-    mat.roughness = std::max(0.02f, std::min(1.f, visual_mat->GetRoughness()));
+    mat.roughness = std::max(0.f, std::min(1.f, visual_mat->GetRoughness()));
     mat.metallic = std::max(0.f, std::min(1.f, visual_mat->GetMetallic()));
     mat.emissive_power = std::max(0.f, visual_mat->GetEmissivePower());
     mat.shininess = std::max(1.f, visual_mat->GetSpecularExponent());

--- a/src/chrono_sensor/vulkan/ChVulkanRTScene.h
+++ b/src/chrono_sensor/vulkan/ChVulkanRTScene.h
@@ -57,29 +57,33 @@ struct CH_SENSOR_API ChVulkanRTTexCoord {
 };
 
 struct CH_SENSOR_API ChVulkanRTMaterial {
-    // OptiX implicit material fallback for shapes without an explicit ChVisualMaterial.
-    ChVector3f diffuse = ChVector3f(0.5f, 0.5f, 0.5f);
-    ChVector3f ambient = ChVector3f(0.5f, 0.5f, 0.5f);
-    ChVector3f specular = ChVector3f(0.2f, 0.2f, 0.2f);
-    ChVector3f emissive = ChVector3f(0.f, 0.f, 0.f);
+    /// Construct the implicit Vulkan material from Chrono's canonical visual default.
+    /// Keeping this conversion centralized prevents the backend from drifting when
+    /// ChVisualMaterial::Default() changes.
+    ChVulkanRTMaterial();
+
+    ChVector3f diffuse;
+    ChVector3f ambient;
+    ChVector3f specular;
+    ChVector3f emissive;
 
     // Mirrors the fields consumed by the OptiX camera shaders. OptiX names this
     // value "transparency", but it is used as opacity/surface weight: 1 is
     // opaque, 0 is fully transparent and traces through the surface.
-    float opacity = 1.f;
-    float roughness = 1.f;
-    float metallic = 0.f;
-    float emissive_power = 0.f;
-    float shininess = 32.f;
-    bool use_specular_workflow = false;
+    float opacity;
+    float roughness;
+    float metallic;
+    float emissive_power;
+    float shininess;
+    bool use_specular_workflow;
 
     // Non-camera sensor response parameters. OptiX keeps these in its material
     // record; mirror them here so LiDAR/Radar parity does not depend on OptiX.
     float lidar_intensity = 1.f;
     float radar_backscatter = 1.f;
 
-    float tex_scale_u = 1.f;
-    float tex_scale_v = 1.f;
+    float tex_scale_u;
+    float tex_scale_v;
     std::string diffuse_texture;
     std::string specular_texture;
     std::string emissive_texture;
@@ -89,8 +93,8 @@ struct CH_SENSOR_API ChVulkanRTMaterial {
     std::string opacity_texture;
     std::string weight_texture;
 
-    unsigned short int class_id = 0;
-    unsigned short int instance_id = 0;
+    unsigned short int class_id;
+    unsigned short int instance_id;
 };
 
 struct CH_SENSOR_API ChVulkanRTTriangle {

--- a/src/chrono_sensor/vulkan/shaders/chrono_sensor_vkrt.rgen
+++ b/src/chrono_sensor/vulkan/shaders/chrono_sensor_vkrt.rgen
@@ -23,7 +23,7 @@ struct GpuLight {
     vec4 pos_range;    // pos xyz, range
     vec4 dir_type;     // dir xyz, LightType as float
     vec4 color_atten;  // color rgb, attenuation scale; negative means constant color
-    vec4 params;       // angle, angle falloff start, angle attenuation rate, area/radius
+    vec4 params;       // angle, angle falloff start, angle attenuation rate, spot cos-half-angle or area/radius
 };
 
 struct GpuSceneData {
@@ -102,7 +102,9 @@ layout(push_constant) uniform PushConstants {
     uint height;
     uint pipeline;
     uint flags;
-    uint frame_index;  // VulkanCameraFrameRng
+    uint frame_index;
+    uint rng_seed_lo;
+    uint rng_seed_hi;
 } pc;
 
 const uint PIPE_CAMERA = 0u;
@@ -159,6 +161,12 @@ uint hash_u32(uint x) {
 
 float hash_unit(uint x) {
     return float(hash_u32(x) & 0x00ffffffu) / float(0x01000000u);
+}
+
+uint camera_rng_key() {
+    // Fold both halves of the 64-bit ChSensorManager stream seed into the
+    // shader's 32-bit hash domain. frame_index remains a separate dimension.
+    return hash_u32(pc.rng_seed_lo ^ (pc.rng_seed_hi * 0x9e3779b9u));
 }
 
 float wrap01(float x) {
@@ -243,10 +251,10 @@ vec3 gamma_correct(vec3 c, float gamma) {
 }
 
 float normal_dist_optix(float ndh, float roughness) {
-    float r = max(0.02, roughness);
-    float rough_sqr = r * r;
+    // Keep this algebra identical to OptiX shader_utils.cuh::NormalDist().
+    float rough_sqr = roughness * roughness;
     float den = ndh * ndh * (rough_sqr - 1.0) + 1.0;
-    return rough_sqr / max(1e-5, den * den);
+    return rough_sqr / (den * den);
 }
 
 float hammon_smith_optix(float ndv, float ndl, float roughness) {
@@ -301,7 +309,7 @@ EvalMaterial eval_material(TraceResult hit) {
     out_mat.specular = mat.specular.rgb;
     out_mat.emissive = mat.emissive.rgb;
     out_mat.opacity = saturate(mat.params.x);
-    out_mat.roughness = clamp(mat.params.y, 0.02, 1.0);
+    out_mat.roughness = clamp(mat.params.y, 0.0, 1.0);
     out_mat.metallic = saturate(mat.params.z);
     out_mat.emissive_power = max(0.0, mat.emissive.w);
     out_mat.use_specular_workflow = mat.params.w > 0.5;
@@ -321,7 +329,7 @@ EvalMaterial eval_material(TraceResult hit) {
         if (mat.texture0.z != INVALID_TEXTURE)
             out_mat.emissive = sample_texture(mat.texture0.z, hit.uv, scale).rgb;
         if (mat.texture1.x != INVALID_TEXTURE)
-            out_mat.roughness = clamp(sample_texture(mat.texture1.x, hit.uv, scale).r, 0.02, 1.0);
+            out_mat.roughness = clamp(sample_texture(mat.texture1.x, hit.uv, scale).r, 0.0, 1.0);
         if (mat.texture1.y != INVALID_TEXTURE)
             out_mat.metallic = saturate(sample_texture(mat.texture1.y, hit.uv, scale).r);
         if (mat.texture1.z != INVALID_TEXTURE)
@@ -589,10 +597,15 @@ vec3 shade_direct(TraceResult hit, vec3 origin, vec3 dir, bool include_ambient, 
 
             if (type == LIGHT_SPOT) {
                 vec3 spot_dir = normalize(light.dir_type.xyz);
-                float angle = acos(clamp(dot(spot_dir, -light_dir), -1.0, 1.0));
-                if (2.0 * angle > light.params.x) {
+                float cos_angle = clamp(dot(spot_dir, -light_dir), -1.0, 1.0);
+                // The hard cone is a dot/cosine comparison. Avoid making a boundary
+                // decision from GLSL acos(), whose permitted error differs by vendor.
+                if (cos_angle < light.params.w) {
                     attenuation = 0.0;
                 } else if (light.color_atten.w >= 0.0 && light.params.z >= 0.0) {
+                    // Keep the existing angular soft-falloff formula for OptiX parity.
+                    // The transcendental is therefore paid only when soft falloff is enabled.
+                    float angle = acos(cos_angle);
                     float a = saturate(light.params.z * (light.params.x - 2.0 * angle));
                     attenuation *= a * a;
                 }
@@ -644,7 +657,8 @@ vec4 trace_camera(vec3 origin, vec3 dir, uint camera_sample_index) {
     uint path_seed = (gl_LaunchIDEXT.x + 1u) * 73856093u ^
                      (gl_LaunchIDEXT.y + 1u) * 19349663u ^
                      (camera_sample_index + 1u) * 83492791u ^
-                     (pc.frame_index + 1u) * 2654435761u;
+                     (pc.frame_index + 1u) * 2654435761u ^
+                     camera_rng_key();
     float first_depth = 0.0;
     vec3 throughput = vec3(1.0);
     vec3 ro = origin;
@@ -734,7 +748,8 @@ float camera_sample_jitter(uint x, uint y, uint sample_index, uint axis) {
                      (y + 1u) * 19349663u ^
                      (sample_index + 1u) * 83492791u ^
                      axis * 2654435761u ^
-                     (pc.frame_index + 1u) * 2246822519u);
+                     (pc.frame_index + 1u) * 2246822519u ^
+                     camera_rng_key());
 }
 
 vec3 camera_ray_sample(uint x, uint y, float jitter_x, float jitter_y, bool aux_projection) {

--- a/src/demos/sensor/demo_SEN_vulkan_validation.cpp
+++ b/src/demos/sensor/demo_SEN_vulkan_validation.cpp
@@ -44,15 +44,10 @@
 // light so run 2 has a measurable gradient.
 //
 // NOTE on geometry choice: an explicit mesh keeps this demo self-contained, needing
-// no Chrono data directory on the machine running the comparison, and it sidesteps a
-// separate defect in the OptiX primitive path. ChOptixPipeline::GetBoxMaterial sets
-// num_blended_materials = mat_list.size(), which is 0 for a box carrying no explicit
-// ChVisualMaterial, and every shading loop in the OptiX shaders is
-// "for (b = 0; b < num_blended_materials; b++)", so such a surface accumulates no
-// color and renders pure black. GetSphereMaterial and GetNVDBMaterial set the count
-// the same way; GetCylinderMaterial and GetMeshMaterial hardcode 1 and are immune.
-// Run with --probe-box-material to see it: two identical boxes, one with a material
-// and one without, where OptiX blacks out the second and Vulkan shades it correctly.
+// no Chrono data directory on the machine running the comparison. The
+// --probe-box-material mode separately exercises the implicit-material path with two
+// otherwise identical boxes, one explicit and one material-less; both render backends
+// are expected to resolve the latter through ChVisualMaterial::Default().
 //
 // =============================================================================
 
@@ -312,10 +307,8 @@ int main(int argc, char* argv[]) {
     bool material_sweep = false;
     int material_index = -1;  // >= 0 isolates a single material sample (floor + that cube only)
     // Overrides the isolated sample's roughness. The fixed sample list below bottoms out at 0.1,
-    // which leaves a region of the parameter space unreachable: the Vulkan reference clamps
-    // roughness to [0.02, 1], and ChVisualMaterial's default roughness is 0, so the value a shape
-    // gets when it carries the default material is inside the clamped region and no configuration
-    // of this demo could reach it. Negative means "use the sample's own value".
+    // so this flag also covers the mirror-like region around the canonical default. Negative means
+    // "use the sample's own value".
     float roughness_override = -1.f;
     std::string feature;      // mesh | texture | normalmap | opacity | envmap (Florian steps c-f)
     std::string data_dir;    // optional Chrono data directory override
@@ -328,13 +321,9 @@ int main(int argc, char* argv[]) {
     // numbers: per-stream seeds include the sensor's identity, which is what the environment-map
     // convergence study relies on.
     //
-    // Only the OptiX arm currently responds to this. The Vulkan RT backend derives its per-pixel
-    // sample sequence from the launch index and GetNumLaunches() alone and never reads the manager's
-    // base seed, so its images repeat across invocations either way: measured on the envmap
-    // configuration, the four OptiX images from two pinned and two clock runs are identical in the
-    // pinned pair and all different otherwise, while the four Vulkan images share one hash. So a
-    // --seed clock run here is a one-sided test, and independent Monte Carlo trials on the Vulkan
-    // path would share camera noise. Remove this paragraph once the backend mixes the base seed in.
+    // Both render backends derive their stochastic streams through ChSensorManager. A pinned seed
+    // must reproduce each backend across runs, while --seed clock must change stochastic samples
+    // across invocations. The streams remain intentionally distinct between sensors/usages.
     bool pin_seed = true;
     unsigned int random_seed = 20260802u;
     std::string out_dir = "SENSOR_OUTPUT/vulkan_validation/";
@@ -528,8 +517,8 @@ int main(int argc, char* argv[]) {
         tag += "_probe";  // the probe changes the scene, so it must not overwrite the plain run's images
     if (roughness_override >= 0.f) {
         // Same reason as the probe: an overridden sample is a different material, so it gets its own
-        // filenames. Written in hundredths, so 0.00 and 0.02 (the Vulkan clamp boundary) cannot
-        // collide, and the name stays free of a decimal point.
+        // filenames. Written in hundredths, so nearby low-roughness overrides such as 0.00 and 0.02
+        // cannot collide, and the name stays free of a decimal point.
         std::string hundredths = std::to_string((int)(roughness_override * 100.f + 0.5f));
         hundredths.insert(hundredths.begin(), 3 - hundredths.size(), '0');
         tag += "_rough" + hundredths;

--- a/src/tests/unit_tests/sensor/utest_SEN_rng_streams.cpp
+++ b/src/tests/unit_tests/sensor/utest_SEN_rng_streams.cpp
@@ -137,8 +137,8 @@ struct Scene {
 // -----------------------------------------------------------------------------
 
 // Grok's binding requirement from the design audit, verbatim in intent: distinct ids for the first
-// 10k ordinals crossed with 20 purposes. Note this deliberately uses 20 usage values, more than the
-// 10 constants RngUsage currently defines, so the field keeps room for future stochastic filters.
+// 10k ordinals crossed with 20 purposes. The deliberately larger usage range leaves room for future
+// stochastic filters beyond the currently defined RngUsage values.
 TEST(ChSensorRngStreams, stream_id_injective_over_10k_ordinals_x_20_usages) {
     const unsigned int kOrdinals = 10000;
     const unsigned int kUsages = 20;
@@ -163,7 +163,7 @@ TEST(ChSensorRngStreams, stream_id_injective_across_all_four_fields) {
     for (unsigned int mgr = 0; mgr < 7; ++mgr) {
         for (unsigned int ordinal = 0; ordinal < 13; ++ordinal) {
             for (unsigned int filt = 0; filt < 11; ++filt) {
-                for (unsigned int u = 0; u < 10; ++u) {
+                for (unsigned int u = 0; u < static_cast<unsigned int>(RngUsage::Count); ++u) {
                     unsigned long long id = ChSensorManager::MakeRngStreamId(mgr, ordinal, filt, (RngUsage)u);
                     ASSERT_TRUE(seen.insert(id).second) << "collision at (" << mgr << "," << ordinal << ","
                                                         << filt << "," << u << ")";


### PR DESCRIPTION
## Summary

This follows up on the Vulkan RT validation work and fixes several differences found while comparing the Vulkan and OptiX sensor backends.

The main changes are:

* Match the OptiX behavior for shapes without an explicit ChVisualMaterial by using ChVisualMaterial::Default().
* Remove the Vulkan-specific 0.02 roughness floor and match the OptiX normal-distribution calculation at low roughness.
* Make the spot-light hard cone test use **cosine** comparisons instead of **acos**, avoiding vendor-sensitive behavior at the cone boundary.
* Connect Vulkan camera sampling to the existing ChSensorManager deterministic RNG infrastructure.
* Prefer host-cached Vulkan staging memory for image readback, with a fallback to the required host-visible/coherent flags.
* Extend the RNG stream usages and tests for the Vulkan camera and physical-camera render paths.


## Testing

Built the Vulkan RT validation target and RNG stream unit tests on both NVIDIA and AMD systems.

NVIDIA:

* RTX 5090
* CUDA 13.1
* OptiX + Vulkan RT enabled
* utest_SEN_rng_streams: 22/22 passed

AMD:

* Radeon 8060S
* Vulkan RT enabled, OptiX disabled
* utest_SEN_rng_streams: 22/22 passed

The RNG tests include stream-key injectivity, distinct manager/sensor/filter/usage streams, deterministic base-seed behavior, clock-based variation, invalid usage rejection, topology fuzzing, and 90,000 derived seeds with zero collisions.

The Vulkan validation demo is also intended to exercise the fixes directly with:

* implicit/default material
* spot lighting
* low metallic roughness down to zero
* fixed versus clock-based stochastic sampling
* cross-vendor Vulkan output comparison
