### PR TITLE
Fix macOS window sizing, keyboard focus and process working directory in Chrono::Irrlicht

### DIFF
--- a/src/chrono_irrlicht/CMakeLists.txt
+++ b/src/chrono_irrlicht/CMakeLists.txt
@@ -40,6 +40,13 @@ set(IRR_HEADER_FILES
   ChIrrNodeShape.h
 )
 
+# Objective-C++ helper needed to reach Irrlicht's Cocoa view (see ChIrrMacOS.h).
+if(APPLE)
+  list(APPEND IRR_SOURCE_FILES ChIrrMacOS.mm)
+  list(APPEND IRR_HEADER_FILES ChIrrMacOS.h)
+  set_source_files_properties(ChIrrMacOS.mm PROPERTIES LANGUAGE CXX COMPILE_FLAGS "-x objective-c++ -fobjc-arc")
+endif()
+
 source_group("" FILES ${IRR_SOURCE_FILES} ${IRR_HEADER_FILES})
 
 #-------------------------------------------------------------------------------
@@ -88,7 +95,10 @@ target_link_libraries(Chrono_irrlicht PRIVATE Chrono_core)
 target_link_libraries(Chrono_irrlicht PUBLIC Irrlicht::Irrlicht)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  target_link_libraries(Chrono_irrlicht PRIVATE ${MAC_LIBS})
+  # Cocoa and OpenGL are needed by ChIrrMacOS.mm.
+  find_library(COCOA_LIBRARY Cocoa REQUIRED)
+  find_library(OPENGL_FRAMEWORK OpenGL REQUIRED)
+  target_link_libraries(Chrono_irrlicht PRIVATE ${MAC_LIBS} ${COCOA_LIBRARY} ${OPENGL_FRAMEWORK})
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/src/chrono_irrlicht/ChIrrMacOS.h
+++ b/src/chrono_irrlicht/ChIrrMacOS.h
@@ -1,0 +1,40 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// macOS-specific helper for the Chrono Irrlicht module.
+//
+// Irrlicht is consumed as a prebuilt library, so its Cocoa device cannot be patched from Chrono. This helper reaches
+// the NSView that Irrlicht renders into and adjusts it from the outside. It is implemented in Objective-C++
+// (ChIrrMacOS.mm) and exposed here with a plain C++ interface, so that the rest of the module can remain plain C++.
+//
+// Only compiled and called on Apple platforms.
+// =============================================================================
+
+#ifndef CH_IRR_MACOS_H
+#define CH_IRR_MACOS_H
+
+namespace chrono {
+namespace irrlicht {
+
+/// Make the OpenGL surface Irrlicht renders into match the logical (point) size of its window, which on a Retina
+/// display it otherwise exceeds by backingScaleFactor. Call once the device exists, with its GL context current.
+/// Returns the backing scale factor, or 0 if the view could not be located and nothing was changed.
+double ChIrrMacOSMatchGLSurfaceToWindowSize();
+
+/// Promote this process to a regular foreground application and give Irrlicht's window keyboard focus; an unbundled
+/// executable is otherwise background-only and its window, never being key, receives no key events. Call once the
+/// device exists. Returns true if the process is a regular foreground application on return.
+bool ChIrrMacOSActivateApplication();
+
+}  // namespace irrlicht
+}  // namespace chrono
+
+#endif

