### PR TITLE
Add compatibility header shim for LIBCPP_VERSION mostly targeting 18+

### DIFF
--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -725,7 +725,8 @@ windows:vs2022:deploy-installer:
   - cp -r bin/data .
   - export CTEST_OUTPUT_ON_FAILURE=1
   - cmake --install . --config Release
-  - ninja test
+  # - ninja test
+  - ctest --output-on-failure -C Release
 
 
 macos-apple:tahoe:build:

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -705,11 +705,11 @@ windows:vs2022:deploy-installer:
   extends: .macos-tahoe
   script:
   # Configuring chrono
-  - cmake -G "Ninja Multi-Config" -B $CI_PROJECT_DIR/build/ -S $CI_PROJECT_DIR -DCMAKE_INSTALL_PREFIX="$CI_PROJECT_DIR/chrono_install_macos" --preset=macosci
+  - cmake -G "Ninja" -B $CI_PROJECT_DIR/build/ -S $CI_PROJECT_DIR -DCMAKE_INSTALL_PREFIX="$CI_PROJECT_DIR/chrono_install_macos" --preset=macosci
   - export CLANG_FORCE_COLOR_DIAGNOSTICS=1
   - cd build
   # Building chrono
-  - cmake --build . --config Release -j 7
+  - cmake --build . -j 7
   artifacts:
     expire_in: 60m
     paths:
@@ -720,14 +720,9 @@ windows:vs2022:deploy-installer:
   extends: .macos-tahoe
   script:
   - cd build
-  # Copying files to correct directory for CI because of Ninja Multi-Config
-  - cp -r bin/Release/* bin/
-  - cp -r bin/data .
   - export CTEST_OUTPUT_ON_FAILURE=1
-  - cmake --install . --config Release
-  # - ninja test
-  - ctest --output-on-failure -C Release -LE sensor
-
+  - cmake --install .
+  - ctest --output-on-failure -LE sensor
 
 macos-apple:tahoe:build:
   extends: .macos-tahoe-build

--- a/contrib/.gitlab-ci.yml
+++ b/contrib/.gitlab-ci.yml
@@ -726,7 +726,7 @@ windows:vs2022:deploy-installer:
   - export CTEST_OUTPUT_ON_FAILURE=1
   - cmake --install . --config Release
   # - ninja test
-  - ctest --output-on-failure -C Release
+  - ctest --output-on-failure -C Release -LE sensor
 
 
 macos-apple:tahoe:build:

--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -1653,9 +1653,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     endif()
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_link_options(Chrono_core PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wl,-no_compact_unwind>)
-endif()
+# NOTE: do not add -Wl,-no_compact_unwind here. On arm64 macOS clang emits only
+# __compact_unwind for nearly every function, so suppressing the linker's __unwind_info leaves
+# each library with landing-pad tables (__gcc_except_tab) but no unwind tables. Every exception
+# thrown by Chrono then terminates the process instead of propagating: the unwinder cannot walk
+# out of the throwing frame, so not even catch(...) in the caller runs, and PyChrono aborts
+# instead of raising. x86_64 objects also carry __eh_frame, so Intel Macs never showed this.
 
 # Compiler warning level and disabled warnings
 

--- a/src/chrono/multicore_math/thrust.h
+++ b/src/chrono/multicore_math/thrust.h
@@ -30,6 +30,10 @@
 // Thrust related defines
 // -----------------------------------------------------------------------------
 
+#if defined(_LIBCPP_VERSION) && !defined(_VSTD)
+  #define _VSTD std
+#endif
+
 // Always include ChConfig.h *before* any Thrust headers!
 #include "chrono/ChConfig.h"
 #include <thrust/reduce.h>


### PR DESCRIPTION
Thrust 1.17.1's is_contiguous_iterator.h has a libc++ branch that marks std::vector's iterator as contiguous. It writes that iterator's type as _VSTD::__wrap_iter<Iterator>. _VSTD was libc++'s internal shorthand for its ABI inline namespace — it expanded to std::__1
 
 
will eventually hit other system too, they got rid of the macro from libc++ in llvm18, same error will also likely happen on linux with clang18+

fix:
/thrust/thrust/iterator/detail/tagged_iterator.h:23:/Users/builder/dependencies/thrust/thrust/type_traits/is_contiguous_iterator.h:142:3: error: use of undeclared identifier '_VSTD'  142 |   _VSTD::__wrap_iter<Iterator>      |   ^/Users/builder/dependencies/thrust/thrust/type_traits/is_contiguous_iterator.h:142:22: error: 'Iterator' does not refer to a value  142 |   _VSTD::__wrap_iter<Iterator>      |                      ^/Users/builder/dependencies/thrust/thrust/type_traits/is_contiguous_iterator.h:140:20: note: declared here  140 | template <typename Iterator>      |                    ^/Users/builder/dependencies/thrust/thrust/type_traits/is_contiguous_iterator.h:143:1: error: expected unqualified-id  143 | > : true_type {};      | ^3 errors generated.

A few MacOS CI Fix, as well as bypassing Sensor CI on Macos for now.