### PR TITLE
FSI: refuse to step a fluid system that was never initialized

### DIFF
--- a/src/chrono_fsi/ChFsiFluidSystem.cpp
+++ b/src/chrono_fsi/ChFsiFluidSystem.cpp
@@ -17,6 +17,7 @@
 // =============================================================================
 
 #include <cmath>
+#include <stdexcept>
 #include <filesystem>
 
 #include "chrono/core/ChTypes.h"
@@ -53,9 +54,24 @@ void ChFsiFluidSystem::Initialize() {
 #else
     Initialize(std::vector<FsiBodyState>());
 #endif
+    // A standalone fluid system (no ChFsiSystem wrapper) is initialized through this call. Mark it
+    // here, after the derived Initialize returned without throwing, so that every derived class gets
+    // the flag on this path whether or not its own Initialize sets it (ChFsiSystem sets it on the
+    // wrapper path). A derived Initialize that throws leaves the flag false and DoStepDynamics refuses.
+    m_is_initialized = true;
 }
 
 void ChFsiFluidSystem::DoStepDynamics(double step) {
+    // Refuse to step an uninitialized system. The wrapper ChFsiSystem::DoStepDynamics already
+    // does this; without the same guard here, a standalone fluid system can be stepped before
+    // Initialize(), which bypasses CheckSPHParameters() and then dereferences the null
+    // m_fluid_dynamics that Initialize() would have constructed. Same message and exception as
+    // the wrapper, so a caller handles both identically.
+    if (!m_is_initialized) {
+        cout << "ERROR: FSI system not initialized!\n" << endl;
+        throw std::runtime_error("FSI system not initialized!\n");
+    }
+
     m_timer_step.reset();
     m_timer_step.start();
 

--- a/src/tests/unit_tests/fsi/sph/CMakeLists.txt
+++ b/src/tests/unit_tests/fsi/sph/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TESTS
     utest_FSI-SPH_setter_guard
     utest_FSI-SPH_rheology_error_flag
     utest_FSI-SPH_mcc_parameters
+    utest_FSI-SPH_init_guard
 )
 
 list(APPEND LIBS Chrono_core)

