### PR TITLE
FSI-SPH: check the return codes of the error-flag helpers, and allocate the collision flag once

### DIFF
--- a/src/chrono_fsi/sph/physics/SphCollisionSystem.cu
+++ b/src/chrono_fsi/sph/physics/SphCollisionSystem.cu
@@ -317,9 +317,15 @@ __global__ void neighborSearchID(const Real4* sortedPosRad,
 
 // =============================================================================
 
-SphCollisionSystem::SphCollisionSystem(FsiDataManager& data_mgr) : m_data_mgr(data_mgr), m_sphMarkersD(nullptr) {}
+SphCollisionSystem::SphCollisionSystem(FsiDataManager& data_mgr) : m_data_mgr(data_mgr), m_errflagD(nullptr), m_sphMarkersD(nullptr) {
+    // Allocated once here rather than on every ArrangeData call: that runs every step, and a
+    // device allocation plus free per step is pure overhead for a one-byte flag.
+    gpuMallocErrorFlag(m_errflagD);
+}
 
-SphCollisionSystem::~SphCollisionSystem() {}
+SphCollisionSystem::~SphCollisionSystem() {
+    gpuFreeErrorFlag(m_errflagD);
+}
 
 void SphCollisionSystem::Initialize() {
     gpuMemcpyToSymbolAsync(paramsD, m_data_mgr.paramsH.get(), sizeof(ChFsiParamsSPH));
@@ -327,9 +333,7 @@ void SphCollisionSystem::Initialize() {
 }
 
 void SphCollisionSystem::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarkersD, std::shared_ptr<SphMarkerDataD> sortedSphMarkersD) {
-    bool* error_flagD;
-    gpuMallocErrorFlag(error_flagD);
-    gpuResetErrorFlag(error_flagD);
+    gpuResetErrorFlag(m_errflagD);
 
     m_sphMarkersD = sphMarkersD;  //// TODO RADU: why is this cached?!?!
 
@@ -350,8 +354,8 @@ void SphCollisionSystem::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarkersD
     computeGridSize((uint)m_data_mgr.countersH->numExtendedParticles, 1024, numBlocks, numThreads);
     calcHashD<<<numBlocks, numThreads>>>(U1CAST(m_data_mgr.markersProximity_D->gridMarkerHashD), U1CAST(m_data_mgr.markersProximity_D->gridMarkerIndexD),
                                          U1CAST(m_data_mgr.activeListD), mR4CAST(m_sphMarkersD->posRadD), mR4CAST(m_sphMarkersD->rhoPresMuD),
-                                         (uint)m_data_mgr.countersH->numExtendedParticles, error_flagD);
-    gpuCheckErrorFlag(error_flagD, "calcHashD");
+                                         (uint)m_data_mgr.countersH->numExtendedParticles, m_errflagD);
+    gpuCheckErrorFlag(m_errflagD, "calcHashD");
 
     // Sort Particles based on Hash
     thrust::sort_by_key(m_data_mgr.markersProximity_D->gridMarkerHashD.begin(), m_data_mgr.markersProximity_D->gridMarkerHashD.begin() + m_data_mgr.countersH->numExtendedParticles,
@@ -382,8 +386,6 @@ void SphCollisionSystem::ArrangeData(std::shared_ptr<SphMarkerDataD> sphMarkersD
         mR4CAST(m_sphMarkersD->posRadD), mR3CAST(m_sphMarkersD->velMasD), mR4CAST(m_sphMarkersD->rhoPresMuD), mR3CAST(m_sphMarkersD->tauXxYyZzD),
         mR3CAST(m_sphMarkersD->tauXyXzYzD), mR3CAST(m_sphMarkersD->pcEvSvD), INT_32CAST(m_data_mgr.activityIdentifierOriginalD), (uint)m_data_mgr.countersH->numExtendedParticles);
     gpuCheckError();
-
-    gpuFreeErrorFlag(error_flagD);
 }
 
 void SphCollisionSystem::NeighborSearch(std::shared_ptr<SphMarkerDataD> sortedSphMarkersD) {

--- a/src/chrono_fsi/sph/physics/SphCollisionSystem.cuh
+++ b/src/chrono_fsi/sph/physics/SphCollisionSystem.cuh
@@ -34,6 +34,14 @@ class SphCollisionSystem {
     SphCollisionSystem(FsiDataManager& data_mgr);
     ~SphCollisionSystem();
 
+    // The object owns a device allocation (m_errflagD) freed in the destructor, so a copy would
+    // alias it and free it twice. Chrono holds this class through a shared_ptr and never copies it;
+    // deleting the operations makes that a compile-time fact rather than a convention.
+    SphCollisionSystem(const SphCollisionSystem&) = delete;
+    SphCollisionSystem& operator=(const SphCollisionSystem&) = delete;
+    SphCollisionSystem(SphCollisionSystem&&) = delete;
+    SphCollisionSystem& operator=(SphCollisionSystem&&) = delete;
+
     /// Complete construction.
     void Initialize();
 
@@ -46,6 +54,7 @@ class SphCollisionSystem {
 
   private:
     FsiDataManager& m_data_mgr;  ///< FSI data manager
+    bool* m_errflagD = nullptr;  ///< device error flag for the proximity kernels, allocated once
     // Note: this is cached on every call to ArrangeData()
     std::shared_ptr<SphMarkerDataD> m_sphMarkersD;  ///< Information of the particles in the original array
 };

--- a/src/chrono_fsi/sph/utils/SphUtilsDevice.cuh
+++ b/src/chrono_fsi/sph/utils/SphUtilsDevice.cuh
@@ -81,40 +81,64 @@ namespace sph {
 
 // ----------------------------------------------------------------------------
 
-#define gpuMallocErrorFlag(error_flag_D)                \
-    {                                                   \
-        gpuMalloc((void**)&error_flag_D, sizeof(bool)); \
+// The four error-flag macros call gpuMalloc, gpuMemcpy and gpuFree, each of which returns a
+// gpuError. Discarding those codes lets an allocation or copy failure pass unnoticed: the flag is
+// then read from memory that was never written, and a failed device-to-host copy reports "no error"
+// because error_flag_H keeps whatever the stack held. So every call is checked. gpuFreeErrorFlag
+// reports rather than throws, because it runs from destructors.
+#define gpuMallocErrorFlag(error_flag_D)                                    \
+    {                                                                       \
+        gpuError err_ = gpuMalloc((void**)&error_flag_D, sizeof(bool));     \
+        if (err_ != gpuSuccess)                                             \
+            gpuThrowError(gpuGetErrorString(err_));                         \
     }
 
-#define gpuFreeErrorFlag(error_flag_D) \
-    {                                  \
-        gpuFree(error_flag_D);         \
+#define gpuFreeErrorFlag(error_flag_D)                                                  \
+    {                                                                                   \
+        if (error_flag_D) {                                                             \
+            bool* flag_to_free_ = error_flag_D;                                         \
+            error_flag_D = nullptr; /* null first; nothing below may skip it */         \
+            gpuError err_ = gpuFree(flag_to_free_);                                     \
+            if (err_ != gpuSuccess) {                                                   \
+                try { /* runs from destructors: report, never throw */                  \
+                    std::cerr << "GPU failure in " << __FILE__ << ":" << __LINE__       \
+                              << " Message: " << gpuGetErrorString(err_) << std::endl;  \
+                } catch (...) {                                                         \
+                }                                                                       \
+            }                                                                           \
+        }                                                                               \
     }
 
-#define gpuResetErrorFlag(error_flag_D)                                              \
-    {                                                                                \
-        bool error_flag_H = false;                                                   \
-        gpuMemcpy(error_flag_D, &error_flag_H, sizeof(bool), gpuMemcpyHostToDevice); \
+#define gpuResetErrorFlag(error_flag_D)                                                              \
+    {                                                                                                \
+        bool error_flag_H = false;                                                                   \
+        gpuError err_ = gpuMemcpy(error_flag_D, &error_flag_H, sizeof(bool), gpuMemcpyHostToDevice); \
+        if (err_ != gpuSuccess)                                                                      \
+            gpuThrowError(gpuGetErrorString(err_));                                                  \
     }
 
-#define gpuCheckErrorFlag(error_flag_D, kernel_name)                                                       \
-    {                                                                                                      \
-        bool error_flag_H;                                                                                 \
-        gpuDeviceSynchronize();                                                                            \
-        gpuMemcpy(&error_flag_H, error_flag_D, sizeof(bool), gpuMemcpyDeviceToHost);                       \
-        if (error_flag_H) {                                                                                \
-            char buffer[256];                                                                              \
-            sprintf(buffer, "Error flag intercepted in %s:%d from %s", __FILE__, __LINE__, kernel_name);   \
-            std::cerr << buffer << std::endl;                                                              \
-            throw std::runtime_error(buffer);                                                              \
-        }                                                                                                  \
-        gpuError e = gpuGetLastError();                                                                    \
-        if (e != gpuSuccess) {                                                                             \
-            char buffer[256];                                                                              \
-            sprintf(buffer, "GPU failure in %s:%d Message: %s", __FILE__, __LINE__, gpuGetErrorString(e)); \
-            std::cerr << buffer << std::endl;                                                              \
-            throw std::runtime_error(buffer);                                                              \
-        }                                                                                                  \
+#define gpuCheckErrorFlag(error_flag_D, kernel_name)                                                         \
+    {                                                                                                        \
+        bool error_flag_H = false;                                                                           \
+        gpuError err_ = gpuDeviceSynchronize();                                                              \
+        if (err_ != gpuSuccess)                                                                              \
+            gpuThrowError(gpuGetErrorString(err_));                                                          \
+        err_ = gpuMemcpy(&error_flag_H, error_flag_D, sizeof(bool), gpuMemcpyDeviceToHost);                  \
+        if (err_ != gpuSuccess)                                                                              \
+            gpuThrowError(gpuGetErrorString(err_));                                                          \
+        if (error_flag_H) {                                                                                  \
+            char buffer[256];                                                                                \
+            sprintf(buffer, "Error flag intercepted in %s:%d from %s", __FILE__, __LINE__, kernel_name);     \
+            std::cerr << buffer << std::endl;                                                                \
+            throw std::runtime_error(buffer);                                                                \
+        }                                                                                                    \
+        gpuError e = gpuGetLastError(); /* a synchronous launch error is not returned by the calls above */  \
+        if (e != gpuSuccess) {                                                                               \
+            char buffer[256];                                                                                \
+            sprintf(buffer, "GPU failure in %s:%d Message: %s", __FILE__, __LINE__, gpuGetErrorString(e));   \
+            std::cerr << buffer << std::endl;                                                                \
+            throw std::runtime_error(buffer);                                                                \
+        }                                                                                                    \
     }
 
 #define gpuCheckError()                                                                                    \


### PR DESCRIPTION
The four error-flag macros in `SphUtilsDevice.cuh` call `gpuMalloc`, `gpuMemcpy` and `gpuFree` and
discard every return code. A failed allocation leaves the flag pointing at unwritten memory, and a
failed device-to-host copy reports "no error" because `error_flag_H` keeps whatever the stack held.
Each call is now checked, including the `gpuDeviceSynchronize()` in the flag check;
`gpuFreeErrorFlag` reports instead of throwing because it runs from destructors, and nulls the
pointer first. `SphCollisionSystem` is made non-copyable, since it now owns a device allocation. Separately, `SphCollisionSystem::ArrangeData` allocated and
freed a one-byte device flag on every call, which is every step; the flag is now a member allocated
in the constructor and freed in the destructor, the arrangement `SphFluidDynamics` already uses for
its rheology flag.

About 70 changed lines in three files. No API change. Builds on CUDA (DGX Spark, CUDA 13) and
HIP (MI350X, ROCm 7.2); the six FSI-SPH unit tests pass on both. On a run-to-run non-deterministic fp32 wheel
case the drawbar pull before and after agrees within the case's own scatter (four runs against two, and one
doubled-box run inside the baseline pair), which is all a statistical check can say; the change touches no kernel.

## In depth description, if of interest

Why the check matters more than it looks: the flag is the only channel by which a device-side
range check in `calcHashD` or a rheology failure reaches the host. If the copy that reads it fails,
the failure is reported as success, and the run continues on corrupted neighbour lists. The
existing `gpuCheckError()` after kernel launches does not cover these copies.

`gpuCheckErrorFlag` also initializes `error_flag_H` to `false` so that a failed copy, now thrown,
can never be misread on the path that used to fall through. The per-step allocation is not a
correctness issue, only cost; it is included because the member flag is the natural place for the
checked allocation to live.

This work used computing resources made available through the AMD University Program (AUP) AI &
HPC Cluster.
