### PR TITLE
Sensor: correct the Vulkan RT auxiliary-camera FOV and empty-scene handling, and compare lights by value

### DIFF
--- a/src/chrono_sensor/vulkan/ChFilterVulkanRTRender.cpp
+++ b/src/chrono_sensor/vulkan/ChFilterVulkanRTRender.cpp
@@ -3567,7 +3567,7 @@ void ChFilterVulkanRTRender::Apply() {
         gpu_frame.max_distance = gpu_frame.max_depth;
         gpu_frame.clip_near = 0.001f;
         gpu_frame.tan_half_hfov = static_cast<float>(std::tan(0.5 * static_cast<double>(gpu_frame.hfov)));
-        gpu_frame.aux_ray_factor = static_cast<float>(static_cast<double>(gpu_frame.hfov) / CH_VKRT_PI * 2.0);
+        gpu_frame.aux_ray_factor = gpu_frame.tan_half_hfov;
         gpu_frame.rgba8 = m_buffer_rgba8.get();
         gpu_frame.rgbd = m_buffer_rgbd.get();
         gpu_frame.depth = m_buffer_depth.get();
@@ -3594,13 +3594,17 @@ void ChFilterVulkanRTRender::Apply() {
         if (m_gpu_renderer->Render(m_scene, gpu_frame))
             return;
 
-        throw std::runtime_error("Chrono::Sensor Vulkan RT GPU renderer had a Vulkan device but no renderable GPU scene; CPU fallback is only used when no Vulkan RT GPU is available");
+        // A scene with no geometry is valid and renders as pure background, but the GPU path has
+        // no acceleration structure to trace against, so that frame falls through to the CPU
+        // renderer. Anything else is a real failure.
+        if (m_scene && !m_scene->GetPrimitives().empty())
+            throw std::runtime_error("Chrono::Sensor Vulkan RT GPU renderer failed to render a scene that holds geometry");
     }
 #endif
 
-    // CPU fallback is only reached when no Vulkan RT device exists.  Do not build
-    // the host BVH/cache on the GPU path; doing so was a large serial cost before
-    // every Vulkan render and masked ray-tracing parallelism.
+    // Reached when no Vulkan RT device exists, and for a scene with no geometry, which the GPU
+    // path cannot trace.  Do not build the host BVH/cache on the GPU path otherwise; doing so was
+    // a large serial cost before every Vulkan render and masked ray-tracing parallelism.
     if (!m_render_cache)
         m_render_cache = std::make_unique<ChVulkanRTRenderCache>();
     if (!m_scene || m_render_cache->scene != m_scene.get() || m_render_cache->scene_revision != m_scene->GetRevision())
@@ -3766,10 +3770,8 @@ void ChFilterVulkanRTRender::Apply() {
         uv_y *= 1.0 / std::max(CH_VKRT_EPS, aspect);
         ApplyOptixLensModel(uv_x, uv_y, hfov, lens_model, lens_params);
 
-        // Camera raygen uses tan(hFOV/2).  The current OptiX depth/normal/segmentation
-        // raygens still use hFOV/pi*2; mirror that convention for pixel-identical
-        // auxiliary buffers instead of silently changing their projection.
-        const double ray_factor = hfov / CH_VKRT_PI * 2.0;
+        // tan(hFOV/2), the same pinhole factor the camera raygen uses.
+        const double ray_factor = std::tan(0.5 * hfov);
         const ChVector3d dir = NormalizeSafe(forward + right * (uv_x * ray_factor) + up * (uv_y * ray_factor), forward);
         const RayHit best = TraceRay(cache, m_scene, origin, dir);
 

--- a/src/tests/unit_tests/sensor/utest_SEN_scene_lights.cpp
+++ b/src/tests/unit_tests/sensor/utest_SEN_scene_lights.cpp
@@ -20,9 +20,9 @@
 // first to B and require the two to become identical. A field the modify path forgets to write
 // fails immediately, and the test does not have to be updated when a field is added.
 //
-// Comparing bytes is sound here because both lights reach the comparison through the same
-// construction helper, which zero-initializes the struct before filling it, so padding is equal
-// whenever the members are.
+// How two lights are compared depends on the backend's light type. Only a trivially copyable
+// struct can be compared by its object representation; the Vulkan light holds a std::string and
+// the Metal one holds ChVector3f and ChColor, so both get a field-wise comparison instead.
 //
 // Runs against whichever backend the build selected: the scene classes are different types with
 // different light structs, and the test is written against neither.
@@ -32,6 +32,7 @@
 #include "gtest/gtest.h"
 
 #include <cstring>
+#include <type_traits>
 #include <functional>
 #include <vector>
 
@@ -66,9 +67,34 @@ struct LightPair {
     std::function<void(SceneType&, unsigned int)> modify_a_to_b;
 };
 
+// Comparing two lights. Byte comparison is only valid for a trivially copyable type, which the
+// OptiX light struct is and the other two are not: the Vulkan one holds a std::string, the Metal
+// one holds ChVector3f and ChColor. Those get a field-wise comparison here rather than in the
+// backend headers, since comparing lights is something only this test needs.
+template <typename L>
+bool LightsEqual(const L& lhs, const L& rhs) {
+    static_assert(std::is_trivially_copyable_v<L>, "add a LightsEqual overload for this light type");
+    return std::memcmp(&lhs, &rhs, sizeof(L)) == 0;
+}
+
+    #ifdef CHRONO_HAS_VULKAN_RT
+bool LightsEqual(const chrono::sensor::ChVulkanRTLight& a, const chrono::sensor::ChVulkanRTLight& b) {
+    return a.type == b.type && a.pos == b.pos && a.dir == b.dir && a.color == b.color && a.range == b.range && a.angle == b.angle && a.const_color == b.const_color &&
+           a.atten_scale == b.atten_scale && a.angle_falloff_start == b.angle_falloff_start && a.angle_atten_rate == b.angle_atten_rate && a.length_vec == b.length_vec &&
+           a.width_vec == b.width_vec && a.radius == b.radius && a.area == b.area && a.texture == b.texture;
+}
+    #endif
+
+    #ifdef CHRONO_HAS_METAL_RT
+bool LightsEqual(const chrono::sensor::MetalSceneLight& a, const chrono::sensor::MetalSceneLight& b) {
+    return a.pos == b.pos && a.range == b.range && a.color.R == b.color.R && a.color.G == b.color.G && a.color.B == b.color.B && a.type == b.type && a.dir == b.dir &&
+           a.cosOuter == b.cosOuter && a.cosInner == b.cosInner && a.p0 == b.p0 && a.const_color == b.const_color;
+}
+    #endif
+
 template <typename L>
 ::testing::AssertionResult SameLight(const L& lhs, const L& rhs, const char* which) {
-    if (std::memcmp(&lhs, &rhs, sizeof(L)) == 0)
+    if (LightsEqual(lhs, rhs))
         return ::testing::AssertionSuccess();
     return ::testing::AssertionFailure() << which << ": Modify*Light did not reproduce what Add*Light builds from the same "
                                          << "parameters, so at least one field is not written by the modify path";
@@ -104,8 +130,8 @@ TEST(ChSensorSceneLights, modify_reproduces_add_for_every_light_type) {
         // Sanity: A and B differ before the modify, or the comparison afterwards proves nothing.
         const auto before = scene.GetLights();
         ASSERT_EQ(before.size(), 2u) << c.name;
-        ASSERT_NE(0, std::memcmp(&before[a], &before[b], sizeof(before[0]))) << c.name << ": the two parameter sets produce identical lights, so this case cannot detect a "
-                                                                             << "modify path that writes nothing";
+        ASSERT_FALSE(LightsEqual(before[a], before[b])) << c.name << ": the two parameter sets produce identical lights, so this case cannot detect a "
+                                                        << "modify path that writes nothing";
 
         c.modify_a_to_b(scene, a);
 
@@ -125,7 +151,7 @@ TEST(ChSensorSceneLights, modify_out_of_range_is_ignored) {
 
     const auto after = scene.GetLights();
     ASSERT_EQ(after.size(), before.size());
-    EXPECT_EQ(0, std::memcmp(&after[id], &before[id], sizeof(after[0]))) << "an out-of-range Modify*Light changed an existing light";
+    EXPECT_TRUE(LightsEqual(after[id], before[id])) << "an out-of-range Modify*Light changed an existing light";
 }
 
 #endif  // any render backend


### PR DESCRIPTION
**Summary**

Two defects in the Vulkan RT backend and one in a sensor unit test. They surfaced together because
the tests added in #818 are backend-neutral while CI builds Vulkan RT rather than OptiX, so that path
had not been covered before.

1. The depth, normal and segmentation cameras used `hFOV/pi*2` as the pinhole factor instead of
   `tan(hFOV/2)`, rendering 67.38 deg for a requested 60 deg. A comment said this mirrored the OptiX
   auxiliary raygens; those were corrected in #819 and the mirror was left behind. The GPU site now
   reuses `tan_half_hfov`, computed two lines above.

2. A scene with no geometry is valid and renders as pure background, but the GPU path has no
   acceleration structure for it, so `Render` returned false and the caller threw. Any program
   rendering before adding bodies aborted. That case now falls through to the CPU renderer; a scene
   holding geometry still throws.

3. `utest_SEN_scene_lights` compared light structs with `memcmp`, valid only for a trivially copyable
   type. None of the three qualify — the Vulkan light holds a `std::string`, the Metal one holds
   `ChVector3f` and `ChColor` — so the test passed on OptiX and Metal by luck. Those two now get a
   field-wise comparison, in the test rather than the backend headers since only this test needs it,
   with a `static_assert` guarding the generic `memcmp` path. The Vulkan modify path was correct
   throughout: `Replace` is bounds-checked and `Modify*Light` uses the same helper as `Add*Light`.

**Related Issue(s)**

CI regression on `main`: [pipeline 2822929389](https://gitlab.com/uwsbel/chrono/-/pipelines/2822929389).
All seven `test` jobs failed; every `build` job passed. It contains both #818 and #827, but #818's own
pipeline was cancelled seconds in, superseded by #827's, so the failures are #818's.

| jobs | sensor tests failing | fixed by |
|---|---|---|
| [gcc](https://gitlab.com/uwsbel/chrono/-/jobs/16325332725) / [clang](https://gitlab.com/uwsbel/chrono/-/jobs/16325332727) amd64 NVIDIA, [gcc](https://gitlab.com/uwsbel/chrono/-/jobs/16325332726) / [clang](https://gitlab.com/uwsbel/chrono/-/jobs/16325332728) amd64 AMD | `analytic_render`, `scene_lights` | 1, 3 |
| [gcc](https://gitlab.com/uwsbel/chrono/-/jobs/16325332729) / [clang](https://gitlab.com/uwsbel/chrono/-/jobs/16325332730) arm64, [windows vs2022](https://gitlab.com/uwsbel/chrono/-/jobs/16325332731) | those two, plus `data_access`, `interface` | 1, 2, 3 |

`analytic_render` reports `"requested 60.00 deg, rendered 67.38 deg"` everywhere. `data_access` and
`interface` fail only where the runner has a Vulkan GPU. The Linux jobs also fail seven to nine
`pyutest_*` tests, which are unrelated: they die in pytest's plugin loading
(`PluginValidationError: Plugin 'launch_testing'`, a ROS 2 package) before reaching Chrono code, and
do not appear on the Windows job.

**On the behaviour change in change 2**

This narrows when the backend throws, so it is worth stating what moves. `Render` returns false only
for a null device or scene, or when the built scene has no triangles — and box, sphere and cylinder
primitives all generate triangles at build time. So a scene containing a single box still throws; only
an empty or null scene now falls through.

`ChVulkanRTEngine.cpp` states the intent this qualifies: *"if a device exists, GPU rendering is
mandatory and render-time errors are surfaced instead of silently falling back to the CPU."* That
guards against a real scene silently dropping to a slower renderer. An empty scene has none of that
cost — an empty cache means every ray misses with no traversal — and what it replaces is not a slow
render but an uncaught exception ending the run, since nothing catches a render-time throw.

The reason to fix rather than keep it is consistency: `utest_SEN_data_access` renders an empty scene
and passes on both OptiX and Metal RT, which simply let rays miss. Only Vulkan RT aborts. If the
project would rather call this a programming error, the consistent form is rejecting it in all three
backends, which is a larger change and a maintainer's call.

**Author(s)**

Kyle Sha — kylesha585@gmail.com (corresponding author, long-lived address).

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and
redistributed under the BSD-3-Clause License.

**Backward Compatibility**

The Vulkan RT depth, normal and segmentation cameras now honour the requested FOV, so anything
calibrated against the old projection needs rechecking. No other rendered output changes and no public
API is added. The production change is confined to `ChFilterVulkanRTRender.cpp` — two FOV
assignments, one added guard and the reworded throw — with both backend scene headers untouched.

**Verification**

Linux, in CI's configuration (`CH_USE_SENSOR_OPTIX=OFF`, `CH_USE_SENSOR_VULKAN_RT=ON`), both Vulkan RT
paths:

| run | commit | `VULKAN_RT_GPU` | registered | failed |
|---|---|---|---|---|
| A1 | `main` | ON | 8 | **4** — `data_access`, `interface`, `analytic_render`, `scene_lights` |
| A2 | `main` | OFF | 8 | **2** — `analytic_render`, `scene_lights` |
| B1 | branch | ON | 8 | **0** |
| B2 | branch | OFF | 8 | **0** |

Every test failing on `main` passes here, in both modes, with the same eight registered throughout —
nothing skipped or gated out. A1 reproduces the CI failure exactly. Counts were confirmed non-zero
before reading results, since `ctest` exits 0 when nothing is registered.

No test in the suite reaches the empty-scene path, so it was exercised directly: a scratch program
rendering a scene whose only geometry is a mesh with faces indexing out of range — rejected by the
scene builder, leaving nothing to trace — throws on `main` and renders 768/768 background pixels on
this branch.

Machine: Ryzen 5 9600X, RTX 5060 Ti (driver 580.173.02), Ubuntu 22.04.5, gcc 11.4.0, CMake 3.22.1,
CUDA 13.0.88, glslangValidator 11.8.0. It exposes three Vulkan devices and `ChVulkanRTDevice` takes
the first that probes successfully without logging it, so which one served these runs is not
established; the failures reproduce identically under the NVIDIA and Mesa/RADV ICDs alone.

On OptiX (`CH_USE_SENSOR_OPTIX=ON`, `CH_USE_SENSOR_VULKAN_RT=OFF`), where the production change
compiles out entirely: 13 of 13 sensor tests pass on two independent machines with different GPUs
and toolchains, including `utest_SEN_scene_lights`, which still
resolves to `memcmp` there because `ChOptixLight` is the one genuinely trivially copyable light
struct — the `static_assert` now enforcing that does not trip.

Also on macOS 15 / arm64 with Metal RT: builds clean, all nine sensor tests pass except
`utest_SEN_rng_streams`, which fails on `main` too for an unrelated reason — `Chrono_core` passes
`-Wl,-no_compact_unwind` on Darwin, suppressing the `__unwind_info` section the arm64 runtime needs,
so an exception thrown from the library terminates instead of propagating. It passes on Linux and
Windows, and CI runs no macOS test job.

**Post Submission Checklist**

- [x] The pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.

No new test is added, but `utest_SEN_scene_lights` is corrected so that it tests what it claims to,
and the other two defects are caught by existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