--- a/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_init_guard.cpp
+++ b/src/tests/unit_tests/fsi/sph/utest_FSI-SPH_init_guard.cpp
@@ -1,0 +1,182 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2026 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+// =============================================================================
+//
+// Unit test for the initialization guard on ChFsiFluidSystem::DoStepDynamics.
+//
+// A standalone fluid system (one used without the ChFsiSystem wrapper) could be
+// stepped before Initialize() was called. That bypasses CheckSPHParameters(),
+// so every configuration check is skipped, and then dereferences the null
+// m_fluid_dynamics that Initialize() would have constructed. The wrapper
+// ChFsiSystem::DoStepDynamics has always guarded against this; the base class
+// did not, so the two paths disagreed about the same mistake.
+//
+// Checks:
+// 1. Stepping before Initialize() throws std::runtime_error rather than
+//    crashing or silently proceeding.
+// 2. The documented pattern (configure, Initialize, then step) still works.
+// 3. The system is usable after the rejected call, i.e. the failed attempt
+//    left no partial state behind.
+//
+// =============================================================================
+
+#include <iostream>
+#include <stdexcept>
+
+#include "chrono/physics/ChSystemSMC.h"
+#include "chrono_fsi/sph/ChFsiFluidSystemSPH.h"
+
+using namespace chrono;
+using namespace chrono::fsi;
+using namespace chrono::fsi::sph;
+
+using std::cout;
+using std::endl;
+
+double initial_spacing = 0.01;
+double dt = 2e-4;
+
+int num_failures = 0;
+
+void check(bool condition, const std::string& what) {
+    if (condition) {
+        cout << "  PASS  " << what << endl;
+    } else {
+        cout << "  FAIL  " << what << endl;
+        num_failures++;
+    }
+}
+
+int main(int argc, char* argv[]) {
+    cout << "Initialization guard on ChFsiFluidSystem::DoStepDynamics" << endl;
+
+    // ------------------------------------------------------------------
+    // 1. Stepping before Initialize() must throw, not crash.
+    // ------------------------------------------------------------------
+    {
+        ChFsiFluidSystemSPH sysSPH;
+        sysSPH.SetVerbose(false);
+        sysSPH.SetInitialSpacing(initial_spacing);
+        sysSPH.SetStepSize(dt);
+
+        bool threw = false;
+        std::string what;
+        try {
+            sysSPH.DoStepDynamics(dt);
+        } catch (const std::runtime_error& e) {
+            threw = true;
+            what = e.what();
+        } catch (...) {
+            // Any other exception type still beats a segmentation fault, but the
+            // guard is specified to raise std::runtime_error like its wrapper.
+        }
+        check(threw, "DoStepDynamics before Initialize() throws std::runtime_error");
+        check(what.find("not initialized") != std::string::npos, "the exception names the problem: " + what);
+        // The rejected call must leave the object untouched: the guard runs before the timer,
+        // frame and time counters are touched, so all three still read their constructor values.
+        check(sysSPH.GetSimTime() == 0.0, "simulation time is still 0 after the rejected call");
+        check(sysSPH.GetRtf() == 0.0, "real-time factor is still 0 after the rejected call");
+    }
+
+    // ------------------------------------------------------------------
+    // 2. The documented order still works, and 3. the system survives a
+    //    rejected call. Both are checked on one system so that the second
+    //    genuinely tests recovery rather than a fresh object.
+    // ------------------------------------------------------------------
+    {
+        ChSystemSMC sysMBS;
+        ChFsiFluidSystemSPH sysSPH;
+        sysSPH.SetVerbose(false);
+        sysSPH.SetInitialSpacing(initial_spacing);
+        sysSPH.SetStepSize(dt);
+
+        // A rejected call first, so any partial state mutation would show up below.
+        bool threw = false;
+        try {
+            sysSPH.DoStepDynamics(dt);
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        check(threw, "the rejected call throws as expected");
+
+        // A minimal box of fluid, enough that Initialize() has something to do.
+        ChFsiFluidSystemSPH::SoilProperties mat_props;
+        mat_props.density = 1700;
+        mat_props.Young_modulus = 1e6;
+        mat_props.Poisson_ratio = 0.3;
+        mat_props.mu_fric_s = 0.7;
+        mat_props.mu_fric_2 = 0.7;
+        mat_props.average_diam = 0.005;
+        sysSPH.SetCrmSPH(mat_props);
+
+        sysSPH.AddBoxSPH(ChVector3d(0, 0, 0), ChVector3d(0.05, 0.05, 0.05));
+        sysSPH.SetComputationalDomain(ChAABB(ChVector3d(-0.2, -0.2, -0.2), ChVector3d(0.2, 0.2, 0.2)));
+
+        bool initialized = true;
+        try {
+            // Qualified deliberately. ChFsiFluidSystemSPH's Initialize overloads HIDE the
+            // base no-arg Initialize(), so an unqualified call does not compile for a
+            // standalone user. That is a separate defect this audit tracks; writing this
+            // test reproduced it independently, which is why the qualification is here and
+            // is commented rather than silently applied.
+            sysSPH.ChFsiFluidSystem::Initialize();
+        } catch (const std::exception& e) {
+            initialized = false;
+            cout << "  (Initialize failed: " << e.what() << ")" << endl;
+        }
+        check(initialized, "Initialize() succeeds after a rejected step");
+
+        if (initialized) {
+            bool stepped = true;
+            try {
+                sysSPH.DoStepDynamics(dt);
+            } catch (const std::exception& e) {
+                stepped = false;
+                cout << "  (step failed: " << e.what() << ")" << endl;
+            }
+            check(stepped, "DoStepDynamics succeeds after Initialize()");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 4. A fresh object that is configured and initialized in the documented
+    //    order, with no rejected call first, steps without throwing.
+    // ------------------------------------------------------------------
+    {
+        ChFsiFluidSystemSPH sysSPH;
+        sysSPH.SetVerbose(false);
+        sysSPH.SetInitialSpacing(initial_spacing);
+        sysSPH.SetStepSize(dt);
+        ChFsiFluidSystemSPH::SoilProperties mat_props;
+        mat_props.density = 1700;
+        mat_props.Young_modulus = 1e6;
+        mat_props.Poisson_ratio = 0.3;
+        mat_props.mu_fric_s = 0.7;
+        mat_props.mu_fric_2 = 0.7;
+        mat_props.average_diam = 0.005;
+        sysSPH.SetCrmSPH(mat_props);
+        sysSPH.AddBoxSPH(ChVector3d(0, 0, 0), ChVector3d(0.05, 0.05, 0.05));
+        sysSPH.SetComputationalDomain(ChAABB(ChVector3d(-0.2, -0.2, -0.2), ChVector3d(0.2, 0.2, 0.2)));
+        bool ok = true;
+        try {
+            sysSPH.ChFsiFluidSystem::Initialize();
+            sysSPH.DoStepDynamics(dt);
+        } catch (const std::exception& e) {
+            ok = false;
+            cout << "  (fresh object failed: " << e.what() << ")" << endl;
+        }
+        check(ok, "a fresh, properly initialized system steps without throwing");
+        check(sysSPH.GetSimTime() > 0.0, "and its simulation time advanced");
+    }
+
+    cout << (num_failures == 0 ? "Test succeeded" : "Test FAILED") << endl;
+    return num_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
`ChFsiSystem::DoStepDynamics` already throws if `Initialize()` was never called;
`ChFsiFluidSystem::DoStepDynamics` does not. A standalone fluid system stepped before
`Initialize()` skips `CheckSPHParameters()` and dereferences the null `m_fluid_dynamics`. This adds
the same guard to the fluid system (same message and exception type as the wrapper), marks the
system initialized in the standalone `ChFsiFluidSystem::Initialize()` after the derived call
returns (the wrapper path already did this in `ChFsiSystem::Initialize`), and adds a unit test,
`utest_FSI-SPH_init_guard`, that checks the throw, that the rejected call changes no state, that a
system which threw can still be initialized and stepped, and that a fresh system steps.

No API change. Built alone on top of `main` and tested on CUDA (DGX Spark, CUDA 13) and HIP
(MI350X, ROCm 7.2): the new test and the six existing FSI-SPH unit tests pass on both.

## In depth description, if of interest

The wrapper's guard protects users who go through `ChFsiSystem`. The fluid system is also a public
class and is driven directly in several demos and tests, so the same misuse there reaches the null
dereference with no message. The guard is placed before the timer starts so a rejected call costs
nothing and leaves no partial state, which the test checks by stepping a fresh system, catching
the throw, then initializing and stepping the same object.

The test qualifies the call as `sysSPH.ChFsiFluidSystem::Initialize()` deliberately:
`ChFsiFluidSystemSPH` declares `Initialize` overloads that hide the base class's no-argument
`Initialize()`, so an unqualified call does not compile for a standalone user. That is a separate
matter, noted in the test's comment and not changed here.

This work used computing resources made available through the AMD University Program (AUP) AI &
HPC Cluster.
