### PR TITLE
Sensor: check every available render backend in utest_SEN_scene_lights

### DIFF
--- a/src/tests/unit_tests/sensor/CMakeLists.txt
+++ b/src/tests/unit_tests/sensor/CMakeLists.txt
@@ -23,7 +23,7 @@ if(CH_SENSOR_HAS_RENDER_BACKEND)
     utest_SEN_threadsafety     # buffer ownership handover out of the filter graph
     utest_SEN_radar            # radar clustering utilities
     utest_SEN_analytic_render  # rendered images vs closed-form ground truth
-    #utest_SEN_scene_lights     # Modify*Light reproduces Add*Light, for every light type
+    utest_SEN_scene_lights     # Modify*Light reproduces Add*Light, for every light type
   )
 endif()
 

--- a/src/tests/unit_tests/sensor/utest_SEN_scene_lights.cpp
+++ b/src/tests/unit_tests/sensor/utest_SEN_scene_lights.cpp
@@ -43,13 +43,12 @@
 
 #ifdef CHRONO_HAS_OPTIX
     #include "chrono_sensor/optix/ChOptixScene.h"
-using SceneType = chrono::sensor::ChOptixScene;
-#elif defined(CHRONO_HAS_METAL_RT)
+#endif
+#ifdef CHRONO_HAS_METAL_RT
     #include "chrono_sensor/metal/ChMetalRTScene.h"
-using SceneType = chrono::sensor::ChMetalRTScene;
-#elif defined(CHRONO_HAS_VULKAN_RT)
+#endif
+#ifdef CHRONO_HAS_VULKAN_RT
     #include "chrono_sensor/vulkan/ChVulkanRTScene.h"
-using SceneType = chrono::sensor::ChVulkanRTScene;
 #endif
 
 using namespace chrono;
