### PR TITLE
Sensor: size the GLFW debug window viewport by framebuffer, not window points

### DIFF
--- a/src/chrono_sensor/filters/ChFilterRadarVisualizeCluster.cpp
+++ b/src/chrono_sensor/filters/ChFilterRadarVisualizeCluster.cpp
@@ -73,7 +73,7 @@ CH_SENSOR_API void ChFilterRadarVisualizeCluster::Apply() {
         glfwMakeContextCurrent(m_window.get());
 
         int window_w, window_h;
-        glfwGetWindowSize(m_window.get(), &window_w, &window_h);
+        glfwGetFramebufferSize(m_window.get(), &window_w, &window_h);
         //
 
         // Set Viewport to window dimensions

--- a/src/chrono_sensor/filters/ChFilterRadarXYZVisualize.cpp
+++ b/src/chrono_sensor/filters/ChFilterRadarXYZVisualize.cpp
@@ -82,7 +82,7 @@ CH_SENSOR_API void ChFilterRadarXYZVisualize::Apply() {
         glfwMakeContextCurrent(m_window.get());
 
         int window_w, window_h;
-        glfwGetWindowSize(m_window.get(), &window_w, &window_h);
+        glfwGetFramebufferSize(m_window.get(), &window_w, &window_h);
         //
 
         // Set Viewport to window dimensions

--- a/src/chrono_sensor/filters/ChFilterVisualize.cpp
+++ b/src/chrono_sensor/filters/ChFilterVisualize.cpp
@@ -117,7 +117,12 @@ void ChFilterVisualize::CreateGlfwWindow(std::string window_name) {
     glOrtho(0, 1, 0, 1, -1, 1);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
-    glViewport(0, 0, m_w, m_h);
+    // Framebuffer size, not the requested window size: on a high-DPI display the framebuffer is
+    // larger than the window in each axis, and a viewport sized in window points covers only part
+    // of it. The two are equal everywhere else.
+    int fb_w, fb_h;
+    glfwGetFramebufferSize(m_window.get(), &fb_w, &fb_h);
+    glViewport(0, 0, fb_w, fb_h);
 
     if (!m_gl_tex_id)
         glGenTextures(1, &m_gl_tex_id);
@@ -171,9 +176,9 @@ CH_SENSOR_API void ChFilterVisualize::Apply() {
 
     glfwMakeContextCurrent(m_window.get());
 
-    int window_w, window_h;
-    glfwGetWindowSize(m_window.get(), &window_w, &window_h);
-    glViewport(0, 0, window_w, window_h);
+    int fb_w, fb_h;
+    glfwGetFramebufferSize(m_window.get(), &fb_w, &fb_h);
+    glViewport(0, 0, fb_w, fb_h);
 
     glBindTexture(GL_TEXTURE_2D, m_gl_tex_id);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -419,10 +424,10 @@ CH_SENSOR_API void ChFilterVisualize::Apply() {
         }
         glBindTexture(GL_TEXTURE_2D, m_gl_tex_id);
 
-        // Set Viewport to window dimensions
-        int window_w, window_h;
-        glfwGetWindowSize(m_window.get(), &window_w, &window_h);
-        glViewport(0, 0, window_w, window_h);
+        // Set viewport to the framebuffer size, which is the window size except on a high-DPI display
+        int fb_w, fb_h;
+        glfwGetFramebufferSize(m_window.get(), &fb_w, &fb_h);
+        glViewport(0, 0, fb_w, fb_h);
 
         // update the textures, making sure data has finished memcpy first
         cudaStreamSynchronize(m_cuda_stream);
@@ -617,7 +622,9 @@ CH_SENSOR_API void ChFilterVisualize::CreateGlfwWindow(std::string window_name) 
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
 
-        glViewport(0, 0, m_w, m_h);
+        int fb_w, fb_h;
+        glfwGetFramebufferSize(m_window.get(), &fb_w, &fb_h);
+        glViewport(0, 0, fb_w, fb_h);
     } else {
         std::cerr << "WARNING: requested window could not be created by GLFW. Will proceed with no window.\n";
         m_window_disabled = true;

--- a/src/chrono_sensor/filters/ChFilterVisualizePointCloud.cpp
+++ b/src/chrono_sensor/filters/ChFilterVisualizePointCloud.cpp
@@ -87,7 +87,7 @@ CH_SENSOR_API void ChFilterVisualizePointCloud::Apply() {
         glfwMakeContextCurrent(m_window.get());
 
         int window_w, window_h;
-        glfwGetWindowSize(m_window.get(), &window_w, &window_h);
+        glfwGetFramebufferSize(m_window.get(), &window_w, &window_h);
         //
 
         // Set Viewport to window dimensions


### PR DESCRIPTION
**Summary**

The sensor visualization filters size the GL viewport with `glfwGetWindowSize`, which reports window
points. On a high-DPI display the framebuffer is larger than the window in each axis, so the rendered
image covers only part of the window, anchored at the lower left because that is the GL origin. This
replaces it with `glfwGetFramebufferSize`, which reports pixels and is what `glViewport` needs.

**Related Issue(s)**

Reported by a reviewer building #818 on macOS: "most of the `demo_SEN_*` demos only use the lower left
quarter of the output window". The defect is on `main` and is not specific to any backend, so it is
here rather than in that PR. The two are independent and merge cleanly in either order.

**Author(s)**

Kyle Sha — kylesha585@gmail.com (corresponding author, long-lived address).

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and
redistributed under the BSD-3-Clause License.

**Backward Compatibility**

No API change. The two sizes are equal wherever there is no display scaling, so this is a no-op on a
conventional display and alters rendering only where the window was already being drawn wrong.

**Detailed Description**

Measured on an M4 Pro (Retina): a 1280x720 window has a 2560x1440 framebuffer, so a viewport sized in
points covers a quarter of it. Instrumenting the running demo to read back `GL_VIEWPORT`:

| | `glViewport` | coverage |
|---|---|---|
| before | `0, 0, 1280, 720` | 25%, lower left |
| after | `0, 0, 2560, 1440` | full window |

Four filters open a debug window. `ChFilterVisualize` had four viewport sites: the per-frame `Apply()`
and the `CreateGlfwWindow` setup, in each of its two backend arms. `Apply()` is the one that mattered,
because it re-set the viewport every frame and so overrode whatever was chosen at window creation.
`ChFilterVisualizePointCloud`, `ChFilterRadarVisualizeCluster` and `ChFilterRadarXYZVisualize` had one
site each.

**Verification**

| configuration | result |
|---|---|
| macOS 15 / arm64, Retina, Metal RT | viewport as in the table above; image fills the window |
| Linux / RTX 5070 Ti / CUDA 13.0.88 / OptiX 9.0.0, no display scaling | strict no-op, as expected |

The Linux run is the one that matters for existing users, and it was run as a regression check rather
than a fix check: that display reports `WindowSize == FramebufferSize` and `ContentScale 1.0`, so the
two code paths are provably equivalent there. `demo_SEN_camera` and `demo_SEN_lidar` open nine windows
between them; across `main` and this branch the window set, sizes and absolute positions are identical,
every window's content bounding box spans the full width and reaches the bottom edge in both arms, and
per-window pixel differences all fall inside the within-arm baseline range measured from repeated runs
of the same binary, with one window pixel-identical.

One unrelated observation from that run, recorded so it is not mistaken for this defect: the
`Raw Lidar Depth Data` window is 2250x160 but its content occupies only the left 1280 pixels. That is
present on `main`, unchanged by this branch, and is a separate question.

**Post Submission Checklist**

- [x] The pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.

On the last item: the failure is in what a GL window displays, which the unit test tree has no way to
observe. It was measured by reading back `GL_VIEWPORT` from the running demo and by comparing captured
window images across the two branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7fm8gN6N265v7Mfws76tS
