### PR TITLE
Sensor: do not require GLEW on macOS

### DIFF
--- a/src/chrono_sensor/CMakeLists.txt
+++ b/src/chrono_sensor/CMakeLists.txt
@@ -1184,22 +1184,32 @@ endif()
 message(STATUS "Looking for optional OpenGL support")
 
 find_package(OpenGL QUIET)
-find_package(GLEW QUIET)
+# Not on Apple: the visualization filters use only OpenGL 1.1 entry points, which the OpenGL
+# framework exports directly, so the extension loader has nothing to load.
+if(NOT APPLE)
+  find_package(GLEW QUIET)
+endif()
 find_package(glfw3 QUIET)
 
 message(STATUS "  OpenGL found: ${OPENGL_FOUND}")
-message(STATUS "  GLEW found:   ${GLEW_FOUND}")
+if(NOT APPLE)
+  message(STATUS "  GLEW found:   ${GLEW_FOUND}")
+endif()
 message(STATUS "  glfw3 found:  ${glfw3_FOUND}")
 
-if(OPENGL_FOUND AND GLEW_FOUND AND glfw3_FOUND)
+if(OPENGL_FOUND AND (GLEW_FOUND OR APPLE) AND glfw3_FOUND)
   message(STATUS "  GL libraries found")
   message(STATUS "    OpenGL include dir: ${OPENGL_INCLUDE_DIR}")
   message(STATUS "    OpenGL libraries:   ${OPENGL_LIBRARIES}")
-  message(STATUS "    GLEW include dir:   ${GLEW_INCLUDE_DIRS}")
-  message(STATUS "    GLEW libraries:     ${GLEW_LIBRARIES}")
+  if(NOT APPLE)
+    message(STATUS "    GLEW include dir:   ${GLEW_INCLUDE_DIRS}")
+    message(STATUS "    GLEW libraries:     ${GLEW_LIBRARIES}")
+  endif()
 
   target_compile_definitions(Chrono_sensor PUBLIC $<$<COMPILE_LANGUAGE:CXX>:USE_SENSOR_GLFW>)
-  target_link_libraries(Chrono_sensor PUBLIC GLEW::glew)
+  if(NOT APPLE)
+    target_link_libraries(Chrono_sensor PUBLIC GLEW::glew)
+  endif()
   target_link_libraries(Chrono_sensor PUBLIC glfw)
   target_link_libraries(Chrono_sensor PUBLIC OpenGL::GL)
 