@@ -60,6 +59,7 @@ namespace {
 
 // Two distinct parameter sets per light type. They differ in every argument, so a modify path that
 // drops one is caught rather than passing because the two happened to agree there.
+template <typename SceneType>
 struct LightPair {
     const char* name;
     std::function<unsigned int(SceneType&)> add_a;
@@ -102,8 +102,9 @@ template <typename L>
 
 }  // namespace
 
-TEST(ChSensorSceneLights, modify_reproduces_add_for_every_light_type) {
-    const std::vector<LightPair> cases = {
+template <typename SceneType>
+void CheckModifyReproducesAdd() {
+    const std::vector<LightPair<SceneType>> cases = {
         {"point", [](SceneType& s) { return s.AddPointLight(ChVector3f(1, 2, 3), ChColor(0.2f, 0.3f, 0.4f), 10.f, true); },
          [](SceneType& s) { return s.AddPointLight(ChVector3f(-4, 5, 6), ChColor(0.7f, 0.6f, 0.5f), 25.f, false); },
          [](SceneType& s, unsigned int i) { s.ModifyPointLight(i, ChVector3f(-4, 5, 6), ChColor(0.7f, 0.6f, 0.5f), 25.f, false); }},
@@ -141,7 +142,8 @@ TEST(ChSensorSceneLights, modify_reproduces_add_for_every_light_type) {
     }
 }
 
-TEST(ChSensorSceneLights, modify_out_of_range_is_ignored) {
+template <typename SceneType>
+void CheckModifyOutOfRangeIsIgnored() {
     SceneType scene;
     const unsigned int id = scene.AddPointLight(ChVector3f(1, 2, 3), ChColor(0.5f, 0.5f, 0.5f), 10.f, true);
     const auto before = scene.GetLights();
@@ -152,6 +154,50 @@ TEST(ChSensorSceneLights, modify_out_of_range_is_ignored) {
     const auto after = scene.GetLights();
     ASSERT_EQ(after.size(), before.size());
     EXPECT_TRUE(LightsEqual(after[id], before[id])) << "an out-of-range Modify*Light changed an existing light";
+}
+
+// Each check runs for every backend the build enabled, not just the first. SCOPED_TRACE names the
+// backend so a failure in a multi-backend build says which one.
+TEST(ChSensorSceneLights, modify_reproduces_add_for_every_light_type) {
+    #ifdef CHRONO_HAS_OPTIX
+    {
+        SCOPED_TRACE("OptiX");
+        CheckModifyReproducesAdd<chrono::sensor::ChOptixScene>();
+    }
+    #endif
+    #ifdef CHRONO_HAS_METAL_RT
+    {
+        SCOPED_TRACE("Metal RT");
+        CheckModifyReproducesAdd<chrono::sensor::ChMetalRTScene>();
+    }
+    #endif
+    #ifdef CHRONO_HAS_VULKAN_RT
+    {
+        SCOPED_TRACE("Vulkan RT");
+        CheckModifyReproducesAdd<chrono::sensor::ChVulkanRTScene>();
+    }
+    #endif
+}
+
+TEST(ChSensorSceneLights, modify_out_of_range_is_ignored) {
+    #ifdef CHRONO_HAS_OPTIX
+    {
+        SCOPED_TRACE("OptiX");
+        CheckModifyOutOfRangeIsIgnored<chrono::sensor::ChOptixScene>();
+    }
+    #endif
+    #ifdef CHRONO_HAS_METAL_RT
+    {
+        SCOPED_TRACE("Metal RT");
+        CheckModifyOutOfRangeIsIgnored<chrono::sensor::ChMetalRTScene>();
+    }
+    #endif
+    #ifdef CHRONO_HAS_VULKAN_RT
+    {
+        SCOPED_TRACE("Vulkan RT");
+        CheckModifyOutOfRangeIsIgnored<chrono::sensor::ChVulkanRTScene>();
+    }
+    #endif
 }
 
 #endif  // any render backend


### PR DESCRIPTION
**Summary**

`utest_SEN_scene_lights` did not compile when two render backends were enabled at once, and even when
it did compile it only ever exercised one of them.

The test selected its scene header with an exclusive chain — OptiX, else Metal RT, else Vulkan RT —
so only one backend's light type was declared, while the `LightsEqual` overloads added in #834 were
guarded on the backend macros individually. With OptiX and Vulkan RT both enabled, a legal
configuration, only `ChOptixScene.h` was included yet the Vulkan overload still compiled and referred
to an undeclared `ChVulkanRTLight`.

Rather than align the two conditions, this removes the exclusive chain. Every enabled backend's
header is now included, the two checks are written once against the scene type, and each test runs
them for **all** available backends with `SCOPED_TRACE` naming which one, so a failure in a
multi-backend build says where. The overloads keep their individual guards, which is correct now that
every header is present. The test is re-enabled.

**Related Issue(s)**

Reported by a reviewer who could not build `main` on Linux or Windows. The test is currently commented
out of `src/tests/unit_tests/sensor/CMakeLists.txt` (3ab055007e) to unbreak the build; this restores
it. Checking every available backend rather than the first was @rserban's suggestion on the earlier
revision of this PR, which fixed the build but left the test silently skipping backends that were
present.

**Author(s)**

Kyle Sha — kylesha585@gmail.com (corresponding author, long-lived address).

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and
redistributed under the BSD-3-Clause License.

**Backward Compatibility**

Test-only. No library code is touched.

**Verification**

Every backend combination that could be built on the available hardware, on both platforms. macOS 15
/ arm64 (Metal RT, and Vulkan RT via MoltenVK for a compile-and-run check of the CPU path), and Linux
/ Ubuntu 22.04, RTX 5060 Ti, CUDA 13.0.88, OptiX 9.0.0:

| backends enabled | platform | `main` + test re-enabled | this branch |
|---|---|---|---|
| Metal RT | macOS | — | **passes** |
| Vulkan RT | macOS | — | **passes** |
| Metal RT + Vulkan RT | macOS | **build fails** | **passes** |
| Vulkan RT | Linux | — | **passes** |
| OptiX | Linux | — | **passes** |
| OptiX + Vulkan RT | Linux | **build fails** | **passes** |

Both failing cells fail the same way, which is the defect being fixed:

```
utest_SEN_scene_lights.cpp:81:40: error: 'ChVulkanRTLight' in namespace 'chrono::sensor'
                                          does not name a type
```

On the branch, the multi-backend builds run the checks against every backend they enable rather than
just the first, so the Metal + Vulkan RT and OptiX + Vulkan RT rows each cover two backends. Since a
passing run shows no `SCOPED_TRACE`, that was confirmed from the linked binaries rather than inferred:
the OptiX + Vulkan RT build contains both `CheckModifyReproducesAdd<ChOptixScene>` and
`<ChVulkanRTScene>`, the single-backend build only the one.

**Post Submission Checklist**

- [x] The pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.

On the last item: no new test is added; an existing one is repaired, broadened to cover every
available backend, and re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