--- a/src/chrono_irrlicht/ChIrrMacOS.mm
+++ b/src/chrono_irrlicht/ChIrrMacOS.mm
@@ -1,0 +1,96 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+// macOS-specific helper for the Chrono Irrlicht module. See ChIrrMacOS.h.
+// =============================================================================
+
+#include "chrono_irrlicht/ChIrrMacOS.h"
+
+#import <Cocoa/Cocoa.h>
+
+namespace chrono {
+namespace irrlicht {
+
+// Locate the NSView that Irrlicht's OpenGL driver draws into.
+//
+// Irrlicht 1.8's SExposedVideoData has no macOS member (only Win32 and X11), so the view cannot be obtained from
+// IVideoDriver::getExposedVideoData(). Cocoa can supply it instead: CIrrDeviceMacOSX creates an NSOpenGLContext,
+// attaches it to its window's content view and makes it current, and leaves it current. The current context's view is
+// therefore exactly Irrlicht's render target.
+static NSView* FindIrrlichtGLView() {
+    NSOpenGLContext* context = [NSOpenGLContext currentContext];
+    if (context) {
+        NSView* view = [context view];
+        if (view)
+            return view;
+    }
+
+    // Fallback, in case a future Irrlicht leaves a different context current: Irrlicht's is the only window this
+    // process owns when the device is created.
+    for (NSWindow* window in [NSApp windows]) {
+        if ([window isVisible] && [window contentView])
+            return [window contentView];
+    }
+
+    return nil;
+}
+
+double ChIrrMacOSMatchGLSurfaceToWindowSize() {
+    double scale = 0.0;
+
+    @autoreleasepool {
+        NSView* view = FindIrrlichtGLView();
+        if (!view)
+            return 0.0;
+
+        NSWindow* window = [view window];
+        scale = window ? (double)[window backingScaleFactor] : 1.0;
+
+        // Drop the high-resolution backing store: this shrinks the surface back to the window's point size, so
+        // Irrlicht's viewport covers all of it and macOS scales the result up to fill the window. A no-op on a
+        // non-Retina display, where the surface already matches the window's point size.
+        [view setWantsBestResolutionOpenGLSurface:NO];
+
+        // Force the context to reallocate its drawable at the new size.
+        NSOpenGLContext* context = [NSOpenGLContext currentContext];
+        if (context)
+            [context update];
+    }
+
+    return scale;
+}
+
+bool ChIrrMacOSActivateApplication() {
+    @autoreleasepool {
+        // Irrlicht has already created the shared application; this just retrieves it.
+        NSApplication* app = [NSApplication sharedApplication];
+
+        // NSApplicationActivationPolicyRegular is what makes this a normal GUI application, after which its window
+        // can take focus like any other. LaunchServices registers a bundle-less executable as background-only
+        // ("type=BackgroundOnly" in lsappinfo), and such a process can never become active.
+        if ([app activationPolicy] != NSApplicationActivationPolicyRegular)
+            [app setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+        [app activateIgnoringOtherApps:YES];
+
+        // Being the active application is not enough on its own: the window has to be the key window before AppKit
+        // will route key events to it.
+        NSView* view = FindIrrlichtGLView();
+        NSWindow* window = view ? [view window] : nil;
+        if (window)
+            [window makeKeyAndOrderFront:nil];
+
+        return [app activationPolicy] == NSApplicationActivationPolicyRegular;
+    }
+}
+
+}  // namespace irrlicht
+}  // namespace chrono

--- a/src/chrono_irrlicht/ChVisualSystemIrrlicht.cpp
+++ b/src/chrono_irrlicht/ChVisualSystemIrrlicht.cpp
@@ -16,7 +16,9 @@
 //// Allow attaching more than one ChSystem to the same Irrlicht visualization
 
 #include <codecvt>
+#include <filesystem>
 #include <locale>
+#include <system_error>
 
 #include "chrono/utils/ChProfiler.h"
 #include "chrono/utils/ChUtils.h"
@@ -25,6 +27,10 @@
 #include "chrono_irrlicht/ChIrrTools.h"
 #include "chrono_irrlicht/ChIrrMeshTools.h"
 #include "chrono_irrlicht/ChIrrSkyBoxSceneNode.h"
+
+#ifdef __APPLE__
+    #include "chrono_irrlicht/ChIrrMacOS.h"
+#endif
 
 namespace chrono {
 namespace irrlicht {
@@ -48,7 +54,13 @@ ChVisualSystemIrrlicht::ChVisualSystemIrrlicht()
     m_device_params.AntiAlias = true;
     m_device_params.Bits = 32;
     m_device_params.Fullscreen = false;
+    // Direct3D9 exists only on Windows; requesting it elsewhere always fails and falls back, and on
+    // macOS that failed attempt builds and tears down a whole CIrrDeviceMacOSX first.
+#ifdef _WIN32
     m_device_params.DriverType = video::EDT_DIRECT3D9;
+#else
+    m_device_params.DriverType = video::EDT_OPENGL;
+#endif
     m_device_params.WindowSize = core::dimension2d<irr::u32>(640, 480);
     m_device_params.Stencilbuffer = false;
     m_device_params.LoggingLevel = irr::ELL_INFORMATION;
@@ -185,17 +197,51 @@ void ChVisualSystemIrrlicht::Initialize() {
     if (!m_verbose)
         m_device_params.LoggingLevel = irr::ELL_NONE;
 
+    // CIrrDeviceMacOSX chdir()s the process to the parent of the main bundle path on creation. For an
+    // unbundled executable that is one directory above where it was launched, so every relative path
+    // used afterwards resolves wrongly. Save the working directory and put it back.
+    std::error_code cwd_ec;
+    auto saved_cwd = std::filesystem::current_path(cwd_ec);
+    bool restore_cwd = !cwd_ec;
+
     // Create Irrlicht device using current parameter values
     m_device = irr::createDeviceEx(m_device_params);
+#ifdef _WIN32
+    // Only Windows asked for something other than OpenGL, so only Windows has anything to fall back
+    // from; elsewhere this would repeat the call that just failed.
     if (!m_device) {
         std::cerr << "Cannot use default video driver - fall back to OpenGL" << std::endl;
         m_device_params.DriverType = video::EDT_OPENGL;
         m_device = irr::createDeviceEx(m_device_params);
-        if (!m_device) {
-            std::cerr << "Failed to create the video driver - giving up" << std::endl;
-            return;
+    }
+#endif
+    if (!m_device) {
+        if (restore_cwd)
+            std::filesystem::current_path(saved_cwd, cwd_ec);
+        std::cerr << "Failed to create the video driver - giving up" << std::endl;
+        return;
+    }
+
+    // A failed restore is deliberately ignored; the only plausible cause is the directory having been
+    // removed underneath the process.
+    if (restore_cwd)
+        std::filesystem::current_path(saved_cwd, cwd_ec);
+
+#ifdef __APPLE__
+    // AppKit gives the view a backing store backingScaleFactor times the window's point size, while
+    // Irrlicht keeps its viewport and GUI layout in points, so it draws into one corner and leaves the
+    // rest black. See ChIrrMacOS.h.
+    {
+        double backing_scale = ChIrrMacOSMatchGLSurfaceToWindowSize();
+        if (m_verbose && backing_scale > 1.0) {
+            std::cout << "Matched the Irrlicht OpenGL surface to the window size (backing scale " << backing_scale << ")" << std::endl;
         }
     }
+
+    // An unbundled executable is registered as background-only, so its window never becomes key and
+    // receives no keyboard events at all. See ChIrrMacOS.h.
+    ChIrrMacOSActivateApplication();
+#endif
 
     // m_device->grab();
 


### PR DESCRIPTION
**Summary**

Three macOS defects in Chrono::Irrlicht, all present on `main` and all affecting any macOS user of the
module today.

| defect | effect |
|---|---|
| `CIrrDeviceMacOSX` `chdir`s the whole process on construction | every relative path afterwards resolves one directory too high — the data path, demo output directories |
| the OpenGL surface is sized in pixels, the viewport in points | on a Retina display the scene fills the bottom-left quarter and the rest is black |
| `EDT_DIRECT3D9` is requested on every platform | a whole `CIrrDeviceMacOSX` is built and torn down before falling back to OpenGL |

A bundle-less executable is also registered by LaunchServices as background-only, so its window never
becomes key and receives no keyboard events at all, silently disabling every Chrono key binding. The
activation policy is switched at run time instead.

Irrlicht is consumed as a prebuilt library, so its Cocoa device cannot be patched from Chrono. The
AppKit adjustments are made from outside through `ChIrrMacOS.mm`, Objective-C++ behind a plain C++
interface so the rest of the module stays plain C++.

**Related Issue(s)**

Independent — four files under `src/chrono_irrlicht` and nothing else. It should merge **before** #818,
which adds a macOS sensor backend: a demo opening an Irrlicht window alongside a sensor window
segfaults unless both this PR's fixes and its own are present, and neither fixes it alone.

**Author(s)**

Kyle Sha — kylesha585@gmail.com (corresponding author, long-lived address).

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and
redistributed under the BSD-3-Clause License.

**Backward Compatibility**

No breaking changes. Two things reach non-Apple platforms; everything else is inside `#ifdef __APPLE__`.

- `EDT_DIRECT3D9` is now requested only under `_WIN32`, and the OpenGL retry after a failed
  `createDeviceEx` is guarded the same way — only Windows asks for another driver, so only Windows has
  anything to fall back from. Elsewhere the retry repeated the call that had just failed.
- The working directory is saved before `createDeviceEx` and restored after, on every platform. It is
  not compiled out elsewhere: `current_path(saved_cwd, cwd_ec)` is a real `chdir` restoring the
  directory to the value it just read, so it is a no-op in effect rather than in execution. Both calls
  use the `error_code` overloads, so neither throws.

**Verification**

*macOS 15 / arm64.* All three defects fixed: relative paths resolve against the launch directory, the
render fills the window, and keyboard bindings work.

*Linux, Ubuntu 22.04 / RTX 5060 Ti / X11.* `demo_IRR_assets`, built twice into separate trees from
upstream `main` and from this branch, whose merge-base is exactly the `main` commit tested.

| check | main | this branch |
|---|---|---|
| `Cannot use default video driver - fall back to OpenGL` | 1 | **0** |
| `Failed to create the video driver - giving up` | 0 | 0 |
| working directory, 120 samples of `/proc/<pid>/cwd` at 50 ms across device creation | 1 distinct value | **1 distinct value** |
| window geometry | 800x600 | 800x600 |
| quadrant mean brightness | 220.25 / 215.69 / 239.21 / 150.98 | 220.24 / 215.72 / 239.22 / 150.98 |

The branch console output is `main`'s minus the fallback line. Sampling the working directory rather
than inferring it is what makes the no-op claim evidence rather than absence of evidence.

The scene is animated, so the same binary was also captured twice four seconds apart to establish a
within-arm noise floor: main against itself differs by 3241 pixels of 480000, branch against itself by
3474, and main against branch by **3409** — bracketed by the two. So the cross-arm difference does not
exceed what one unchanged binary produces against itself. Pixel-exact equality is **not** claimed; the
residual is the still-moving particles.

*Not covered.* Chrono::VSG was not exercised, so the claim that this cannot affect anything outside
`chrono_irrlicht` rests on the file list rather than on a render. One demo, not a sweep. Windows is
untested and its `_WIN32` branch is unchanged from `main`.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.

On the last item: these are window-server and process-state behaviours that a headless unit test
cannot observe. The Linux comparison above is a controlled A/B on real demos instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7fm8gN6N265v7Mfws76tS