--- a/src/chrono_sensor/filters/ChFilterVisualize.cpp
+++ b/src/chrono_sensor/filters/ChFilterVisualize.cpp
@@ -121,11 +121,13 @@ void ChFilterVisualize::CreateGlfwWindow(std::string window_name) {
     glfwMakeContextCurrent(m_window.get());
     glfwSwapInterval(0);
 
+#ifndef __APPLE__
     GLenum glew_status = glewInit();
     if (glew_status != GLEW_OK) {
         std::cerr << "WARNING: GLEW initialization failed for Chrono::Sensor visualization window: "
                   << reinterpret_cast<const char*>(glewGetErrorString(glew_status)) << "\n";
     }
+#endif
 
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();

--- a/src/chrono_sensor/filters/ChFilterVisualize.h
+++ b/src/chrono_sensor/filters/ChFilterVisualize.h
@@ -18,7 +18,11 @@
 #define CHFILTERVISUALIZE_H
 
 #ifdef USE_SENSOR_GLFW
-    #include <GL/glew.h>
+    #ifdef __APPLE__
+        #include <OpenGL/gl.h>
+    #else
+        #include <GL/glew.h>
+    #endif
     #include <GLFW/glfw3.h>
 #endif
 


### PR DESCRIPTION
**Summary**

GLEW is an OpenGL extension loader. Chrono::Sensor's visualization filters use 23 GL entry points and
every one is OpenGL 1.1 fixed-function: the matrix stack, immediate mode, and basic texture objects.
There are no shaders, no buffer objects and no extensions, and GLEW's only appearances in the module
are `glewInit`, `GLEW_OK` and `glewGetErrorString`, so it is used solely to initialize itself. On macOS
the OpenGL framework exports those entry points directly and the loader has nothing to do.

This drops the requirement on Apple only. GLEW is not looked for there at all and its status lines
are not printed, so neither the dependency nor its confusing output remains. Every other platform is
untouched: the `find_package`, the include, the `glewInit` call and the link all remain for them.

For a Mac user the sensor configuration output becomes:

```
-- Looking for optional OpenGL support
--   OpenGL found: TRUE
--   glfw3 found:  1
--   GL libraries found
```

**Related Issue(s)**

None filed. Raised by two reviewers on #818: that the macOS configuration ignores GLEW path settings,
and separately whether GLEW is needed on macOS at all.

**Author(s)**

Kyle Sha — kylesha585@gmail.com (corresponding author, long-lived address).

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and
redistributed under the BSD-3-Clause License.

**Backward Compatibility**

No API change, and no change on any non-Apple platform: the three edits are all guarded by `APPLE` or
`__APPLE__`. On macOS a build that previously found GLEW behaves the same, and one that previously did
not now gets its sensor windows instead of losing them.

**Detailed Description**

`GLEW_FOUND` currently gates the entire GL window feature, so a Mac without a findable GLEW silently
configures with OpenGL support disabled and every sensor visualization window disappears, with only a
`STATUS` line to say so. That is easy to hit. A Homebrew GLEW ships a CMake config package, so
`find_package(GLEW)` resolves in config mode, and CMake's own `FindGLEW` returns from that path without
setting the variables it documents (CMake issue 20699) — which also makes `GLEW_INCLUDE_DIR` and
`GLEW_SHARED_LIBRARY_RELEASE` appear to be ignored, because in that mode they are never read.

Removing the dependency on Apple removes that failure mode rather than documenting it, and removing
the now-meaningless status lines removes the report that prompted this. Verified with Homebrew's glew
installed and findable: `libChrono_sensor` links no GLEW, and no GLEW line appears in the output.

The 23 entry points, for review: `glBegin`, `glBindTexture`, `glClear`, `glColor3f`, `glDisable`,
`glEnable`, `glEnd`, `glFlush`, `glFrustum`, `glGenTextures`, `glLoadIdentity`, `glMatrixMode`,
`glOrtho`, `glPointSize`, `glPopMatrix`, `glPushMatrix`, `glRotatef`, `glTexCoord2f`, `glTexImage2D`,
`glTexParameteri`, `glVertex2f`, `glVertex3f`, `glViewport`.

**Verification**

Measured on macOS 15 / arm64 (M4 Pro), configuring with `-DCMAKE_DISABLE_FIND_PACKAGE_GLEW=TRUE` so
GLEW is genuinely undiscoverable, against a control build of unmodified `main` with GLEW available:

| | control (GLEW) | this branch (GLEW absent) |
|---|---|---|
| configure | `GLEW found: TRUE` | `GLEW found:` (empty), GL windows still enabled |
| build | clean | clean |
| `libGLEW` entries across 10 demo binaries | 10 | **0** |
| all 10 `demo_SEN_*` demos | run | identical exit behaviour, no new warnings |
| `glGetError` after the draw | `0x0000` | `0x0000` |
| framebuffer readback at window centre | content present | identical value |
| `ctest -L sensor` | 8/9, one failure | **8/9, the same one failure** |

The rendering check is the load-bearing one: instrumenting `ChFilterVisualize::Apply` to call
`glReadPixels` after the draw returns the same non-uniform content in both builds, so the window is
genuinely being drawn and not merely opening. Note that `glewInit` is compiled in on macOS, since it
sits inside the `(VULKAN_RT || METAL_RT) && !OPTIX` arm, so this removes an active call rather than
dead code.

*Note on `ctest -L sensor`.* Both builds give an identical result: the same nine tests, eight passing,
and the same single failure, `utest_SEN_rng_streams`.
That test fails on unmodified `main` as well, and on `main` as it stood before the Metal backend
landed, so it is unrelated to this change. `Chrono_core` passes `-Wl,-no_compact_unwind` on Darwin,
which suppresses the `__unwind_info` section; `__eh_frame` is still emitted, but the arm64 runtime
uses `__unwind_info`, so an exception thrown from the library terminates instead of propagating. The
test throws exactly as it intends and then cannot be caught. Dropping that one link option restores
`__unwind_info` and all 22 assertions pass. That is a `Chrono_core` matter and not part of this PR.

**Not verified**

Only Apple is changed, so no other platform can regress, but for completeness: the same reasoning
suggests GLEW may be unnecessary on Linux and Windows too — on Linux `libGL` exports all 23 directly,
and a stock OptiX build already does not link GLEW because `glewInit` is compiled out of that arm. I
have not tested Windows at all. That is why this change is scoped to Apple rather than removing the
dependency outright.

**Post Submission Checklist**

- [x] The pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.

On the last item: what changed is a build dependency and what it guards. The observable behaviour is
whether a GL window opens and draws, which the unit test tree has no way to check; it was measured by
reading back the framebuffer from the running demos instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7fm8gN6N265v7Mfws76tS

