### PR TITLE
ChWheelTestRig: enlarge the estimated CRM active domain from 1.25 to 2.5 times the wheel's half-dimensions

### DIFF
--- a/src/chrono_vehicle/wheeled_vehicle/test_rig/ChWheelTestRig.cpp
+++ b/src/chrono_vehicle/wheeled_vehicle/test_rig/ChWheelTestRig.cpp
@@ -576,9 +576,16 @@ void ChWheelTestRig::SetWheelActiveDomain(const ChAABB& aabb) {
 }
 
 void ChWheelTestRig::SetWheelActiveDomain() {
+    // The box must extend well past the soil the wheel is shearing. Measured on one Viper wheel case
+    // (40 percent slip, 10 mm spacing, single precision): at 1.25 times the wheel's half-dimensions
+    // (the previous estimate) the drawbar pull read 12 to 43 percent below the value obtained with
+    // larger boxes and fluctuated strongly inside the measurement window; at 2.5 times (twice the
+    // previous estimate) it matches the values obtained with 4 and 8 times the previous estimate
+    // (5 and 10 times the wheel's half-dimensions). The factor was fitted at that one operating point.
+    // To check any box, including this one, double it and rerun: if the answer moves, it was too small.
     auto corner = ChVector3d(m_wheel_assembly->GetRadius(), m_wheel_assembly->GetWidth() / 2, m_wheel_assembly->GetRadius());
-    m_wheel_AABB.min = -1.25 * corner;
-    m_wheel_AABB.max = +1.25 * corner;
+    m_wheel_AABB.min = -2.5 * corner;
+    m_wheel_AABB.max = +2.5 * corner;
 }
 
 void ChWheelTestRig::CreateTerrainCRM() {

--- a/src/chrono_vehicle/wheeled_vehicle/test_rig/ChWheelTestRig.h
+++ b/src/chrono_vehicle/wheeled_vehicle/test_rig/ChWheelTestRig.h
@@ -262,7 +262,11 @@ class CH_VEHICLE_API ChWheelTestRig {
     void SetWheelActiveDomain(const ChAABB& aabb);
 
     /// Set a single active domain of estimated dimensions associated with the entire wheel assembly (CRM terrain only).
-    /// The default size is based on the wheel AABB inflated by 25%.
+    /// The estimated box extends 2.5 times the wheel's half-dimensions (radius, half-width, radius) from the hub,
+    /// twice the previous estimate. That factor was fitted on one Viper wheel case at 40 percent slip and 10 mm
+    /// particle spacing, where the previous estimate understated the drawbar pull by 12 to 43 percent. A box
+    /// that stops inside the soil the wheel is shearing understates the force; to check any box for your own
+    /// wheel, slip and spacing, double it and rerun: if the answer moves, the box was too small.
     /// This active AABB is associated with the hub body. If the wheel assembly has multiple bodies,
     /// it may be more efficient to set CRM active domains for each body individually.
     void SetWheelActiveDomain();


### PR DESCRIPTION
Fixes #824. `SetWheelActiveDomain()` with no argument estimated the active box as 1.25 times the
wheel's half-dimensions around the hub, which stops inside the soil the wheel is shearing; the shipped
Viper wheel demo reads 12 to 43 percent low with it and fluctuates strongly. At 2.5 times the
half-dimensions (twice the previous estimate) the drawbar pull matches the value from boxes 4 and 8
times the previous estimate (251.2 and 252.6 N against about 252 N, at 40 percent slip, 10 mm spacing,
single precision; that one operating point is where the factor was fitted, and the comments say so). One number in `ChWheelTestRig.cpp`, plus a comment there and in the
header saying how to check any box: double it and rerun.

Built on CUDA (DGX Spark, CUDA 13) and HIP (MI350X, ROCm 7.2). With the new estimate the wheel case
that read 147 N reads 256.5 and 257.6 N (on top of the other fixes) and 255.9 and 266.6 N (this change
alone on `main`), all inside the converged band.

## In depth description, if of interest

The measurements behind the number are in #824. The cost of the larger box is real (about 2.8 times
the run time of the old estimate at 205,821 particles), which is why the small default was easy to
keep; a user who wants the old size back can pass it explicitly through the `ChAABB` overload.

This work used computing resources made available through the AMD University Program (AUP) AI &
HPC Cluster.
