### PR TITLE
Fix the FOV of the OptiX depth, normal and segmentation cameras

### DIFF
--- a/src/chrono_sensor/optix/shaders/depth_cam_raygen.cu
+++ b/src/chrono_sensor/optix/shaders/depth_cam_raygen.cu
@@ -67,7 +67,7 @@ extern "C" __global__ void __raygen__depth_camera() {
     float4 ray_quat = nlerp(raygen->rot0, raygen->rot1, t_frac);
     // float3 ray_origin = raygen->pos0;
     // float4 ray_quat = raygen->rot0;
-    const float h_factor = camera.hFOV / CUDART_PI_F * 2.0;
+    const float h_factor = tanf(camera.hFOV / 2.f);
     float3 forward;
     float3 left;
     float3 up;

--- a/src/chrono_sensor/optix/shaders/normal_cam_raygen.cu
+++ b/src/chrono_sensor/optix/shaders/normal_cam_raygen.cu
@@ -68,7 +68,7 @@ extern "C" __global__ void __raygen__normal_camera() {
     float4 ray_quat = nlerp(raygen->rot0, raygen->rot1, t_frac);
     // float3 ray_origin = raygen->pos0;
     // float4 ray_quat = raygen->rot0;
-    const float h_factor = camera.hFOV / CUDART_PI_F * 2.0;
+    const float h_factor = tanf(camera.hFOV / 2.f);
     float3 forward;
     float3 left;
     float3 up;

--- a/src/chrono_sensor/optix/shaders/segment_cam_raygen.cu
+++ b/src/chrono_sensor/optix/shaders/segment_cam_raygen.cu
@@ -64,7 +64,7 @@ extern "C" __global__ void __raygen__segment_camera() {
     const float t_traverse = raygen->t0 + t_frac * (raygen->t1 - raygen->t0);  // simulation time when ray is sent
     float3 ray_origin = lerp(raygen->pos0, raygen->pos1, t_frac);
     float4 ray_quat = nlerp(raygen->rot0, raygen->rot1, t_frac);
-    const float h_factor = camera.hFOV / CUDART_PI_F * 2.0;
+    const float h_factor = tanf(camera.hFOV / 2.f);
     float3 forward;
     float3 left;
     float3 up;


### PR DESCRIPTION
**Summary**

The OptiX depth, normal and segmentation cameras do not render at the horizontal FOV they are asked
for. All three raygen programs compute the pinhole scale factor as a linear function of the angle
instead of its tangent:

```c
const float h_factor = camera.hFOV / CUDART_PI_F * 2.0;   // depth_cam_raygen.cu:70
                                                          // normal_cam_raygen.cu:71
                                                          // segment_cam_raygen.cu:67
```

where the pinhole model calls for `tanf(hFOV / 2)`. Three lines, one per file.

**Related Issue(s)**

None. Found while validating a new backend against analytic ground truth.

Companion PR: #818 adds a Metal ray-tracing backend and the test that found this. That PR does not
include this fix, because this one changes rendered output for existing OptiX users and deserves its
own review. #818 currently reports one expected failure on OptiX until this lands.

**Author(s)**

Kyle Sha — kylesha585@gmail.com (corresponding author, long-lived address).

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and
redistributed under the BSD-3-Clause License.

**Backward Compatibility**

**This changes rendered output** for any `ChDepthCamera`, `ChNormalCamera` or `ChSegmentationCamera`
at an FOV other than 90 degrees. The new output is what the requested FOV asks for, and matches what
`ChCameraSensor` has produced since its own fix, so the camera types now agree with each other.
Anyone who calibrated against the old behaviour will need to recheck.

**Detailed Description**

The expression is exact at `hFOV = 90 deg`, where both forms equal 1, and wrong everywhere else, by
more the further from 90. Measured on an RTX 5070 Ti by rendering a flat wall at a known distance
with a `ChDepthCamera` and inverting the depth buffer:

| requested | before | after fix |
|---|---|---|
| 20 deg | 25.06 | 20.00 |
| 40 deg | 47.93 | 40.00 |
| 60 deg | 67.38 | 60.00 |
| 80 deg | 83.27 | 80.00 |
| 90 deg | 90.00 | 90.00 |
| 100 deg | 96.03 | (see note) |

Every "before" measurement matches `2*atan(hFOV_deg / 90)`, which is what the buggy expression
reduces to. Note on 100 deg: the measurement probes two pixels at `W/2 +- W/8` and inverts assuming
they land on the flat wall; at a genuinely 100 deg FOV those rays miss it. The unfixed build stayed
on the wall only because it rendered 96 deg. This is a limit of the probe, not of the fix.

Five independent lines of evidence that this is a defect rather than a different intended
convention:

1. `camera_raygen.cu:95` and `phys_cam_raygen.cu:109` contain **the identical line, commented out and
   annotated `// bug here`**, with `tanf(camera.hFOV / 2.f)` in its place. This was found and fixed
   for the RGB and physical cameras and left in the other three.
2. Within `depth_cam_raygen.cu` itself, the `FOV_LENS` and `RADIAL` branches compute their focal
   quantity as `tanf(camera.hFOV / 2.0)`. Only the pinhole path uses the linear form, so the file
   contradicts itself.
3. The screen coordinate `d` is built exactly as the RGB camera builds `uv`: `((idx + 0.5) / screen)
   * 2 - 1` with the same aspect correction. The two are directly comparable.
4. `hFOV` reaches all five raygen programs untransformed (`ChFilterOptixRender.cpp`, `= GetHFOV()`),
   and `ChDepthCamera::GetHFOV` is identical in implementation and documentation to
   `ChCameraSensor::GetHFOV`. Nothing compensates downstream.
5. Applying the fix makes measured FOV equal requested FOV at every angle tested.

The RGB camera path is untouched by this change.

**Post Submission Checklist**

- [x] The pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.

On the last item: the test that found this is `utest_SEN_analytic_render`, which arrives with #818. It
renders scenes whose correct pixel values are computable in closed form and checks against them with
an independent double-precision intersector, rather than diffing against a reference image — which
is why a long-standing FOV error was visible at all. Happy to split that test out into this PR
instead if you would rather have the fix and its test land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


