### PR TITLE
macOS: stop discarding unwind tables, which made every throw an abort

### DIFF
--- a/src/chrono/CMakeLists.txt
+++ b/src/chrono/CMakeLists.txt
@@ -1653,9 +1653,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     endif()
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    target_link_options(Chrono_core PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wl,-no_compact_unwind>)
-endif()
+# NOTE: do not add -Wl,-no_compact_unwind here. On arm64 macOS clang emits only
+# __compact_unwind for nearly every function, so suppressing the linker's __unwind_info leaves
+# each library with landing-pad tables (__gcc_except_tab) but no unwind tables. Every exception
+# thrown by Chrono then terminates the process instead of propagating: the unwinder cannot walk
+# out of the throwing frame, so not even catch(...) in the caller runs, and PyChrono aborts
+# instead of raising. x86_64 objects also carry __eh_frame, so Intel Macs never showed this.
 
 # Compiler warning level and disabled warnings
 


### PR DESCRIPTION
**Summary**

On Apple Silicon Macs, no C++ exception thrown by Chrono can be caught. Every throw terminates the
process, even inside a matching `try`/`catch`, and in PyChrono it kills the interpreter instead of
raising a Python exception. The cause is one link option, `-Wl,-no_compact_unwind`, which
`Chrono_core` passes as a `PUBLIC` link option on Darwin and therefore hands to every Chrono library
and executable. This removes it, three lines in `src/chrono/CMakeLists.txt`, and leaves a note
against reintroducing it.

**Related Issue(s)**

None filed. It surfaced on the GitLab macOS CI after the macOS jobs were re-enabled (#822). The
macOS build on `main` currently stops earlier, in Thrust, so the tests only run on the branch
carrying that build fix (#837), and there `utest_SEN_rng_streams` aborts at its first `EXPECT_THROW`
([job 16455216481](https://gitlab.com/uwsbel/chrono/-/jobs/16455216481)). That is the only failure in
that job this PR addresses; the other sensor failures there are a separate matter.

This is therefore based on `fix/thrust_libc18_version_conflict` (#837) rather than `main`, so that a
macOS pipeline can get past the build and actually run the tests. It can be retargeted to `main`
once #837 lands; the change itself is independent of it.

**Author(s)**

Kyle Sha, kylesha585@gmail.com (corresponding author, long-lived address).

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in Chrono and
redistributed under the BSD-3-Clause License.

**Backward Compatibility**

No API change. The edit sits inside the existing `Darwin` block, so Linux and Windows builds are
untouched, and Intel Macs see no practical change either (below). On Apple Silicon, exceptions now
behave as they already do everywhere else: they reach their handlers and run destructors on the way.
Code that used to abort will now reach its `catch`, or terminate as before if nothing catches.
Libraries grow by about 1% for the restored `__unwind_info`, and there is no runtime cost, since the
tables are only read while an exception is in flight.

**Detailed Description**

When an exception is thrown, the unwinder walks up the stack one frame at a time, and to leave each
frame it needs that function's unwind entry. On arm64, Apple clang writes those entries only as
`__compact_unwind` records, emitting DWARF `__eh_frame` just for the rare function it cannot encode
compactly, and the linker turns the records into each image's `__unwind_info`. `-no_compact_unwind`
tells the linker to skip that step. The result is a library that still carries its landing pads
(`__gcc_except_tab`) but almost no unwind tables, so the unwinder cannot leave the throwing frame and
`__cxa_throw` goes straight to `std::terminate`. Not even `catch (...)` in the caller runs.

Section sizes in bytes, from one build tree relinked both ways:

| library | `__unwind_info` | `__eh_frame` | `__gcc_except_tab` |
|---|---|---|---|
| `libChrono_core`, with the flag | none | 1,832 | 489,048 |
| `libChrono_core`, without | 91,640 | 1,832 | 489,048 |
| `libChrono_sensor`, with the flag | none | none | 47,580 |
| `libChrono_sensor`, without | 8,296 | none | 47,580 |

With the flag, `libChrono_core` has `__eh_frame` entries for 27 of its roughly 26,000 functions, so
this reaches every exception Chrono throws, not one module:

- **C++:** a `try`/`catch` around `ChFunctionCycloidal(1, -1)`, whose `SetWidth` throws
  `std::invalid_argument`, aborts with `libc++abi: terminating due to uncaught exception`. Without
  the flag the same binary catches it.
- **PyChrono:** the same call inside a Python `try`/`except` kills the interpreter (exit 134),
  observed on an existing local PyChrono build. The `%exception` wrapper in `ChModuleCore.i`, which
  exists to turn these into `RuntimeError`, never receives the exception.
- **`utest_SEN_rng_streams`:** aborts at its first `EXPECT_THROW`, so the 19 tests after it never
  run. Only two tests in the tree use `EXPECT_THROW`, and this is the first of them built on macOS,
  which is why the flag survived this long.

Intel Macs were never affected, which is likely the other half of the answer. x86_64 objects carry
`__eh_frame` for every function alongside the compact records, and a standalone repro built for
x86_64 with the flag catches normally under Rosetta.

History: the flag arrived in 2aff50333 (2022, as `CH_LINKERFLAG_EXE`/`CH_LINKERFLAG_SHARED`) and was
carried into `Chrono_core`'s `PUBLIC` link options by the modern-CMake rewrite in 1852ba84d. Neither
commit records what it was for, and removing it produces no linker warnings in anything built here. I
did not build Chrono::Mumps, the module the 2022 commit was about, so that is the one configuration
this does not cover.

Testing:

- macOS 26.5.1, M4 Pro, Apple clang 17, Release, core and sensor (Metal RT) with unit tests. This
  same commit was verified on top of `main`; the base branch adds only a Thrust header shim and a CI
  change, neither of which this touches. One
  build tree, relinked with and without the flag, nothing else varying: `utest_SEN_rng_streams` goes
  from abort (exit 134) to 22/22, the C++ case above goes from abort to caught, and there are no new
  linker warnings. Full unit-test suite with the fix: 66/66 pass.
- Ubuntu 24.04, gcc 13.3, Release, as a no-change check: core with unit tests builds clean and
  passes 59/59, and with Chrono::Sensor added on the CPU-only Vulkan RT fallback all 8 sensor tests
  pass, `utest_SEN_rng_streams` among them. The flag never reaches a Linux link line, since the
  block it sits in is `Darwin`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
